### PR TITLE
fix(template): migrate template repo URL and extend template CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-03-25
+
+### Added
+
+**MCP Server (Model Context Protocol)**
+- 12-tool MCP server for AI agent integration via `cxg mcp serve`
+  - `cxg_search`, `cxg_template_list`, `cxg_template_info`, `cxg_scan`
+  - `cxg_template_validate`, `cxg_template_create`, `cxg_template_write`
+  - `cxg_template_get_notes`, `cxg_ai_generate`, `cxg_template_test`
+  - `cxg_template_stats`, `cxg_template_update`
+- `cxg mcp install` — auto-configure 6 AI coding agents (Claude Desktop, Cursor, Windsurf, Cline, Roo Code, Claude Code)
+
+**AI Template Generation**
+- `cxg ai generate` — natural-language to template generation (dual-mode: scaffold or full)
+- Multi-provider support: Ollama (local-first default), OpenAI, Anthropic, DeepSeek
+- `--api-key` flag for session-only cloud provider authentication
+
+**Parameterised Template Metadata**
+- 5 new metadata fields for Bravos pipeline routing: `context_vars`, `batch_group`, `confidence`, `execution_mode`, `pipeline_stage`
+- `@field:` annotation parsing across all 12 supported languages
+- `context` and `batch_group` parameters added to `cxg_scan` MCP tool
+
+**Template CLI Extensions**
+- `cxg template search` — search templates by query, language, severity, or tags
+- `cxg template pwd` — display template directory paths with existence status
+- `cxg template skeleton` — view scaffold template for any supported language
+- `cxg template add` — copy a local template file into the user template directory
+
+### Fixed
+
+- Auto-migrate official template repository URL on org rename (`BugB-Tech` → `Bugb-Technologies`)
+- Detect remote URL drift during `cxg template update` and re-clone when necessary
+- `cargo fmt` formatting in skeleton template error path
+
+### Changed
+
+- Template count updated from 58 to 147 across 9 categories and 12 languages
+- MCP server instructions updated to reflect current template count
+
 ## [1.0.0] - 2025-01-13
 
 ### Added
@@ -51,5 +90,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.0.0...v1.1.1
 [1.0.0]: https://github.com/Bugb-Technologies/cert-x-gen/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "cert-x-gen"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cert-x-gen"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["CERT-X-GEN Core Team"]
 description = "Advanced Multi-Language Security Scanning Engine"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Write security checks as real code — Python, Rust, Go, C, Shell, or YAML — a
 <a href="https://github.com/Bugb-Technologies/cert-x-gen/releases"><img src="https://img.shields.io/github/v/release/Bugb-Technologies/cert-x-gen?style=flat-square"></a>
 <a href="https://github.com/Bugb-Technologies/cert-x-gen/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square"></a>
 <a href="https://github.com/Bugb-Technologies/cert-x-gen/actions"><img src="https://img.shields.io/github/actions/workflow/status/Bugb-Technologies/cert-x-gen/ci.yml?style=flat-square"></a>
-<a href="https://github.com/Bugb-Technologies/cert-x-gen-templates"><img src="https://img.shields.io/badge/templates-58-orange?style=flat-square"></a>
+<a href="https://github.com/Bugb-Technologies/cert-x-gen-templates"><img src="https://img.shields.io/badge/templates-147-orange?style=flat-square"></a>
 </p>
 
 <p align="center">

--- a/src/ai/manager.rs
+++ b/src/ai/manager.rs
@@ -703,6 +703,7 @@ mod tests {
             let err_msg = result.unwrap_err().to_string().to_lowercase();
             // Check for various error patterns that indicate Ollama is not available
             let has_expected_error = err_msg.contains("not available")
+                || err_msg.contains("not enabled")
                 || err_msg.contains("ollama serve")
                 || err_msg.contains("not running")
                 || err_msg.contains("connection refused")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -818,9 +818,25 @@ EXAMPLES:
   cxg template list --language c --severity critical
   cxg template list --tags database,unauthenticated
 
+  # Search templates
+  cxg template search redis
+  cxg template search \"sql injection\" --language python
+  cxg template search unauthenticated --detailed
+
   # Get template information
   cxg template info redis-unauthenticated
   cxg template info sql-injection-detection
+
+  # Show template directories
+  cxg template pwd
+
+  # View skeleton template for a language
+  cxg template skeleton python
+  cxg template skeleton c
+
+  # Add a local template to cxg
+  cxg template add ./my-redis-check.py
+  cxg template add ./custom-check.c custom/network
 
   # Validate templates
   cxg template validate ~/.cert-x-gen/templates/
@@ -923,6 +939,57 @@ pub enum TemplateAction {
         /// Enable debug output
         #[arg(long)]
         debug: bool,
+    },
+
+    /// Search templates (shortcut for `cxg search`)
+    Search {
+        /// Search query
+        query: String,
+
+        /// Filter by programming language
+        #[arg(long, value_enum, value_name = "LANG")]
+        language: Option<LanguageArg>,
+
+        /// Filter by severity level
+        #[arg(long, value_enum, value_name = "LEVEL")]
+        severity: Option<SeverityArg>,
+
+        /// Filter by tags (comma-separated)
+        #[arg(long, value_name = "TAG,TAG,...")]
+        tags: Option<String>,
+
+        /// Search in template content/code
+        #[arg(long)]
+        content: bool,
+
+        /// Show detailed results
+        #[arg(long)]
+        detailed: bool,
+
+        /// Maximum number of results
+        #[arg(long, default_value_t = 50, value_name = "N")]
+        limit: usize,
+    },
+
+    /// Show the template directories used by cxg
+    Pwd,
+
+    /// Display the skeleton/scaffold template for a language
+    Skeleton {
+        /// Programming language for the skeleton
+        #[arg(value_enum, value_name = "LANG")]
+        language: LanguageArg,
+    },
+
+    /// Add a local template file into the cxg template directory
+    Add {
+        /// Path to the template file to add
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Destination subdirectory within the user template folder (e.g. "custom/redis")
+        #[arg(value_name = "DEST")]
+        dest: Option<String>,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2109,10 +2109,7 @@ async fn run_template_command(cmd: cli::TemplateCommand) -> Result<()> {
                     println!("{}", content);
                 }
                 None => {
-                    eprintln!(
-                        "❌ Skeleton template '{}' not found.",
-                        skeleton_name
-                    );
+                    eprintln!("❌ Skeleton template '{}' not found.", skeleton_name);
                     eprintln!("   Run 'cxg template update' to download templates.");
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1983,6 +1983,200 @@ async fn run_template_command(cmd: cli::TemplateCommand) -> Result<()> {
             // TODO: Implement template testing
             Ok(())
         }
+
+        // @g.comment -- "Delegates `cxg template search <query>` to the existing search engine"
+        TemplateAction::Search {
+            query,
+            language,
+            severity,
+            tags,
+            content,
+            detailed,
+            limit,
+        } => {
+            use cert_x_gen::search::{
+                SearchArgs as LibSearchArgs, SearchFormat, SearchResultFormatter, SearchSort,
+                TemplateSearchEngine,
+            };
+
+            let config = Config::default();
+            let engine = CertXGen::new(config).await?;
+            let templates = engine.load_templates().await?;
+
+            let search_args = LibSearchArgs {
+                query: Some(query),
+                language: language.map(|l| l.into()),
+                severity: severity.map(|s| s.into()),
+                tags,
+                author: None,
+                cwe: None,
+                content,
+                case_sensitive: false,
+                regex: false,
+                limit,
+                format: SearchFormat::Table,
+                detailed,
+                sort: SearchSort::Relevance,
+                reverse: false,
+                ids_only: false,
+                stats: false,
+            };
+
+            let search_engine = TemplateSearchEngine::new(templates);
+            let (results, stats) = search_engine.search(&search_args);
+
+            let output = SearchResultFormatter::format_results(
+                &results,
+                &stats,
+                search_args.format,
+                detailed,
+                false,
+            );
+            print!("{}", output);
+
+            Ok(())
+        }
+
+        // @g.comment -- "Prints all template directory paths with existence status"
+        TemplateAction::Pwd => {
+            use cert_x_gen::template::PathResolver;
+
+            println!("\n📂 Template Directories (priority order):\n");
+
+            let dirs = vec![
+                ("Local (project)", PathResolver::local_template_dir()),
+                ("User", PathResolver::user_template_dir()),
+                ("System", PathResolver::system_template_dir()),
+            ];
+
+            for (label, dir) in &dirs {
+                let exists = dir.exists();
+                let marker = if exists { "✓" } else { "✗" };
+                let abs_path = if dir.is_relative() {
+                    let stripped = dir.strip_prefix("./").unwrap_or(dir);
+                    let joined = std::env::current_dir()
+                        .map(|cwd| cwd.join(stripped))
+                        .unwrap_or_else(|_| dir.clone());
+                    joined.canonicalize().unwrap_or(joined)
+                } else {
+                    dir.clone()
+                };
+                println!("  [{}] {:<18} {}", marker, label, abs_path.display());
+            }
+
+            println!();
+            Ok(())
+        }
+
+        // @g.comment -- "Reads and prints the skeleton scaffold file for a given language"
+        TemplateAction::Skeleton { language } => {
+            use cli::LanguageArg;
+
+            let skeleton_name = match language {
+                LanguageArg::Python => "python-template-skeleton.py",
+                LanguageArg::Rust => "rust-template-skeleton.rs",
+                LanguageArg::C => "c-template-skeleton.c",
+                LanguageArg::Cpp => "cpp-template-skeleton.cpp",
+                LanguageArg::Java => "java-template-skeleton.java",
+                LanguageArg::Go => "go-template-skeleton.go",
+                LanguageArg::JavaScript => "javascript-template-skeleton.js",
+                LanguageArg::Ruby => "ruby-template-skeleton.rb",
+                LanguageArg::Perl => "perl-template-skeleton.pl",
+                LanguageArg::Php => "php-template-skeleton.php",
+                LanguageArg::Shell => "shell-template-skeleton.sh",
+                LanguageArg::Yaml => "yaml-template-skeleton.yaml",
+            };
+
+            let skeleton_paths = vec![
+                std::path::PathBuf::from("templates/skeleton").join(skeleton_name),
+                dirs::home_dir()
+                    .unwrap_or_default()
+                    .join(".cert-x-gen/templates/official/templates/skeleton")
+                    .join(skeleton_name),
+            ];
+
+            match skeleton_paths.iter().find_map(|p| {
+                std::fs::read_to_string(p)
+                    .ok()
+                    .map(|content| (p.clone(), content))
+            }) {
+                Some((path, content)) => {
+                    println!(
+                        "📄 Skeleton template for {:?} ({})\n",
+                        language,
+                        path.display()
+                    );
+                    println!("{}", content);
+                }
+                None => {
+                    eprintln!(
+                        "❌ Skeleton template '{}' not found.",
+                        skeleton_name
+                    );
+                    eprintln!("   Run 'cxg template update' to download templates.");
+                }
+            }
+
+            Ok(())
+        }
+
+        // @g.comment -- "Copies a researcher-authored template file into the user template directory"
+        TemplateAction::Add { file, dest } => {
+            use cert_x_gen::template::PathResolver;
+
+            if !file.exists() {
+                eprintln!("❌ File not found: {}", file.display());
+                return Err(Error::config(format!(
+                    "Template file does not exist: {}",
+                    file.display()
+                )));
+            }
+
+            let file_name = file
+                .file_name()
+                .ok_or_else(|| Error::config("Invalid file path".to_string()))?;
+
+            let user_dir = PathResolver::user_template_dir();
+            let target_dir = match &dest {
+                Some(sub) => user_dir.join(sub),
+                None => user_dir.clone(),
+            };
+
+            std::fs::create_dir_all(&target_dir).map_err(|e| {
+                Error::config(format!(
+                    "Failed to create directory {}: {}",
+                    target_dir.display(),
+                    e
+                ))
+            })?;
+
+            let target_path = target_dir.join(file_name);
+
+            if target_path.exists() {
+                println!("⚠️  File already exists: {}", target_path.display());
+                println!("   Overwriting...");
+            }
+
+            std::fs::copy(&file, &target_path).map_err(|e| {
+                Error::config(format!(
+                    "Failed to copy {} → {}: {}",
+                    file.display(),
+                    target_path.display(),
+                    e
+                ))
+            })?;
+
+            println!("✅ Template added: {}", target_path.display());
+            println!("   Source: {}", file.display());
+            println!("\nNext steps:");
+            println!(
+                "   1. Validate: cxg template validate {}",
+                target_path.display()
+            );
+            println!("   2. List:     cxg template list");
+
+            Ok(())
+        }
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1431,7 +1431,7 @@ impl ServerHandler for CxgMcpServer {
             instructions: Some(
                 "CERT-X-GEN: Multi-language security scanning engine. \
                  Search, validate, create, write, test, and run vulnerability scanning templates \
-                 across 12 programming languages with 77+ built-in security checks. \
+                 across 12 programming languages with 147 built-in security checks. \
                  Tools: cxg_search, cxg_template_list, cxg_template_info, cxg_scan, \
                  cxg_template_validate, cxg_template_create, cxg_template_write, \
                  cxg_template_get_notes, cxg_ai_generate, cxg_template_test, \

--- a/src/template/git.rs
+++ b/src/template/git.rs
@@ -308,6 +308,28 @@ impl GitClient {
         path.join(".git").exists()
     }
 
+    // @g.comment -- "Returns the origin remote URL for an existing repo"
+    /// Get the current remote URL for origin
+    pub fn get_remote_url(path: &Path) -> Result<String> {
+        let repo = GitRepository::open(path)
+            .map_err(|e| Error::config(format!("Failed to open repository: {}", e)))?;
+        let remote = repo
+            .find_remote("origin")
+            .map_err(|e| Error::config(format!("Failed to find remote 'origin': {}", e)))?;
+        Ok(remote.url().unwrap_or("").to_string())
+    }
+
+    // @g.comment -- "Updates the origin remote URL and re-fetches from the new remote"
+    /// Update the remote URL for origin
+    pub fn set_remote_url(path: &Path, new_url: &str) -> Result<()> {
+        let repo = GitRepository::open(path)
+            .map_err(|e| Error::config(format!("Failed to open repository: {}", e)))?;
+        repo.remote_set_url("origin", new_url)
+            .map_err(|e| Error::config(format!("Failed to set remote URL: {}", e)))?;
+        info!("Updated remote URL to {}", new_url);
+        Ok(())
+    }
+
     /// Fast-forward merge
     fn fast_forward(repo: &GitRepository, fetch_commit: &AnnotatedCommit<'_>) -> Result<()> {
         let head_ref = repo

--- a/src/template/repository.rs
+++ b/src/template/repository.rs
@@ -36,10 +36,37 @@ impl RepositoryManager {
             config
         };
 
-        Ok(Self {
+        let mut manager = Self {
             config_path,
             config,
-        })
+        };
+
+        // @g.comment -- "Migrate stale official repo URL from old org to current default"
+        manager.migrate_official_url()?;
+
+        Ok(manager)
+    }
+
+    /// Migrate the official repository URL if it differs from the current default.
+    /// Handles org renames (e.g. BugB-Tech -> Bugb-Technologies) transparently.
+    fn migrate_official_url(&mut self) -> Result<()> {
+        let default_config = RepositoryConfig::default_config();
+        let Some(default_official) = default_config.repositories.first() else {
+            return Ok(());
+        };
+
+        if let Some(official) = self.config.get_repository_mut("official") {
+            if official.url != default_official.url {
+                warn!(
+                    "Migrating official repo URL: {} -> {}",
+                    official.url, default_official.url
+                );
+                official.url = default_official.url.clone();
+                self.save()?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Initialize repositories (clone if needed)
@@ -68,6 +95,7 @@ impl RepositoryManager {
         Ok(())
     }
 
+    // @g.comment -- "Updates a single repo: detects remote URL drift, re-clones if needed, then pulls"
     /// Update a specific repository
     pub fn update_repository(&mut self, name: &str) -> Result<()> {
         let repo = self
@@ -82,11 +110,32 @@ impl RepositoryManager {
         }
 
         if !repo.local_path.exists() {
-            // Clone if doesn't exist
             info!("Cloning repository '{}'...", name);
             GitClient::clone(&repo.url, &repo.local_path, &repo.branch)?;
         } else {
-            // Check if clean
+            // Check if the configured URL differs from the on-disk remote
+            if let Ok(current_url) = GitClient::get_remote_url(&repo.local_path) {
+                if current_url != repo.url {
+                    warn!(
+                        "Repository '{}' remote URL changed: {} -> {}",
+                        name, current_url, repo.url
+                    );
+                    info!("Re-cloning repository '{}' with new URL...", name);
+                    std::fs::remove_dir_all(&repo.local_path).map_err(|e| {
+                        Error::config(format!(
+                            "Failed to remove old clone at {}: {}",
+                            repo.local_path.display(),
+                            e
+                        ))
+                    })?;
+                    GitClient::clone(&repo.url, &repo.local_path, &repo.branch)?;
+                    repo.last_updated = Some(Utc::now());
+                    self.save()?;
+                    info!("Successfully re-cloned repository '{}'", name);
+                    return Ok(());
+                }
+            }
+
             if !GitClient::is_clean(&repo.local_path)? {
                 warn!(
                     "Repository '{}' has uncommitted changes. Skipping update.",
@@ -95,7 +144,6 @@ impl RepositoryManager {
                 return Ok(());
             }
 
-            // Pull updates
             info!("Updating repository '{}'...", name);
             GitClient::pull(&repo.local_path, &repo.branch)?;
         }


### PR DESCRIPTION
- Add `cxg template search`, `pwd`, `skeleton`, and `add` subcommands.
- Migrate stale `repositories.yaml` official URL and re-clone when repo remote URL drifts.

Made-with: Cursor

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] New template
- [ ] Documentation update

## Related Issues

Fixes #(issue number)

## Testing

Describe how you tested these changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
