### PR TITLE
feat(pentest): add AI-driven whitebox pentest pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "handlebars",
  "hex",
  "hyper 1.7.0",
+ "include_dir",
  "indicatif",
  "ipnetwork",
  "libloading",
@@ -2060,6 +2061,25 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ tokio = { version = "1.35", features = ["full"] }
 futures = "0.3"
 async-trait = "0.1"
 tempfile = "3.8"
+# Embed the pentest Python orchestrator into the binary at compile time
+include_dir = "0.7"
 
 # CLI parsing
 clap = { version = "4.4", features = ["derive", "env", "color"] }

--- a/pentest/README.md
+++ b/pentest/README.md
@@ -1,0 +1,519 @@
+# cxg pentest — AI-driven whitebox pentest pipeline
+
+`cxg pentest` is a first-class subcommand in the cxg CLI that turns a
+guardlink-annotated codebase plus one or more captured authenticated browser
+sessions into a series of code-aware, runtime-confirmed security findings.
+
+It reads `whitebox/findings.sarif` produced by guardlink, ranks threats against
+a natural-language operator goal, asks a local AI CLI (Claude / Codex / Gemini)
+to write JavaScript probe templates that themselves read the target's source to
+craft payloads, then executes those templates in N parallel authenticated
+Chromium contexts. Every HTTP request is captured to an audit log; every
+finding is classified deterministically as CONFIRMED, REFUTED (mitigation
+holds), or AMBIGUOUS (with payload-fixable AMBIGUOUS retried via AI mutation).
+
+## Table of contents
+
+- [Why this exists](#why-this-exists)
+- [Quick start](#quick-start)
+- [Subcommand reference](#subcommand-reference)
+  - [`cxg pentest install`](#cxg-pentest-install)
+  - [`cxg pentest auth`](#cxg-pentest-auth)
+  - [`cxg pentest auth-list`](#cxg-pentest-auth-list)
+  - [`cxg pentest scope-init`](#cxg-pentest-scope-init)
+  - [`cxg pentest run`](#cxg-pentest-run)
+- [Pipeline architecture](#pipeline-architecture)
+- [The JS template contract](#the-js-template-contract)
+- [Runtime intelligence](#runtime-intelligence)
+- [Report structure](#report-structure)
+- [Files and directories](#files-and-directories)
+- [Companion docs](#companion-docs)
+
+## Why this exists
+
+Existing security tools fall into two camps that don't talk to each other:
+
+| Camp | Example | Limitation |
+|------|---------|------------|
+| Whitebox SAST | semgrep, sonarqube | Finds bugs in code. Doesn't exploit them. |
+| Blackbox DAST | nuclei, ZAP, Burp | Probes the running app. Doesn't read source. |
+
+`cxg pentest` bridges both: source-aware whitebox understanding informs
+authenticated runtime exploitation. The AI doesn't fabricate generic payloads
+— it reads the actual route handler, validator, and middleware to craft probes
+specific to the code it's testing.
+
+## Quick start
+
+```bash
+# 1. One-time install
+cxg pentest install
+
+# 2. Generate guardlink SARIF in your codebase (requires guardlink CLI)
+cd /path/to/your/codebase
+guardlink sarif . -p <project-name> -o whitebox/findings.sarif
+
+# 3. Capture an authenticated browser session
+cxg pentest auth \
+  --target https://app.example.com \
+  --profile admin \
+  --label admin
+
+#    A headed Chromium opens. Log in by ANY means (SSO, MFA, magic link,
+#    OAuth popup). When the dashboard is showing, press ENTER in the
+#    terminal. The session is captured.
+
+# 4. (Optional) Create a scope file
+cxg pentest scope-init -o engagement.scope.yaml
+# edit it: allowlist URLs, set per-endpoint budgets, etc.
+
+# 5. Run the pipeline
+cxg pentest run \
+  --codebase /path/to/your/codebase \
+  --target https://app.example.com \
+  --auth admin \
+  --goal "test all unmitigated threats in the auth and records APIs" \
+  --ai --ai-provider claude \
+  --max-templates 8 --mutation-retries 2 \
+  --scope-file engagement.scope.yaml \
+  --attestation "Engagement PT-2026-001, operator J. Doe"
+
+# Results land in ~/.cert-x-gen/sessions/pentest-<timestamp>/
+#   - report.json   (split: confirmed, refuted, ambiguous)
+#   - audit.jsonl   (every HTTP request, every triage verdict)
+```
+
+## Subcommand reference
+
+### `cxg pentest install`
+
+One-time setup. Copies the Python orchestrator bundled with cxg's source tree
+to `~/.cert-x-gen/pentest/`, then verifies required Python deps (playwright,
+anthropic) are installed.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force` | off | Reinstall even if already present. Run after pulling a new cxg source tree. |
+
+### `cxg pentest auth`
+
+Capture an authenticated browser session as a reusable profile. The profile is
+saved at `~/.cert-x-gen/auth/<profile>.json` plus metadata at
+`<profile>.meta.json`.
+
+A post-capture landing test re-opens a fresh browser context with the saved
+state, navigates to `--target`, and checks whether the final URL/page looks like
+a login or the app dashboard.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target <URL>` | required | Target URL where login happens. |
+| `--profile <NAME>` | required | Profile name (or prefix when `--auth-numbers > 1`). |
+| `--auth-numbers <N>` | `1` | Capture N profiles in sequence. Each capture opens its own Chromium window and prompts for a label. |
+| `--label <TEXT>` | none | Human-readable label (e.g. "admin", "low-priv-user"). |
+| `--creds email:pw` | none | Inline credentials for scripted login (skips browser pop-up). Password auth only — SSO/MFA must use interactive capture. |
+| `--creds-file <FILE>` | none | File with `email:password[:label]` per line for batch scripted capture. |
+| `--login-path <PATH>` | `/api/auth/login` | Endpoint for scripted login POST. |
+| `--verify-url <URL>` | none | Optional URL hit as secondary identity check. The landing test remains the source of truth. Pass empty string to skip. |
+| `--header NAME:VALUE` | none | Custom HTTP header sent on every outbound request from this profile's context. Repeatable. Saved with the profile. Use for WAF-bypass tokens granted by infra. |
+
+**Examples:**
+
+```bash
+# Single interactive capture
+cxg pentest auth --target https://app.example.com --profile admin
+
+# Two identities for chained-auth (e.g. IDOR victim + attacker)
+cxg pentest auth --target https://app.example.com --profile pentest --auth-numbers 2
+
+# Scripted login (no browser pop-up)
+cxg pentest auth --target https://app.example.com --profile bot \
+  --creds 'user@example.com:hunter2'
+
+# Capture a profile that sends a WAF-bypass header on every request
+cxg pentest auth --target https://app.example.com --profile pentest \
+  --header "x-test-automation:abc123xyz"
+```
+
+### `cxg pentest auth-list`
+
+Shows all saved auth profiles under `~/.cert-x-gen/auth/`: name, label, target,
+and whether extra headers are configured. No flags.
+
+### `cxg pentest scope-init`
+
+Writes an example scope.yaml the operator can edit. scope.yaml controls the
+safety rails: method allowlist, URL allow/blocklist regexes, per-endpoint and
+total request budgets, 5xx-streak hard-kill threshold, and the
+`authorization_attestation` field recorded in the audit log header.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o, --output <PATH>` | `scope.yaml` | Output file path. |
+
+The generated scope.yaml is heavily commented. Read it before running a scan
+against any non-local target.
+
+### `cxg pentest run`
+
+Run the full pentest pipeline against a target.
+
+#### Codebase / target / output
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--codebase <PATH>` | required | Source codebase root. Must contain `whitebox/findings.sarif`. The codebase is also the AI CLI's working directory during template generation. |
+| `--target <URL>` | required | Running target app URL. The landing test verifies you arrive at a non-login page from this URL. |
+| `--session-dir <PATH>` | `~/.cert-x-gen/sessions/pentest-<ts>/` | Session artifacts directory (audit.jsonl, report.json). |
+| `--output, -o <PATH>` | `report.json` under session-dir | JSON report output path. |
+
+#### Identity
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--auth <CSV>` | `""` | Comma-separated profile names captured via `cxg pentest auth`. Leave empty if using `--interactive-auth`. |
+| `--interactive-auth <N>` | `0` | Open N headed browser windows for interactive login at scan start, then run with the resulting fresh profiles. |
+| `--auth-profile <PREFIX>` | `pentest` | Profile name prefix for `--interactive-auth` captures. |
+| `--auth-numbers <N>` | none | Minimum auth contexts required (warning-only — templates skipped if not enough). |
+| `--creds-file <FILE>` | none | File of `profile:email:password[:label]` lines used to AUTO RE-AUTH dead sessions mid-scan. Strongly recommended for any scan that runs destructive probes or has `--mutation-retries > 0`. |
+
+#### AI provider
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--ai` | off | Enable AI-driven template generation. Without `--ai`, only built-in Python probes run. |
+| `--ai-provider <NAME>` | `auto` | `auto`, `claude`, `codex`, `gemini`, `anthropic`, `openai`. `auto` picks the first available CLI tool (claude > codex > gemini), then falls back to HTTP APIs. CLI providers don't need API keys. |
+| `--generation-timeout <SEC>` | `240` | Hard wall-clock timeout per AI generation call. Process tree is killed if exceeded. |
+
+#### Hypothesis filtering / template selection
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--goal <TEXT>` | none | Natural-language pentest goal. Used for LLM-based hypothesis ranking AND prompt context for template generation. |
+| `--mitigation-mode <MODE>` | `any` | `any` / `unmitigated` (find unguarded holes) / `mitigated` (verify defenses hold). |
+| `--max-templates <N>` | `8` | Maximum templates the LLM ranker may select per scan. |
+| `--template-lang <LANG>` | `js` | `js` (default) or `py` (legacy, built-in probes only). |
+| `--template-dir <PATH>` | none | Reuse JS templates from a previously-generated session directory. Skips the AI generation step. |
+
+#### Probe execution
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--mutation-retries <N>` | `2` | Maximum times the AI may mutate a template after AMBIGUOUS triage. Environment-bound AMBIGUOUS skip mutation automatically. |
+| `--headed` | off | Show Chromium windows during scan. Useful for debugging probes or when WAF bot-detection blocks headless requests. |
+| `--scope-file <PATH>` | safe defaults | Path to scope.yaml. Generate one with `cxg pentest scope-init`. |
+| `--destructive-ok` | off | Allow DELETE/PUT/PATCH methods + destructive-pattern paths in scope.yaml. |
+| `--attestation <TEXT>` | none | Free-text written authorization recorded in the audit log header. |
+
+#### Health checks
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--me-path <PATH>` | `/api/me` | Optional identity endpoint hit during pre-flight inspection. Failure here does NOT mark the profile dead — the landing test is source of truth. |
+| `--skip-health-check` | off | Skip pre-flight session health check. Use for multi-tenant apps where the session lives at a subdomain different from `--target`. |
+
+#### Out-of-band callback
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--oast <HOST>` | none | OOB callback host (interactsh, Burp Collaborator). Exposed to templates as `cxg.oast.url(label)` for definitive blind-vuln confirmation. |
+
+#### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No confirmed findings (clean scan). |
+| `1` | No templates available — guardlink output missing or empty. |
+| `2` | Confirmed findings present. Treat as CI failure. |
+| `3` | Scan was hard-killed (5xx streak, scope violation, etc.). |
+
+## Pipeline architecture
+
+```
+                  ┌──────────────────────────────────────────────────────────┐
+                  │  cxg pentest run --codebase <repo> --target <url>        │
+                  │                  --auth <names>   --goal "<text>"        │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [1] guardlink.load(codebase)                              │
+                  │     • parse whitebox/findings.sarif (extended OR upstream │
+                  │       schema, auto-detected)                              │
+                  │     • parse inline @exposes/@mitigates/@flows/@audit/    │
+                  │       @comment annotations from source                    │
+                  │     • enrich hypotheses missing http_method/http_path:    │
+                  │       sibling-by-function → sibling-by-location → regex   │
+                  │       over description → source-scrape Express/Next/Hono/ │
+                  │       FastAPI route definitions near SARIF line           │
+                  │     • attach nearby @comment annotations as intent hints  │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [1b] profile_inspect.inspect_profiles_async               │
+                  │      • landing-test: navigate to --target with each       │
+                  │        captured profile, check if final URL/HTML looks    │
+                  │        like a login/SSO redirect (DEAD) or app dashboard  │
+                  │        (ALIVE) — works without /me endpoint               │
+                  │      • secondary: optional --me-path probe extracts role/ │
+                  │        email/id from JSON response (best-effort)          │
+                  │      • coverage_summary: warn if missing low-priv or      │
+                  │        high-priv tier, single-identity, etc.              │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [2] js_generator.generate_all                             │
+                  │      • dedupe hypotheses by (method, path, function)      │
+                  │      • LLM-rank: one call scores each 0-10 against goal + │
+                  │        identity coverage; returns top --max-templates     │
+                  │      • for each selected hypothesis: invoke AI CLI with   │
+                  │        cwd=codebase so it Read/Grep's source itself;      │
+                  │        prompt teaches the JS template contract + hard     │
+                  │        rules (no raw fetch, no destructive paths, etc.)   │
+                  │      • cache by hash(vuln_class, method, path, goal)      │
+                  │      • 240s timeout per call, SIGTERM the whole tree on   │
+                  │        timeout (kill subprocess of subprocess workers)    │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [3] js_engine.load_templates + validator.validate         │
+                  │      • parse meta header (id, vuln_class, severity, etc.) │
+                  │      • static checks: required meta, cxgProbe defined,    │
+                  │        no raw fetch(), no destructive path literals       │
+                  │      • rejected templates are dropped with a clear reason │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [4] JsEngine.run                                          │
+                  │      • open N parallel Chromium contexts, one per auth    │
+                  │        profile, with extra_http_headers from profile      │
+                  │      • inject cxg JS bridge via add_init_script (survives │
+                  │        navigations) + page.evaluate (for already-loaded   │
+                  │        page) — defines window.__cxg.{fetch, fetchAs,      │
+                  │        getCookies, setCookies, oast, ...}                 │
+                  │      • smart runner selection: for privesc/IDOR-class     │
+                  │        probes, run as LOWEST-tier identity available      │
+                  │      • per-template ensure_bridge (defensive re-eval if   │
+                  │        navigation wiped window.__cxg)                     │
+                  │      • each request goes through ScopeGuard, AuditLog,    │
+                  │        and SessionHealthMonitor                           │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [5] mutator.classify (per-finding triage)                 │
+                  │      CONFIRMED → confirmed_findings bucket                │
+                  │      REFUTED   → mitigation_verifications bucket          │
+                  │        • 401/403/404 status                               │
+                  │        • "mitigation holds" / "scoping enforced" /        │
+                  │          "no exploitation observed" in description        │
+                  │        • parenthetical-tolerant regex catches "mitigation │
+                  │          (parenthetical detail) holds"                    │
+                  │      AMBIGUOUS → ambiguous bucket                         │
+                  │        reason_kind=payload → eligible for mutation retry  │
+                  │          (e.g. 422 schema reject, 2xx without proof)      │
+                  │        reason_kind=environment → skip mutation, surface   │
+                  │          to operator (missing role, missing primitive,    │
+                  │          OAST not configured)                             │
+                  │      Mutation retries use the AI provider to rewrite the  │
+                  │      template targeting the specific failure mode. The    │
+                  │      mutated template is re-validated before execution.   │
+                  │      When a retry produces a definitive verdict, the      │
+                  │      original ambiguous sibling is removed from the       │
+                  │      ambiguous bucket and added to retried_then_resolved. │
+                  └────────────────────────────┬─────────────────────────────┘
+                                               │
+                  ┌────────────────────────────▼─────────────────────────────┐
+                  │ [6] Report + audit                                        │
+                  │      • report.json: confirmed_findings, mitigation_       │
+                  │        verifications, ambiguous, retried_then_resolved,   │
+                  │        rejected_templates, dead_profiles, scope_stats     │
+                  │      • audit.jsonl: scan_start (with attestation, scope), │
+                  │        per-request lines, per-finding lines (with triage │
+                  │        verdict), scan_end (with stats)                    │
+                  └──────────────────────────────────────────────────────────┘
+```
+
+## The JS template contract
+
+Templates are real JavaScript that must define a function `cxgProbe(cxg)`.
+They're paste-runnable in browser DevTools when given a stub `cxg` object,
+and consumable by the engine via `page.evaluate`.
+
+Full template authoring guide: see [docs/TEMPLATES.md](docs/TEMPLATES.md).
+
+### Mandatory header
+
+```javascript
+// @id: <kebab-case unique id>
+// @vuln_class: <normalized class>   // idor | csrf | xss | ssrf | command_injection
+                                     // | session_replay | credential_stuffing
+                                     // | rate_limit_bypass | privilege_escalation
+                                     // | sensitive_data_exposure | metrics_info_disclosure
+                                     // | clickjacking | content_sniffing | auth_api
+// @severity: <low|medium|high|critical>
+// @requires_auth_count: <1|2>          // 2 for chained-auth probes
+// @destructive_priority: <0..100>      // 0=read-only, 100=session-killing
+// @description: <one-line summary>
+```
+
+### The cxg API
+
+| Symbol | Description |
+|--------|-------------|
+| `cxg.profile` | `{name, label, index}` — current identity |
+| `cxg.profiles` | `[{name, label, index}, ...]` — all identities |
+| `cxg.url(p)` | Full URL helper. Strings starting with `http` pass through. |
+| `cxg.fetch(path, opts)` | Fetch in THIS identity. Auto-adds X-CSRF-Token on POST/PUT/PATCH/DELETE. Returns `{status, headers, body_text, body_json}`. Scope-checked + audit-logged automatically. |
+| `cxg.fetchAs(idx, path, opts)` | Fetch in another identity's browser context. Used for chained-auth probes. |
+| `cxg.getCookies()` | Returns all cookies for current context — **HttpOnly cookies included** (via Playwright's cookie jar, not document.cookie). |
+| `cxg.getCookiesAs(idx)` | Cookies for another identity. |
+| `cxg.getCookie(name)` | Single cookie or null. |
+| `cxg.setCookies(arr)` | REPLACE entire jar with arr. |
+| `cxg.addCookies(arr)` | MERGE arr into existing jar. |
+| `cxg.clearCookies()` | Empty the jar. |
+| `cxg.oast.available` | `true` iff `--oast` was passed. |
+| `cxg.oast.host` | OAST hostname or null. |
+| `cxg.oast.url(label, scheme?)` | `http://<sanitized-label>.<host>` for OOB callbacks. |
+
+### Finding shape
+
+```javascript
+{
+  id: 'unique-finding-id',
+  vuln_class: 'ssrf',
+  severity: 'critical',
+  confirmed: true | false,
+  endpoint: 'POST /api/foo',
+  description: 'plain-text summary including any mitigation references',
+  evidence: { /* any structured proof */ },
+  payload: '<request body / params / payload string>'
+}
+```
+
+### Hard rules (validator-enforced)
+
+1. Must define `async function cxgProbe(cxg)`.
+2. No raw `fetch()` — must use `cxg.fetch` / `cxg.fetchAs` (CSRF + audit).
+3. No destructive path literals (`/wipe`, `/delete-all`, `/factory-reset`).
+4. No more than ~30 fetch call sites combined with a loop (runaway protection).
+5. Required meta: `@id`, `@vuln_class`.
+6. `@requires_auth_count` must be int 1-5.
+
+## Runtime intelligence
+
+Behavior the engine applies automatically to every template execution:
+
+| Subsystem | What it does | Where |
+|-----------|--------------|-------|
+| Static validator | Rejects bad templates before execution (raw fetch, destructive literals, missing meta) | `validator.py` |
+| Scope guard | Per-request method/URL/destructive checks, per-endpoint + total budgets, 5xx-streak hard-kill | `scope.py` |
+| Audit log | One JSONL line per request, finding, scope-block, scan_start, scan_end | `scope.py` |
+| Session health monitor | Landing-test based — before each template, re-navigate target and check for login redirect. Auto re-auth from `--creds-file` on death | `session_health.py` |
+| Triage classifier | Pure-function CONFIRMED/REFUTED/AMBIGUOUS classification with reason_kind | `mutator.py` |
+| Retry-with-mutation | AMBIGUOUS payload-fixable → AI rewrites template targeting specific failure. Environment-bound skip mutation | `mutator.py` |
+| Smart runner selection | For privesc/IDOR-class probes, run as lowest-tier identity | `js_engine.py` |
+| Dedup / retry suppression | Identical probe shapes collapsed before LLM ranking. Retry definitive verdicts suppress original ambiguous siblings | `js_generator.py`, `js_engine.py` |
+
+## Report structure
+
+`report.json`:
+
+```jsonc
+{
+  "target": "https://app.example.com",
+  "codebase": "/path/to/repo",
+  "auth_profiles": ["admin", "user"],
+  "goal": "test all unmitigated IDOR threats",
+  "template_dir": "~/.cert-x-gen/templates/session-...",
+  "session_dir": "~/.cert-x-gen/sessions/pentest-...",
+  "audit_log": "<session_dir>/audit.jsonl",
+  "duration_seconds": 1022.6,
+  "guardlink_hypotheses": 77,
+  "scope_stats": {
+    "total_requests": 131,
+    "distinct_endpoints": 11,
+    "five_xx_streak": 0,
+    "per_endpoint": { "GET /api/me": 23, ... }
+  },
+  "rejected_templates": [],
+  "dead_profiles": [],
+  "confirmed_findings": [ /* CONFIRMED — exit code 2 */ ],
+  "ambiguous": [ /* AMBIGUOUS — need human review or more data */ ],
+  "mitigation_verifications": [ /* REFUTED — defense holds */ ],
+  "retried_then_resolved": [ /* original ambiguous IDs whose retries produced verdicts */ ]
+}
+```
+
+`audit.jsonl` lines (one per event):
+
+```jsonc
+{"_event":"scan_start", "ts":..., "target":..., "attestation":..., "scope":{...}}
+{"_event":"profile_inspection", "ts":..., "profiles":[...], "coverage":{...}}
+{"_event":"request", "ts":..., "identity":"admin", "template_id":"...",
+ "method":"GET", "url":"https://...", "status":200, "duration_ms":3.4,
+ "blocked_reason":null}
+{"_event":"blocked", "ts":..., "blocked_reason":"per-endpoint budget exhausted"}
+{"_event":"finding", "ts":..., "triage":"confirmed", "triage_reason":"...",
+ "vuln_class":"ssrf", ...}
+{"_event":"scan_end", "ts":..., "status":"ok", "confirmed_findings":1, ...}
+```
+
+## Files and directories
+
+```
+pentest/
+├── README.md               (this file)
+├── docs/
+│   ├── ARCHITECTURE.md     deep dive on data flow + module responsibilities
+│   ├── TEMPLATES.md        template authoring guide + full cxg.* API
+│   ├── OPERATOR_GUIDE.md   end-to-end playbook for a real engagement
+│   └── TROUBLESHOOTING.md  common failures and fixes
+├── cxg_pentest.py          CLI dispatcher (argparse, end-to-end orchestration)
+├── auth.py                 interactive + scripted login capture, profile storage,
+│                           multi-profile mode with label prompts, header support
+├── guardlink.py            SARIF parser (both schemas), inline @-annotation parser,
+│                           route enrichment (sibling lookup, source scrape),
+│                           @comment attachment via function-name lookup
+├── profile_inspect.py      landing-test based session health check, role-tier mapping,
+│                           coverage summary
+├── js_engine.py            JsEngine — N parallel Chromium contexts, bridge injection,
+│                           smart runner selection, scope/audit/health/mutation loop
+├── js_generator.py         AI template generation: dedup, LLM-ranking against goal+
+│                           identity coverage, CLI invocation with process-group timeout,
+│                           cache by hash
+├── validator.py            pre-execution static template validator
+├── scope.py                ScopeGuard (URL/method allowlist, budgets, 5xx hard-kill),
+│                           AuditLog (JSONL append-only)
+├── session_health.py       SessionHealthMonitor — landing-test based per-template
+│                           health check, auto re-auth from creds
+├── mutator.py              triage classifier (CONFIRMED/REFUTED/AMBIGUOUS with
+│                           reason_kind=payload/environment), AI-driven payload
+│                           mutation generation
+├── ai_generator.py         multi-provider abstraction: ClaudeCliProvider /
+│                           CodexCliProvider / GeminiCliProvider / AnthropicApiProvider
+│                           / OpenAiApiProvider — used by both ranker and mutator
+├── browser_engine.py       Python probe engine (legacy --template-lang py path)
+└── payloads/               built-in Python probes (idor, csrf, privesc, ...)
+
+~/.cert-x-gen/
+├── pentest/                installed Python orchestrator (copy of pentest/ above)
+├── auth/                   captured auth profiles
+│   ├── <profile>.json          Playwright storage_state (cookies, localStorage)
+│   └── <profile>.meta.json     name, target, label, extra_headers
+├── templates/              AI-generated JS templates per session
+│   └── session-<ts>/
+│       └── <vuln_class>-<hash>.js
+├── mutations/              AI-mutated retry templates (cached)
+│   └── <template_id>_<sig>.js
+├── ai_probes/              cached Python AI probes (legacy --template-lang py)
+└── sessions/               per-scan artifacts
+    └── pentest-<ts>/
+        ├── audit.jsonl
+        └── report.json
+```
+
+## Companion docs
+
+- [docs/TEMPLATES.md](docs/TEMPLATES.md) — JS template authoring guide and full `cxg.*` API reference
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — Module-by-module deep dive
+- [docs/OPERATOR_GUIDE.md](docs/OPERATOR_GUIDE.md) — End-to-end playbook for a real pentest engagement
+- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — Common failures, error messages, and fixes

--- a/pentest/ai_generator.py
+++ b/pentest/ai_generator.py
@@ -1,0 +1,333 @@
+"""AI fallback for hypotheses not covered by the built-in probe library.
+
+Supports multiple AI providers, including SUBPROCESS-based CLI tools (no API key needed):
+
+  CLI tools (preferred — uses user's existing CLI auth, no env-var key juggling):
+    - claude       (Anthropic Claude Code CLI: `claude --print`)
+    - codex        (OpenAI Codex CLI: `codex exec --skip-git-repo-check`)
+    - gemini       (Google Gemini CLI: `gemini --prompt`)
+
+  HTTP API providers (require env var):
+    - anthropic    (ANTHROPIC_API_KEY)
+    - openai       (OPENAI_API_KEY)
+
+Provider is chosen via --ai-provider; "auto" picks the first available CLI tool,
+falling back to ANTHROPIC_API_KEY then OPENAI_API_KEY.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+CACHE_DIR = Path.home() / ".cert-x-gen" / "ai_probes"
+SYSTEM_PROMPT = """You are a security pentest payload generator working inside cert-x-gen.
+
+Given a guardlink hypothesis (a SAST-derived vulnerability hint with HTTP method/path and
+threat class), you write a Python async probe that tests whether the vulnerability is
+exploitable at runtime.
+
+CONTRACT — your output MUST be a single Python code block with EXACTLY this shape:
+
+```python
+async def run(ctxs, hypothesis):
+    # ctxs: list[ProbeContext] — each has .api(method, path, body=None) -> {status, headers, body_text, body_json}
+    # ctxs[i].profile.label / .name identify the auth identity
+    # ctxs[i].url(path) -> full URL
+    # ctxs[i].page is the Playwright Page (use page.evaluate(...) for raw fetch)
+    # Return list of dict findings: [{id, vuln_class, severity, confirmed, endpoint, description, evidence, payload}]
+    findings = []
+    # ... your probe logic ...
+    return findings
+```
+
+HARD RULES:
+- Use ONLY ctxs[i].api(...) or ctxs[i].page.evaluate(...). No imports of requests/httpx/etc.
+- NEVER send DELETE/PUT/PATCH against any path matching /admin, /reset, /wipe, /purge, /drop.
+- NEVER send more than 30 requests total per probe run.
+- If confirmation is ambiguous (timing-based, response-length heuristic), mark confirmed=False
+  and explain in the description what would confirm it.
+- For IDOR-style probes that need a second identity, check len(ctxs) >= 2 first.
+
+Return ONLY the python code block, no commentary.
+"""
+
+
+# ---------------------------------------------------------------- providers
+
+class _Provider:
+    name: str
+    def available(self) -> tuple[bool, str]:
+        return False, "not implemented"
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        raise NotImplementedError
+
+
+class ClaudeCliProvider(_Provider):
+    """Anthropic Claude Code CLI (`claude --print`). No API key needed."""
+    name = "claude"
+    def __init__(self):
+        self.bin = shutil.which("claude")
+    def available(self) -> tuple[bool, str]:
+        if not self.bin:
+            return False, "`claude` binary not on PATH"
+        return True, f"{self.bin}"
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        prompt = f"{system}\n\n---\n\n{user}"
+        r = subprocess.run([self.bin, "--print", prompt], capture_output=True, text=True, timeout=120)
+        if r.returncode != 0:
+            raise RuntimeError(f"claude CLI failed: {r.stderr.strip()[:300]}")
+        return r.stdout
+
+
+class CodexCliProvider(_Provider):
+    """OpenAI Codex CLI (`codex exec`). No API key needed (uses CLI's stored auth)."""
+    name = "codex"
+    def __init__(self):
+        self.bin = shutil.which("codex")
+    def available(self) -> tuple[bool, str]:
+        if not self.bin:
+            return False, "`codex` binary not on PATH"
+        return True, f"{self.bin}"
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        # codex exec is non-interactive: prompt → stdout (sandbox + git checks disabled
+        # because we want pure text-in/text-out, not file edits).
+        prompt = f"{system}\n\n---\n\n{user}"
+        r = subprocess.run(
+            [self.bin, "exec", "--skip-git-repo-check", "--sandbox", "read-only", prompt],
+            capture_output=True, text=True, timeout=180,
+        )
+        if r.returncode != 0:
+            raise RuntimeError(f"codex CLI failed: {r.stderr.strip()[:300]}")
+        return r.stdout
+
+
+class GeminiCliProvider(_Provider):
+    """Google Gemini CLI (`gemini --prompt`). No API key needed."""
+    name = "gemini"
+    def __init__(self):
+        self.bin = shutil.which("gemini")
+    def available(self) -> tuple[bool, str]:
+        if not self.bin:
+            return False, "`gemini` binary not on PATH"
+        return True, f"{self.bin}"
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        prompt = f"{system}\n\n---\n\n{user}"
+        r = subprocess.run([self.bin, "--prompt", prompt], capture_output=True, text=True, timeout=180)
+        if r.returncode != 0:
+            raise RuntimeError(f"gemini CLI failed: {r.stderr.strip()[:300]}")
+        return r.stdout
+
+
+class AnthropicApiProvider(_Provider):
+    """Direct Anthropic HTTP API. Requires ANTHROPIC_API_KEY."""
+    name = "anthropic-api"
+    def __init__(self, model: str = "claude-sonnet-4-6"):
+        self.model = model
+    def available(self) -> tuple[bool, str]:
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            return False, "ANTHROPIC_API_KEY env var not set"
+        try:
+            import anthropic  # noqa
+            return True, f"anthropic SDK, model={self.model}"
+        except ImportError:
+            return False, "`anthropic` python package not installed"
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        import anthropic
+        client = anthropic.Anthropic()
+        resp = client.messages.create(
+            model=self.model, max_tokens=max_tokens, system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        return "".join(b.text for b in resp.content if hasattr(b, "text"))
+
+
+class OpenAiApiProvider(_Provider):
+    """Direct OpenAI HTTP API. Requires OPENAI_API_KEY."""
+    name = "openai-api"
+    def __init__(self, model: str = "gpt-4o"):
+        self.model = model
+    def available(self) -> tuple[bool, str]:
+        if not os.environ.get("OPENAI_API_KEY"):
+            return False, "OPENAI_API_KEY env var not set"
+        try:
+            import openai  # noqa
+            return True, f"openai SDK, model={self.model}"
+        except ImportError:
+            return False, "`openai` python package not installed"
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        import openai
+        client = openai.OpenAI()
+        resp = client.chat.completions.create(
+            model=self.model, max_tokens=max_tokens,
+            messages=[{"role": "system", "content": system},
+                      {"role": "user", "content": user}],
+        )
+        return resp.choices[0].message.content or ""
+
+
+_PROVIDER_REGISTRY = {
+    "claude":        ClaudeCliProvider,
+    "codex":         CodexCliProvider,
+    "gemini":        GeminiCliProvider,
+    "anthropic":     AnthropicApiProvider,
+    "anthropic-api": AnthropicApiProvider,
+    "openai":        OpenAiApiProvider,
+    "openai-api":    OpenAiApiProvider,
+}
+
+# Preference order when --ai-provider=auto: CLI tools first (no key juggling),
+# API providers as fallback.
+_AUTO_ORDER = ["claude", "codex", "gemini", "anthropic-api", "openai-api"]
+
+
+def pick_provider(name: str = "auto") -> tuple[Optional[_Provider], str]:
+    """Return (provider, reason). If reason is non-empty and provider is None,
+    it explains why nothing was picked."""
+    if name == "auto":
+        attempted = []
+        for n in _AUTO_ORDER:
+            p = _PROVIDER_REGISTRY[n]()
+            ok, detail = p.available()
+            if ok:
+                return p, f"auto-selected {p.name} ({detail})"
+            attempted.append(f"{n}: {detail}")
+        return None, "no AI provider available:\n    " + "\n    ".join(attempted)
+    if name not in _PROVIDER_REGISTRY:
+        return None, f"unknown provider '{name}'. options: {sorted(set(_PROVIDER_REGISTRY))}"
+    p = _PROVIDER_REGISTRY[name]()
+    ok, detail = p.available()
+    if not ok:
+        return None, f"provider '{name}' unavailable: {detail}"
+    return p, f"using {p.name} ({detail})"
+
+
+# ---------------------------------------------------------------- cache + entry
+
+def _cache_key(hypothesis) -> str:
+    payload = json.dumps({
+        "vuln_class": hypothesis.vuln_class,
+        "http_method": hypothesis.http_method,
+        "http_path": hypothesis.http_path,
+        "function_name": hypothesis.function_name,
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def cached_probe_source(hypothesis) -> Optional[str]:
+    p = CACHE_DIR / f"{hypothesis.vuln_class}_{_cache_key(hypothesis)}.py"
+    return p.read_text() if p.exists() else None
+
+
+def save_probe_source(hypothesis, source: str):
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    p = CACHE_DIR / f"{hypothesis.vuln_class}_{_cache_key(hypothesis)}.py"
+    p.write_text(source)
+
+
+def _extract_code(text: str) -> Optional[str]:
+    m = re.search(r"```(?:python)?\s*\n(.*?)```", text, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def generate_probe_source(hypothesis, provider: Optional[_Provider] = None,
+                          provider_name: str = "auto", verbose: bool = False) -> Optional[str]:
+    """Generate (or load cached) probe source for a hypothesis. Returns Python source,
+    or None on failure (with a printed reason if verbose=True)."""
+    cached = cached_probe_source(hypothesis)
+    if cached:
+        if verbose:
+            print(f"    · cached probe for {hypothesis.vuln_class}/{_cache_key(hypothesis)}")
+        return cached
+
+    if provider is None:
+        provider, reason = pick_provider(provider_name)
+        if provider is None:
+            if verbose:
+                print(f"    ✗ no provider: {reason}")
+            return None
+
+    user_msg = (
+        f"Hypothesis to test:\n"
+        f"- vuln_class: {hypothesis.vuln_class}\n"
+        f"- threat: {hypothesis.threat}\n"
+        f"- http_method: {hypothesis.http_method}\n"
+        f"- http_path: {hypothesis.http_path}\n"
+        f"- function_name: {hypothesis.function_name}\n"
+        f"- severity: {hypothesis.severity}\n"
+        f"- cwe: {hypothesis.cwe}\n"
+        f"- description: {hypothesis.description}\n"
+        f"- has_mitigation_declared: {hypothesis.has_mitigation_declared}\n"
+        f"- payload_hint: {hypothesis.payload_hint}\n\n"
+        f"Write the probe."
+    )
+    try:
+        raw = provider.generate(SYSTEM_PROMPT, user_msg)
+    except Exception as e:
+        if verbose:
+            print(f"    ✗ {provider.name} generate failed: {e}")
+        return None
+    code = _extract_code(raw)
+    if not code:
+        if verbose:
+            print(f"    ✗ {provider.name} returned no ```python block (got {len(raw)} chars)")
+        return None
+    save_probe_source(hypothesis, code)
+    return code
+
+
+def make_probe_class(vuln_class: str, source: str, requires_auth_count: int = 1):
+    """Compile AI-generated source into an in-memory probe object matching the engine contract."""
+    from browser_engine import Finding
+    ns: dict = {"Finding": Finding}
+    exec(compile(source, "<ai-probe>", "exec"), ns)
+    if "run" not in ns or not callable(ns["run"]):
+        return None
+    user_run = ns["run"]
+
+    class _AIProbe:
+        pass
+    _AIProbe.vuln_class = vuln_class
+    _AIProbe.requires_auth_count = requires_auth_count
+
+    async def _run(self, ctxs, hypothesis):
+        raw_findings = await user_run(ctxs, hypothesis)
+        out = []
+        for f in raw_findings or []:
+            if isinstance(f, Finding):
+                out.append(f); continue
+            if not isinstance(f, dict):
+                continue
+            try:
+                out.append(Finding(
+                    id=f.get("id", f"ai-{vuln_class}"),
+                    vuln_class=f.get("vuln_class", vuln_class),
+                    severity=f.get("severity", "medium"),
+                    confirmed=bool(f.get("confirmed", False)),
+                    target=ctxs[0].target if ctxs else "",
+                    endpoint=f.get("endpoint", ""),
+                    description=f.get("description", ""),
+                    evidence=f.get("evidence", {}) or {},
+                    payload=f.get("payload"),
+                ))
+            except Exception:
+                continue
+        return out
+
+    _AIProbe.run = _run
+    return _AIProbe()
+
+
+# Small CLI for inspection
+if __name__ == "__main__":
+    import sys
+    p, reason = pick_provider(sys.argv[1] if len(sys.argv) > 1 else "auto")
+    print(reason)
+    if p:
+        print("test generation:")
+        out = p.generate("You are a terse assistant.", "Say exactly: ready")
+        print("  ", out.strip()[:200])

--- a/pentest/auth.py
+++ b/pentest/auth.py
@@ -1,0 +1,478 @@
+"""Auth profile management for cxg pentest.
+
+A profile = a saved Playwright storage_state (cookies + localStorage + sessionStorage)
+for one identity. Profiles live at ~/.cert-x-gen/auth/<name>.json.
+
+Two capture modes:
+  1. Interactive: opens a real Chromium window, user logs in by hand, we save the state.
+  2. Scripted:    POSTs creds to a known login endpoint, captures resulting cookies.
+
+--auth-numbers N triggers N captures in sequence (interactive) or N from a creds file
+(scripted), naming them <profile>-1, <profile>-2, ...
+"""
+from __future__ import annotations
+import json
+import os
+import sys
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Optional
+
+AUTH_DIR = Path.home() / ".cert-x-gen" / "auth"
+
+
+@dataclass
+class AuthProfile:
+    name: str
+    target: str
+    storage_state_path: str
+    label: Optional[str] = None  # human-readable: "admin", "analyst", "user"
+    extra_headers: dict = field(default_factory=dict)  # WAF bypass header, etc.
+
+    @property
+    def storage_state(self) -> dict:
+        return json.loads(Path(self.storage_state_path).read_text())
+
+
+def profile_path(name: str) -> Path:
+    return AUTH_DIR / f"{name}.json"
+
+
+def save_profile(name: str, target: str, storage_state: dict, label: Optional[str] = None,
+                 extra_headers: Optional[dict] = None) -> AuthProfile:
+    AUTH_DIR.mkdir(parents=True, exist_ok=True)
+    state_path = profile_path(name)
+    state_path.write_text(json.dumps(storage_state, indent=2))
+    meta_path = AUTH_DIR / f"{name}.meta.json"
+    meta = {"name": name, "target": target, "label": label,
+            "extra_headers": extra_headers or {}}
+    meta_path.write_text(json.dumps(meta, indent=2))
+    return AuthProfile(name=name, target=target, storage_state_path=str(state_path),
+                         label=label, extra_headers=extra_headers or {})
+
+
+def load_profile(name: str) -> AuthProfile:
+    state_path = profile_path(name)
+    if not state_path.exists():
+        raise FileNotFoundError(f"auth profile '{name}' not found at {state_path}")
+    meta_path = AUTH_DIR / f"{name}.meta.json"
+    meta = json.loads(meta_path.read_text()) if meta_path.exists() else {"target": "", "label": None}
+    return AuthProfile(
+        name=name,
+        target=meta.get("target", ""),
+        storage_state_path=str(state_path),
+        label=meta.get("label"),
+        extra_headers=meta.get("extra_headers") or {},
+    )
+
+
+def list_profiles() -> list[AuthProfile]:
+    if not AUTH_DIR.exists():
+        return []
+    out = []
+    for p in sorted(AUTH_DIR.glob("*.json")):
+        if p.name.endswith(".meta.json"):
+            continue
+        try:
+            out.append(load_profile(p.stem))
+        except Exception:
+            pass
+    return out
+
+
+def capture_interactive(target: str, profile_name: str, label: Optional[str] = None,
+                        verify_url: Optional[str] = None,
+                        extra_headers: Optional[dict] = None) -> AuthProfile:
+    """Open headed Chromium, let the operator log in (SSO / MFA / magic link / OAuth popup all work),
+    save the storage_state. Two ways to signal completion:
+
+      1. Press ENTER in the terminal (primary — robust across SSO multi-tab flows)
+      2. Close the browser window (fallback — works even if terminal is detached)
+
+    Before saving, optionally hit verify_url with the captured cookies and warn if 401/403.
+    """
+    from playwright.sync_api import sync_playwright
+    import threading
+    import time
+
+    who = label or profile_name
+    print(f"\n  ┌─ Interactive auth capture: {who}", file=sys.stderr)
+    print(f"  │  target:  {target}", file=sys.stderr)
+    print(f"  │  profile: {profile_name}", file=sys.stderr)
+    print(f"  │", file=sys.stderr)
+    print(f"  │  1. A Chromium window will open.", file=sys.stderr)
+    print(f"  │  2. Log in by ANY means: SSO, MFA, magic link, OAuth popup, etc.", file=sys.stderr)
+    print(f"  │  3. When the app dashboard is showing and you're definitely logged in,", file=sys.stderr)
+    print(f"  │       press ENTER here ↩  (closing the browser also works).", file=sys.stderr)
+    print(f"  └─", file=sys.stderr)
+    # Print the prompt EARLY so the user knows what to do as soon as the browser appears
+    print(f"\n  ↩  Press ENTER when logged in (or close the browser): ", end="", file=sys.stderr, flush=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        # extra_http_headers applies to every request out of this context, including
+        # any iframes / popups / OAuth bounces during login. So a WAF-bypass header
+        # like x-test-automation gets sent on every outbound call automatically.
+        ctx_kwargs = {}
+        if extra_headers:
+            ctx_kwargs["extra_http_headers"] = extra_headers
+        ctx = browser.new_context(**ctx_kwargs)
+        page = ctx.new_page()
+        try:
+            page.goto(target, wait_until="domcontentloaded", timeout=15000)
+        except Exception as e:
+            print(f"\n  (initial goto warning: {e})", file=sys.stderr)
+
+        # Wait for EITHER stdin ENTER or browser-disconnect, whichever comes first.
+        # IMPORTANT: do NOT call any Playwright methods from worker threads — Playwright's
+        # sync API uses greenlets that can't switch across threads. Only stdin runs on a
+        # thread; we poll Playwright state from the main thread.
+        stdin_done = threading.Event()
+
+        def _wait_stdin():
+            try:
+                input()  # prompt already printed above
+            except (EOFError, KeyboardInterrupt):
+                pass
+            stdin_done.set()
+
+        t1 = threading.Thread(target=_wait_stdin, daemon=True)
+        t1.start()
+
+        deadline = time.time() + 600  # 10 min hard cap
+        while time.time() < deadline:
+            if stdin_done.is_set():
+                break
+            # Main-thread Playwright call — safe.
+            if not browser.is_connected():
+                # User closed the whole window; treat as "done" signal
+                print(" (browser closed — capturing)", file=sys.stderr)
+                break
+            try:
+                # If every page has been closed, also treat as done.
+                if not ctx.pages:
+                    print(" (all tabs closed — capturing)", file=sys.stderr)
+                    break
+            except Exception:
+                break
+            time.sleep(0.4)
+
+        # Snapshot cookies from the context (covers all open pages incl. OAuth popups).
+        state = None
+        all_pages_urls = []
+        try:
+            if browser.is_connected():
+                all_pages_urls = [pg.url for pg in ctx.pages]
+                state = ctx.storage_state()
+        except Exception as e:
+            print(f"  ⚠ could not capture storage_state: {e}", file=sys.stderr)
+
+        try:
+            browser.close()
+        except Exception:
+            pass
+
+    if state is None:
+        raise RuntimeError(f"failed to capture state for {profile_name} — browser closed before snapshot")
+
+    cookies = state.get("cookies", [])
+    origins = state.get("origins", [])
+    print(f"  ✓ captured {len(cookies)} cookies across "
+          f"{len({c.get('domain','?') for c in cookies})} domains, "
+          f"{sum(len(o.get('localStorage',[])) for o in origins)} localStorage items, "
+          f"{sum(len(o.get('sessionStorage',[])) for o in origins)} sessionStorage items",
+          file=sys.stderr)
+    if len(all_pages_urls) > 1:
+        print(f"  ✓ captured state from {len(all_pages_urls)} pages (OAuth popups handled)",
+              file=sys.stderr)
+
+    prof = save_profile(profile_name, target, state, label=label,
+                          extra_headers=extra_headers)
+
+    # Post-capture verification — same landing-page test the scan-time inspector uses.
+    # If verify_url is set, we ALSO hit it as a bonus check (without overriding the
+    # landing-test verdict). Default (None) = landing test only.
+    _verify_captured_session(target, verify_url, state, extra_headers=extra_headers)
+    return prof
+
+
+def _looks_like_login_page(final_url: str, html: str) -> bool:
+    """Same heuristic profile_inspect uses: URL/content tells us if the saved session
+    bounced us to a login/SSO page instead of the app."""
+    u = (final_url or "").lower()
+    if any(s in u for s in ("/login", "/signin", "/sign-in", "/auth/login",
+                              "/oauth/authorize", "/sso", "/saml",
+                              "auth.ac", "okta.com", "auth0.com", "accounts.google.com",
+                              "/keycloak", "/realms/")):
+        return True
+    h = (html or "")[:65536].lower()
+    login_markers = (
+        '<input type="password"', "<input type='password'", "type=password",
+        'name="password"', "name='password'",
+        "sign in to", "log in to", "please sign in", "please log in",
+        ">login</", ">sign in</",
+    )
+    return sum(1 for m in login_markers if m in h) >= 2
+
+
+def _verify_captured_session(target: str, verify_url: Optional[str], state: dict,
+                              extra_headers: Optional[dict] = None) -> None:
+    """Spin up a quick headless context with the captured state, navigate to `target`,
+    and see where we land. If the final URL/page looks like a login page → session is
+    dead. Otherwise → alive.
+
+    If verify_url is supplied, we ALSO probe it for completeness, but the landing test
+    is the source of truth.
+    """
+    from playwright.sync_api import sync_playwright
+    try:
+        with sync_playwright() as p:
+            b = p.chromium.launch(headless=True)
+            ctx_kwargs = {"storage_state": state}
+            if extra_headers:
+                ctx_kwargs["extra_http_headers"] = extra_headers
+            c = b.new_context(**ctx_kwargs)
+            pg = c.new_page()
+            try:
+                pg.goto(target, wait_until="domcontentloaded", timeout=15000)
+                try:
+                    pg.wait_for_load_state("networkidle", timeout=5000)
+                except Exception:
+                    pass
+            except Exception as e:
+                print(f"  ⚠ couldn't load {target} during verification: {e}", file=sys.stderr)
+                b.close()
+                return
+
+            landed_url = pg.url
+            try:
+                landed_html = pg.content()
+            except Exception:
+                landed_html = ""
+
+            looks_login = _looks_like_login_page(landed_url, landed_html)
+
+            # Optional bonus: also probe verify_url if user supplied one
+            bonus_status = None
+            if verify_url:
+                full = verify_url if verify_url.startswith("http") else target.rstrip("/") + verify_url
+                try:
+                    res = pg.evaluate(
+                        """async (url) => {
+                            try {
+                                const r = await fetch(url, {credentials:'include'});
+                                return {status: r.status};
+                            } catch(e) { return {status: 0, error: String(e)}; }
+                        }""",
+                        full,
+                    )
+                    bonus_status = res.get("status")
+                except Exception:
+                    pass
+
+            b.close()
+
+            if looks_login:
+                print(f"  ⚠ session VERIFICATION FAILED: landed at {landed_url}",
+                      file=sys.stderr)
+                print(f"     That URL or page content looks like a login/SSO page — your captured",
+                      file=sys.stderr)
+                print(f"     cookies aren't authenticating against {target}.", file=sys.stderr)
+                print(f"     Common causes: (1) you closed before login completed, (2) SSO scoped",
+                      file=sys.stderr)
+                print(f"     cookies to a different subdomain than --target. Re-run and complete",
+                      file=sys.stderr)
+                print(f"     the login fully before pressing ENTER.", file=sys.stderr)
+            else:
+                msg = f"  ✓ session verified — landed at {landed_url} (no login redirect)"
+                if bonus_status is not None:
+                    msg += f"; {verify_url} → {bonus_status}"
+                print(msg, file=sys.stderr)
+    except Exception as e:
+        print(f"  ⚠ session verification skipped: {e}", file=sys.stderr)
+
+
+def capture_interactive_multi(target: str, profile_prefix: str, n: int,
+                              verify_url: Optional[str] = None,
+                              extra_headers: Optional[dict] = None) -> list[AuthProfile]:
+    """Open N headed Chromium windows in sequence. Before each, prompt the operator for a
+    human-readable label (e.g. "attacker", "victim"). Saves as <prefix>-1, <prefix>-2, ...
+
+    Same login mechanism as capture_interactive — any auth method works (SSO, MFA, OAuth, etc.)."""
+    profiles: list[AuthProfile] = []
+    for i in range(1, n + 1):
+        name = f"{profile_prefix}-{i}"
+        print(f"\n══════════════════════════════════════════════════════════════════")
+        print(f"  Auth capture {i}/{n}")
+        print(f"══════════════════════════════════════════════════════════════════")
+        try:
+            label = input(f"  Label for this identity (e.g. attacker / victim / admin) [{name}]: ").strip()
+        except EOFError:
+            label = ""
+        if not label:
+            label = name
+        prof = capture_interactive(target, name, label=label, verify_url=verify_url,
+                                     extra_headers=extra_headers)
+        profiles.append(prof)
+    print(f"\n  ✓ captured {len(profiles)} auth profiles")
+    return profiles
+
+
+def capture_scripted(target: str, profile_name: str, email: str, password: str,
+                     login_path: str = "/api/auth/login", label: Optional[str] = None,
+                     extra_headers: Optional[dict] = None) -> AuthProfile:
+    """Headless login flow: navigate, POST creds via the page's fetch (so cookies stick), save state.
+
+    We use the page's fetch() instead of a raw HTTP client so cookies are stored in the browser
+    context exactly as a real session would be — matching what storage_state captures.
+    """
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx_kwargs = {}
+        if extra_headers:
+            ctx_kwargs["extra_http_headers"] = extra_headers
+        ctx = browser.new_context(**ctx_kwargs)
+        page = ctx.new_page()
+        page.goto(target, wait_until="domcontentloaded")
+        # CSRF double-submit: the app sets csrf_token cookie on first GET; we need to send it back.
+        csrf = None
+        for c in ctx.cookies():
+            if c["name"] == "csrf_token":
+                csrf = c["value"]
+                break
+        login_url = target.rstrip("/") + login_path
+        result = page.evaluate(
+            """async ({url, body, csrf}) => {
+                const headers = {'Content-Type': 'application/json'};
+                if (csrf) headers['X-CSRF-Token'] = csrf;
+                const r = await fetch(url, {method:'POST', credentials:'include', headers, body: JSON.stringify(body)});
+                let data = null; try { data = await r.json(); } catch(e){}
+                return {status: r.status, data};
+            }""",
+            {"url": login_url, "body": {"email": email, "password": password}, "csrf": csrf},
+        )
+        if result.get("status") not in (200, 201, 204):
+            browser.close()
+            raise RuntimeError(f"scripted login failed for {email}: status={result.get('status')} body={result.get('data')}")
+        state = ctx.storage_state()
+        browser.close()
+    return save_profile(profile_name, target, state, label=label)
+
+
+def main(argv: list[str]) -> int:
+    import argparse
+    ap = argparse.ArgumentParser(prog="cxg-pentest auth")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_login = sub.add_parser("login", help="Capture an auth profile")
+    p_login.add_argument("--target", required=True,
+                         help="Target URL where login happens. The post-capture verifier opens "
+                              "this URL with the saved cookies; if it doesn't bounce to a login "
+                              "page, the session is alive.")
+    p_login.add_argument("--profile", required=True,
+                         help="Profile name. If --auth-numbers > 1, this is the PREFIX and final "
+                              "profiles are named <profile>-1, <profile>-2, etc. Use a stable name "
+                              "so subsequent `cxg pentest run --auth <profile>` invocations work.")
+    p_login.add_argument("--auth-numbers", type=int, default=1,
+                         help="Number of profiles to capture in sequence. Each capture opens its "
+                              "own Chromium window and prompts for a label. Required ≥2 for chained-"
+                              "auth probes like IDOR cross-user tests.")
+    p_login.add_argument("--label", default=None,
+                         help="Human-readable label (e.g. 'admin', 'low-priv-user'). Shown in scan "
+                              "output to make findings readable.")
+    p_login.add_argument("--creds", default=None,
+                         help="Inline credentials email:password for scripted login (skips browser "
+                              "pop-up). Only works for password-based auth — SSO/MFA flows MUST use "
+                              "interactive capture.")
+    p_login.add_argument("--creds-file", default=None,
+                         help="File with email:password[:label] per line for scripted batch capture.")
+    p_login.add_argument("--login-path", default="/api/auth/login",
+                         help="Endpoint path for scripted login POST. Only used with --creds or "
+                              "--creds-file. The captured browser will POST {email, password} as "
+                              "JSON to <target><login-path>.")
+    p_login.add_argument("--header", action="append", default=[], metavar="NAME:VALUE",
+                         help="Custom HTTP header sent on EVERY outbound request from this "
+                              "profile's browser context — login, scan probes, health checks. "
+                              "Repeatable for multiple headers. Saved with the profile so future "
+                              "`cxg pentest run --auth <profile>` invocations reuse them automatically. "
+                              "Use case: WAF-bypass tokens granted by infra. SECURITY: stored in "
+                              "plaintext under ~/.cert-x-gen/auth/<profile>.meta.json — treat as a "
+                              "credential, chmod 600 if your machine has multiple users.")
+    p_login.add_argument("--verify-url", default=None,
+                         help="Optional URL probed after capture as a secondary identity check. "
+                              "The landing test is the primary signal regardless. Default: no "
+                              "secondary probe. Pass an empty string to explicitly skip.")
+
+    p_list = sub.add_parser("list", help="List saved auth profiles under ~/.cert-x-gen/auth/")
+
+    args = ap.parse_args(argv)
+    if args.cmd == "list":
+        for prof in list_profiles():
+            print(f"  {prof.name:20s} label={prof.label or '-':10s} target={prof.target}")
+        return 0
+
+    if args.cmd == "login":
+        n = max(1, args.auth_numbers)
+        creds_list: list[tuple[str, str, Optional[str]]] = []
+        if args.creds_file:
+            for line in Path(args.creds_file).read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split(":")
+                if len(parts) < 2:
+                    continue
+                email, pw = parts[0], parts[1]
+                lbl = parts[2] if len(parts) > 2 else None
+                creds_list.append((email, pw, lbl))
+        elif args.creds:
+            email, pw = args.creds.split(":", 1)
+            creds_list.append((email, pw, args.label))
+
+        # Resolve verify_url: None → default to <target>/api/me; "" → skip verification
+        vurl = args.verify_url
+        if vurl == "":
+            vurl_resolved = None  # passing None to capture_interactive means use default
+            skip_verify = True
+        else:
+            vurl_resolved = vurl
+            skip_verify = False
+
+        # Parse repeatable --header NAME:VALUE into a dict
+        extra_headers: dict = {}
+        for h in getattr(args, "header", []) or []:
+            if ":" not in h:
+                print(f"  ⚠ ignoring malformed --header '{h}' (expected NAME:VALUE)", file=sys.stderr)
+                continue
+            name, _, val = h.partition(":")
+            extra_headers[name.strip()] = val.strip()
+        if extra_headers:
+            # Don't print values — they may be secrets like WAF tokens.
+            print(f"  ✓ {len(extra_headers)} extra header(s) will be sent on every request: "
+                  f"{list(extra_headers)}", file=sys.stderr)
+
+        if not creds_list and n > 1:
+            # Interactive multi-capture with per-profile label prompt
+            capture_interactive_multi(args.target, args.profile, n,
+                                       verify_url=vurl_resolved, extra_headers=extra_headers)
+            return 0
+        for i in range(n):
+            name = args.profile if n == 1 else f"{args.profile}-{i+1}"
+            if creds_list:
+                email, pw, lbl = creds_list[i % len(creds_list)]
+                prof = capture_scripted(args.target, name, email, pw, args.login_path,
+                                          label=lbl or args.label, extra_headers=extra_headers)
+                print(f"[auth] saved {prof.name} (scripted, {email})")
+            else:
+                prof = capture_interactive(args.target, name, label=args.label,
+                                             verify_url=vurl_resolved,
+                                             extra_headers=extra_headers)
+                print(f"[auth] saved {prof.name} (interactive)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/pentest/browser_engine.py
+++ b/pentest/browser_engine.py
@@ -1,0 +1,228 @@
+"""Browser engine: runs probes in N parallel authenticated Chromium contexts.
+
+The contract a probe must satisfy:
+    class MyProbe:
+        vuln_class = "idor"          # matches normalized guardlink threat
+        requires_auth_count = 2      # min authenticated contexts needed
+        async def run(self, ctxs: list[ProbeContext], hypothesis) -> list[Finding]: ...
+
+ProbeContext wraps:
+  - playwright BrowserContext (cookies/storage from a real session)
+  - the AuthProfile metadata (label, target)
+  - a captured-events log (network/console/pageerror) populated automatically
+
+--auth-numbers controls how many *distinct* AuthProfiles get spawned simultaneously.
+For IDOR / chained-auth, the probe declares requires_auth_count >= 2 and the engine
+ensures it gets at least that many contexts before running.
+"""
+from __future__ import annotations
+import asyncio
+import json
+import re
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+from auth import AuthProfile, load_profile
+
+
+@dataclass
+class Finding:
+    id: str
+    vuln_class: str
+    severity: str
+    confirmed: bool
+    target: str
+    endpoint: str
+    description: str
+    evidence: dict = field(default_factory=dict)
+    payload: Optional[str] = None
+    hypothesis_id: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class CapturedEvent:
+    kind: str  # "request" | "response" | "console" | "pageerror"
+    ts: float
+    data: dict
+
+
+class ProbeContext:
+    """Per-auth-profile execution context exposed to probes."""
+    def __init__(self, profile: AuthProfile, browser_ctx, page, target: str):
+        self.profile = profile
+        self.ctx = browser_ctx
+        self.page = page
+        self.target = target.rstrip("/")
+        self.events: list[CapturedEvent] = []
+
+    def url(self, path: str) -> str:
+        return self.target + (path if path.startswith("/") else "/" + path)
+
+    async def api(self, method: str, path: str, body: Any = None, headers: Optional[dict] = None) -> dict:
+        """Issue a fetch() from inside the page, so cookies & origin match a real session.
+
+        Auto-includes X-CSRF-Token from the csrf_token cookie for state-changing methods.
+        Returns {status, headers, body_text, body_json (or None)}.
+        """
+        url = self.url(path)
+        hdr = dict(headers or {})
+        if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
+            for c in await self.ctx.cookies():
+                if c["name"] == "csrf_token":
+                    hdr.setdefault("X-CSRF-Token", c["value"])
+                    break
+        result = await self.page.evaluate(
+            """async ({url, method, body, headers}) => {
+                const opts = {method, credentials:'include', headers: headers || {}};
+                if (body !== null && body !== undefined) {
+                    opts.headers['Content-Type'] = opts.headers['Content-Type'] || 'application/json';
+                    opts.body = (typeof body === 'string') ? body : JSON.stringify(body);
+                }
+                const r = await fetch(url, opts);
+                const text = await r.text();
+                const respHeaders = {};
+                r.headers.forEach((v,k) => respHeaders[k]=v);
+                let j = null; try { j = JSON.parse(text); } catch(e){}
+                return {status: r.status, headers: respHeaders, body_text: text, body_json: j};
+            }""",
+            {"url": url, "method": method.upper(), "body": body, "headers": hdr},
+        )
+        return result
+
+
+class BrowserEngine:
+    def __init__(self, target: str, profile_names: list[str], headless: bool = True):
+        self.target = target.rstrip("/")
+        self.profiles = [load_profile(n) for n in profile_names]
+        self.headless = headless
+
+    async def _open_context(self, p, profile: AuthProfile) -> ProbeContext:
+        browser = await p.chromium.launch(headless=self.headless)
+        ctx = await browser.new_context(storage_state=profile.storage_state)
+        page = await ctx.new_page()
+        # Navigate to the target origin so subsequent in-page fetch() is same-origin
+        # (cross-origin fetches from about:blank fail with "Failed to fetch").
+        try:
+            await page.goto(self.target, wait_until="domcontentloaded", timeout=15000)
+        except Exception as e:
+            print(f"[engine] warning: initial goto({self.target}) for {profile.name} failed: {e}")
+        pc = ProbeContext(profile, ctx, page, self.target)
+
+        # Auto-capture interesting events for evidence
+        def on_req(req):
+            pc.events.append(CapturedEvent("request", time.time(),
+                                           {"method": req.method, "url": req.url}))
+        def on_resp(resp):
+            pc.events.append(CapturedEvent("response", time.time(),
+                                           {"status": resp.status, "url": resp.url}))
+        def on_console(msg):
+            pc.events.append(CapturedEvent("console", time.time(),
+                                           {"type": msg.type, "text": msg.text}))
+        def on_pageerr(err):
+            pc.events.append(CapturedEvent("pageerror", time.time(),
+                                           {"error": str(err)}))
+        page.on("request", on_req)
+        page.on("response", on_resp)
+        page.on("console", on_console)
+        page.on("pageerror", on_pageerr)
+        # Stash browser so we can close it later
+        pc._browser = browser  # type: ignore
+        return pc
+
+    async def _close_context(self, pc: ProbeContext):
+        try:
+            await pc._browser.close()  # type: ignore
+        except Exception:
+            pass
+
+    async def run_probes(self, probes: list, hypotheses_by_class: dict[str, list]) -> list[Finding]:
+        """For each probe class, open the contexts it needs and run it against each matching hypothesis."""
+        from playwright.async_api import async_playwright
+
+        findings: list[Finding] = []
+        async with async_playwright() as p:
+            # Open ALL contexts up front (one per profile). Probes share them.
+            all_ctxs: list[ProbeContext] = []
+            for prof in self.profiles:
+                all_ctxs.append(await self._open_context(p, prof))
+
+            try:
+                seen_finding_ids: set[str] = set()
+                # Run non-mutating probes first; mutating ones (which call logout, change roles,
+                # rate-limit themselves out) go LAST so they don't poison earlier probes' sessions.
+                # destructive_priority: 0 = read-only, higher = more disruptive to later probes.
+                # SessionReplay logs out its target user, so it must run last for that auth ctx.
+                probes = sorted(probes, key=lambda p: getattr(p, "destructive_priority",
+                                                              10 if getattr(p, "mutates_session", False) else 0))
+                for probe in probes:
+                    need = getattr(probe, "requires_auth_count", 1)
+                    if need > len(all_ctxs):
+                        print(f"[engine] skip {probe.__class__.__name__}: needs {need} auth contexts, have {len(all_ctxs)}")
+                        continue
+                    ctxs = all_ctxs[:need]
+                    hyps = hypotheses_by_class.get(probe.vuln_class, [])
+                    if not hyps:
+                        continue
+                    # Run probe ONCE per class, with the highest-confidence hypothesis as the
+                    # representative. Probes that want per-hypothesis runs can opt in via
+                    # `per_hypothesis = True` class attribute.
+                    per_hyp = getattr(probe, "per_hypothesis", False)
+                    runs = hyps if per_hyp else [max(hyps, key=lambda h: getattr(h, "confidence", 0.0))]
+                    for h in runs:
+                        # Restore the original storage_state for each probe so destructive
+                        # probes (logout, role changes) don't bleed state into later probes.
+                        for pc in ctxs:
+                            try:
+                                await pc.ctx.clear_cookies()
+                                await pc.ctx.add_cookies(pc.profile.storage_state.get("cookies", []))
+                            except Exception:
+                                pass
+                        try:
+                            res = await probe.run(ctxs, h)
+                            for f in res or []:
+                                if f.id in seen_finding_ids:
+                                    continue
+                                seen_finding_ids.add(f.id)
+                                f.hypothesis_id = h.id
+                                findings.append(f)
+                        except Exception as e:
+                            print(f"[engine] probe {probe.__class__.__name__} on {h.id} crashed: {e}")
+            finally:
+                for pc in all_ctxs:
+                    await self._close_context(pc)
+        return findings
+
+
+def group_hypotheses(hyps) -> dict[str, list]:
+    """Group hypotheses by their vuln_class for probe dispatch.
+
+    Some classes are aliases (e.g. guardlink emits 'idor' for IDOR but also surfaces
+    'records_api', 'users_api', 'transactions_api' which are really IDOR-flavored).
+    We normalize aliases here.
+    """
+    aliases = {
+        "records_api": "idor",
+        "users_api": "privilege_escalation",
+        "transactions_api": "idor",
+        "stats_api": "sensitive_data_exposure",
+        "security_events_api": "sensitive_data_exposure",
+        "service_health_api": "sensitive_data_exposure",
+        "auth_api": "credential_stuffing",
+        "absence_missing_rate_limiting": "rate_limit_bypass",
+        "metrics_endpoint": "metrics_info_disclosure",
+        "audit_log": "sensitive_data_exposure",
+        "frontend": "xss",
+    }
+    out: dict[str, list] = {}
+    for h in hyps:
+        key = aliases.get(h.vuln_class, h.vuln_class)
+        out.setdefault(key, []).append(h)
+        # also keep under original class for direct matches
+        if key != h.vuln_class:
+            out.setdefault(h.vuln_class, []).append(h)
+    return out

--- a/pentest/cxg_pentest.py
+++ b/pentest/cxg_pentest.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""cxg pentest — AI-driven whitebox pentest pipeline.
+
+Pipeline:
+  1. Parse guardlink output (SARIF + inline) from --codebase
+  2. Group hypotheses by vuln_class
+  3. For each class, pick the matching built-in probe (or AI-generate one if missing)
+  4. Open N authenticated browser contexts (one per --auth profile)
+  5. Run probes; capture confirmed findings
+  6. Print + write JSON report
+"""
+from __future__ import annotations
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+from guardlink import load as load_guardlink
+from browser_engine import BrowserEngine, group_hypotheses
+from payloads import ALL_PROBES
+from ai_generator import generate_probe_source, make_probe_class, pick_provider
+from auth import capture_scripted, capture_interactive_multi
+from js_generator import generate_all as generate_js_all
+from js_engine import JsEngine, load_templates as load_js_templates
+from scope import ScopeConfig, AuditLog, write_example_scope_file, HardKillSignal
+from session_health import SessionHealthMonitor
+from profile_inspect import inspect_profiles_async, coverage_summary
+
+
+SCOPE_BANNER = (
+    "\n========================================================================\n"
+    " ⚠  cxg pentest is OFFENSIVE tooling. By running this you confirm you have\n"
+    "    WRITTEN AUTHORIZATION to test the specified target.\n"
+    "========================================================================\n"
+)
+
+
+def _print_finding(f, marker: str):
+    print(f"  [{marker}] [{f.severity.upper():8s}] {f.vuln_class:25s} {f.endpoint}")
+    print(f"             {f.description}")
+    if f.payload:
+        print(f"             payload: {str(f.payload)[:200]}")
+    if f.evidence:
+        ev = json.dumps(f.evidence, default=str)
+        if len(ev) > 220:
+            ev = ev[:220] + "...(truncated)"
+        print(f"             evidence: {ev}")
+    print()
+
+
+def select_probes(hypotheses_by_class: dict, enable_ai: bool, ai_provider_name: str,
+                  sample_per_class: int) -> list:
+    """Pick a probe per vuln_class. Built-in first; if missing AND --ai, ask the AI provider."""
+    picked = []
+    builtin_by_class = {p.vuln_class: p for p in ALL_PROBES}
+
+    provider = None
+    if enable_ai:
+        provider, reason = pick_provider(ai_provider_name)
+        print(f"  AI: {reason}")
+        if provider is None:
+            print("    ⚠ AI generation disabled for this run — no provider available")
+            enable_ai = False
+
+    for cls in sorted(hypotheses_by_class):
+        if cls in builtin_by_class:
+            picked.append(builtin_by_class[cls])
+            print(f"  → probe={builtin_by_class[cls].__class__.__name__} for class={cls}")
+            continue
+        if not enable_ai:
+            print(f"  · no built-in probe for class={cls}, skipping (use --ai to synthesize)")
+            continue
+        # Only attempt AI for hypotheses that have enough shape (http_path) to write a probe against.
+        hyps = [h for h in hypotheses_by_class[cls] if h.http_path]
+        if not hyps:
+            print(f"  · class={cls}: no hypotheses with concrete http_path — skipping AI")
+            continue
+        sample = hyps[0]
+        print(f"  ⚙ AI-generating probe for class={cls} (sample: {sample.http_method} {sample.http_path})")
+        src = generate_probe_source(sample, provider=provider, verbose=True)
+        if not src:
+            continue
+        ai_probe = make_probe_class(cls, src, requires_auth_count=2 if cls == "idor" else 1)
+        if ai_probe is None:
+            print(f"    ⚠ AI probe did not compile for {cls}")
+            continue
+        print(f"    ✓ AI probe synthesized for {cls}")
+        picked.append(ai_probe)
+    return picked
+
+
+async def run_pentest(args) -> int:
+    print(SCOPE_BANNER)
+    print(f"target:        {args.target}")
+    print(f"codebase:      {args.codebase}")
+    print(f"auth:          {', '.join(args.auth)} ({len(args.auth)} contexts; --auth-numbers={args.auth_numbers})")
+    print(f"template lang: {args.template_lang}")
+    print(f"goal:          {args.goal or '(none — broad coverage)'}")
+    print(f"AI:            {'on' if args.ai else 'off'}")
+    print()
+
+    # --- JS pipeline path -----------------------------------------------------
+    if args.template_lang == "js":
+        cb = Path(args.codebase)
+        sarif, inline, surface = load_guardlink(cb)
+        print(f"[1] guardlink: {len(sarif)} SARIF hypotheses, {len(inline)} inline, "
+              f"{surface['endpoint_count']} endpoints")
+
+        # SCOPE: load (or default) + audit log
+        scope_cfg = ScopeConfig.load(Path(args.scope_file) if args.scope_file else None,
+                                     destructive_ok=args.destructive_ok)
+        scope_cfg.target = args.target
+        if args.attestation:
+            scope_cfg.authorization_attestation = args.attestation
+
+        session_root = Path(args.session_dir) if args.session_dir else \
+                       Path.home() / ".cert-x-gen" / "sessions" / time.strftime("pentest-%Y%m%d-%H%M%S")
+        session_root.mkdir(parents=True, exist_ok=True)
+        audit = AuditLog(session_root / "audit.jsonl")
+        audit.header({
+            "target": args.target, "codebase": str(cb), "goal": args.goal,
+            "auth_profiles": args.auth, "attestation": scope_cfg.authorization_attestation,
+            "scope": {"method_allowlist": scope_cfg.method_allowlist,
+                      "destructive_ok": scope_cfg.destructive_ok,
+                      "max_requests_total": scope_cfg.max_requests_total,
+                      "max_requests_per_endpoint": scope_cfg.max_requests_per_endpoint},
+        })
+        print(f"[scope] audit log → {session_root / 'audit.jsonl'}")
+        if not scope_cfg.authorization_attestation:
+            print("[scope] ⚠  no --attestation supplied. For real engagements, "
+                  "include written authorization text via --attestation or scope.yaml.")
+
+        # SESSION HEALTH: build creds map from --creds-file if present
+        creds_map: dict[str, tuple[str, str, str]] = {}
+        if args.creds_file:
+            for line in Path(args.creds_file).read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split(":")
+                if len(parts) >= 3:
+                    creds_map[parts[0]] = (parts[1], parts[2], parts[3] if len(parts) > 3 else parts[0])
+        health = SessionHealthMonitor(args.target, creds_map=creds_map)
+
+        # 1b. PRE-FLIGHT: inspect captured auth profiles so the ranker knows what
+        # identities we have to attack with (and warns if we're missing critical tiers).
+        # Primary check: navigate to --target with the saved cookies and see where we
+        # land. Login-page redirect = dead. Anything else = alive. /me-path probe is
+        # secondary, used only to populate role/email metadata.
+        print(f"[1b] inspecting {len(args.auth)} captured auth profiles…")
+        profile_infos = await inspect_profiles_async(args.auth, args.target, me_path=args.me_path)
+        if getattr(args, "skip_health_check", False):
+            for info in profile_infos:
+                if not info.alive:
+                    info.alive = True
+                    info.notes.append("health check skipped via --skip-health-check")
+                    print(f"     ⓘ forcing {info.profile_name} alive (--skip-health-check)")
+        for info in profile_infos:
+            print(f"     · {info.short()}")
+            for n in info.notes:
+                print(f"         · {n}")
+        cov = coverage_summary(profile_infos)
+        for note in cov["notes"]:
+            print(f"     ⚠ {note}")
+        # Persist into audit log so the report explains why certain probes were deprioritized
+        audit._write({"_event": "profile_inspection", "ts": time.time(),
+                      "profiles": [info.__dict__ for info in profile_infos],
+                      "coverage": cov})
+        print()
+
+        # 2. Generate (or reuse cached) JS templates
+        if args.template_dir:
+            tpl_dir = Path(args.template_dir)
+            print(f"[2] using existing template dir: {tpl_dir}")
+        else:
+            print(f"[2] generating JS templates via {args.ai_provider} (reads codebase)…")
+            tpl_dir = generate_js_all(cb, sarif, args.goal, top_n=args.max_templates,
+                                       provider=args.ai_provider,
+                                       profile_infos=profile_infos,
+                                       generation_timeout_s=args.generation_timeout,
+                                       mitigation_mode=args.mitigation_mode)
+
+        templates = load_js_templates(tpl_dir)
+        if not templates:
+            print("[3] no templates available — exiting")
+            audit.footer({"status": "no_templates"})
+            audit.close()
+            return 1
+        print(f"[3] loaded {len(templates)} templates from {tpl_dir}")
+        for t in templates:
+            print(f"    · {t.id:50s} vuln_class={t.vuln_class} sev={t.severity}")
+        print()
+
+        print(f"[4] opening {len(args.auth)} authenticated Chromium contexts ({'headed' if args.headed else 'headless'})")
+        engine = JsEngine(args.target, args.auth, headless=not args.headed,
+                          scope_cfg=scope_cfg, audit_log=audit, health_monitor=health,
+                          codebase=cb, mutation_retries=args.mutation_retries,
+                          profile_infos=profile_infos, oast_host=args.oast)
+        t0 = time.time()
+        try:
+            results = await engine.run(templates)
+        except HardKillSignal as e:
+            print(f"⛔ scan hard-killed: {e}")
+            results = engine.run.__self__ if False else None  # placeholder
+            audit.footer({"status": "hard_killed", "reason": str(e)})
+            audit.close()
+            return 3
+        dur = time.time() - t0
+        print(f"[5] scan complete in {dur:.1f}s")
+        print(f"     confirmed_findings={len(results.confirmed_findings)} "
+              f"mitigation_verifications={len(results.mitigation_verifications)} "
+              f"ambiguous={len(results.ambiguous)} "
+              f"rejected_templates={len(results.rejected_templates)} "
+              f"dead_profiles={len(results.dead_profiles)}")
+        print()
+
+        # --- console output, grouped ---
+        print("=" * 72)
+        print("CONFIRMED FINDINGS")
+        print("=" * 72)
+        if not results.confirmed_findings:
+            print("  (none)")
+        else:
+            for f in results.confirmed_findings:
+                _print_finding(f, marker="CONFIRMED")
+        print()
+        if results.ambiguous:
+            print("=" * 72)
+            print(f"AMBIGUOUS (post-mutation, still unclear) — {len(results.ambiguous)}")
+            print("=" * 72)
+            for f in results.ambiguous[:10]:
+                _print_finding(f, marker="AMBIGUOUS")
+            if len(results.ambiguous) > 10:
+                print(f"  ... and {len(results.ambiguous)-10} more (see report)")
+            print()
+        if results.mitigation_verifications:
+            print(f"MITIGATIONS VERIFIED HOLDING: {len(results.mitigation_verifications)} "
+                  "(probes ran, server rejected exploit — control is working)")
+            for f in results.mitigation_verifications[:5]:
+                print(f"  ✓ {f.vuln_class:25s} {f.endpoint} — {f.description[:80]}")
+            if len(results.mitigation_verifications) > 5:
+                print(f"  ... and {len(results.mitigation_verifications)-5} more (see report)")
+            print()
+
+        # --- report ---
+        report = {
+            "target": args.target, "codebase": str(cb),
+            "auth_profiles": args.auth, "goal": args.goal,
+            "template_dir": str(tpl_dir),
+            "session_dir": str(session_root),
+            "audit_log": str(session_root / "audit.jsonl"),
+            "duration_seconds": round(dur, 2),
+            "guardlink_hypotheses": len(sarif),
+            "scope_stats": results.scope_stats,
+            "rejected_templates": results.rejected_templates,
+            "dead_profiles": results.dead_profiles,
+            "confirmed_findings": [f.to_dict() for f in results.confirmed_findings],
+            "ambiguous": [f.to_dict() for f in results.ambiguous],
+            "mitigation_verifications": [f.to_dict() for f in results.mitigation_verifications],
+            "retried_then_resolved": results.retried_then_resolved,
+        }
+        out_path = args.output or (session_root / "report.json")
+        Path(out_path).write_text(json.dumps(report, indent=2, default=str))
+        print(f"report → {out_path}")
+
+        audit.footer({
+            "status": "ok", "duration_seconds": round(dur, 2),
+            "confirmed_findings": len(results.confirmed_findings),
+            "mitigation_verifications": len(results.mitigation_verifications),
+            "ambiguous": len(results.ambiguous),
+            "scope_stats": results.scope_stats,
+        })
+        audit.close()
+        return 0 if not results.confirmed_findings else 2
+    # --- /JS pipeline path ----------------------------------------------------
+
+    # 1. Parse guardlink
+    cb = Path(args.codebase)
+    sarif, inline, surface = load_guardlink(cb)
+    print(f"[1] guardlink: {len(sarif)} SARIF hypotheses, {len(inline)} inline annotations, "
+          f"{surface['endpoint_count']} distinct endpoints")
+
+    # 2. Group by vuln_class
+    grouped = group_hypotheses(sarif)
+    nonempty = {k: v for k, v in grouped.items() if v}
+    print(f"[2] vuln classes: {sorted(nonempty)}")
+    print()
+
+    # 3. Pick probes
+    print("[3] selecting probes:")
+    probes = select_probes(nonempty, enable_ai=args.ai, ai_provider_name=args.ai_provider,
+                           sample_per_class=1)
+    if not probes:
+        print("no probes selected; nothing to run.")
+        return 1
+    print()
+
+    # 4 + 5. Open contexts & run
+    print(f"[4] opening {len(args.auth)} authenticated Chromium contexts ({'headed' if args.headed else 'headless'})")
+    engine = BrowserEngine(args.target, args.auth, headless=not args.headed)
+    t0 = time.time()
+    findings = await engine.run_probes(probes, nonempty)
+    dur = time.time() - t0
+    print(f"[5] {len(findings)} confirmed findings in {dur:.1f}s\n")
+
+    # 6. Report
+    print("=" * 72)
+    if not findings:
+        print("NO CONFIRMED FINDINGS")
+    else:
+        for f in findings:
+            sev = f.severity.upper()
+            print(f"[{sev:8s}] {f.vuln_class:25s} {f.endpoint}")
+            print(f"           {f.description}")
+            if f.payload:
+                print(f"           payload: {f.payload}")
+            if f.evidence:
+                ev = json.dumps(f.evidence, default=str)
+                if len(ev) > 220:
+                    ev = ev[:220] + "...(truncated)"
+                print(f"           evidence: {ev}")
+            print()
+
+    # Write JSON report
+    if args.output:
+        report = {
+            "target": args.target,
+            "codebase": str(cb),
+            "auth_profiles": args.auth,
+            "duration_seconds": round(dur, 2),
+            "guardlink_hypotheses": len(sarif),
+            "guardlink_endpoints": surface["endpoint_count"],
+            "findings": [f.to_dict() for f in findings],
+        }
+        Path(args.output).write_text(json.dumps(report, indent=2, default=str))
+        print(f"report written to {args.output}")
+    return 0 if not findings else 2  # non-zero on findings for CI
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        prog="cxg-pentest",
+        description="AI-driven whitebox pentest orchestrator. Invoked by the cxg Rust CLI "
+                    "via `cxg pentest <subcommand>`. Reads guardlink SARIF + inline annotations, "
+                    "generates JS probe templates via a local AI CLI, executes them in parallel "
+                    "authenticated Chromium contexts, and triages findings.",
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    # auth subcommand defers to auth.py's parser — accept arbitrary args
+    p_auth = sub.add_parser("auth", help="Manage auth profiles (see `auth.py --help`)",
+                            add_help=False)
+    p_auth.add_argument("auth_args", nargs=argparse.REMAINDER)
+
+    # scope subcommand
+    p_scope = sub.add_parser("scope", help="Manage scope.yaml files")
+    p_scope_sub = p_scope.add_subparsers(dest="scope_cmd", required=True)
+    p_scope_init = p_scope_sub.add_parser("init", help="Write an example scope.yaml")
+    p_scope_init.add_argument("--output", "-o", default="scope.yaml",
+                              help="Output path. Default: scope.yaml in the current directory.")
+
+    p_run = sub.add_parser("pentest", help="Run the full pentest pipeline")
+    p_run.add_argument("--codebase", required=True,
+                       help="Path to the source codebase root. Must contain "
+                            "whitebox/findings.sarif produced by `guardlink sarif`. The codebase "
+                            "is also the working directory of the AI CLI during template "
+                            "generation, so the AI can read source via its own Read/Grep tools.")
+    p_run.add_argument("--target", required=True,
+                       help="Running app URL (e.g. http://localhost:8000, https://app.example.com). "
+                            "Both http and https supported. The landing test verifies you arrive "
+                            "at a non-login page from this URL.")
+    p_run.add_argument("--auth", default="",
+                       help="Comma-separated auth profile names captured via `cxg pentest auth`. "
+                            "Chained-auth probes (IDOR cross-user) need ≥2 profiles. The lowest-"
+                            "privilege identity is auto-selected as actor for privesc-class probes. "
+                            "Leave empty if using --interactive-auth for inline capture.")
+    p_run.add_argument("--auth-numbers", type=int, default=None,
+                       help="Minimum auth contexts required. Templates that need more than the "
+                            "supplied --auth count get skipped with a warning.")
+    p_run.add_argument("--ai", action="store_true",
+                       help="Enable AI-driven template generation. Without --ai, only built-in "
+                            "Python probes from pentest/payloads/ run.")
+    p_run.add_argument("--ai-provider", default="auto",
+                       choices=["auto", "claude", "codex", "gemini", "anthropic", "openai"],
+                       help="AI provider. 'auto' picks the first available CLI tool (order: "
+                            "claude > codex > gemini), falling back to ANTHROPIC_API_KEY / "
+                            "OPENAI_API_KEY HTTP APIs. CLI providers don't need API keys — they "
+                            "use your existing CLI auth.")
+    p_run.add_argument("--creds-file", default=None,
+                       help="File of profile:email:password[:label] lines used to AUTO RE-AUTH "
+                            "dead sessions mid-scan. Recommended for any scan with destructive "
+                            "probes (session_replay, csrf) or --mutation-retries > 0.")
+    p_run.add_argument("--template-lang", default="js", choices=["py", "js"],
+                       help="js (default, recommended): AI generates copy-paste-runnable JS "
+                            "templates that drive the cxg JS bridge. py: legacy Python probe "
+                            "path — only built-in probes, no AI generation.")
+    p_run.add_argument("--goal", default=None,
+                       help="Natural-language pentest goal. Used as context for LLM-based "
+                            "hypothesis ranking AND template generation. Examples: 'test for "
+                            "IDOR in records and transactions APIs'; 'verify each declared "
+                            "@mitigates actually holds at runtime'; 'find unguarded admin "
+                            "endpoints accessible to non-admin tokens'.")
+    p_run.add_argument("--max-templates", type=int, default=8,
+                       help="Maximum number of templates the LLM ranker selects per scan. Each "
+                            "template = one AI generation call (~60-180s with claude/codex). "
+                            "Default 8.")
+    p_run.add_argument("--template-dir", default=None,
+                       help="Reuse JS templates from a previously-generated session directory "
+                            "(under ~/.cert-x-gen/templates/). Skips the AI generation step. "
+                            "Useful for re-running templates against different targets or after "
+                            "engine bug fixes.")
+    p_run.add_argument("--interactive-auth", type=int, default=0, metavar="N",
+                       help="Open N headed browser windows for interactive login at scan start, "
+                            "then run the pipeline with the resulting fresh profiles. Each "
+                            "capture prompts for a per-identity label. Profiles saved as "
+                            "<--auth-profile>-1, ..., <--auth-profile>-N.")
+    p_run.add_argument("--auth-profile", default="pentest",
+                       help="Profile name prefix for --interactive-auth captures.")
+    # Scope + audit
+    p_run.add_argument("--scope-file", default=None,
+                       help="Path to scope.yaml. Default: safe permissive defaults (any URL, "
+                            "GET/POST/HEAD/OPTIONS, 30 reqs/endpoint, 1500 total, kill on "
+                            "8-streak 5xx). Generate one with `cxg pentest scope-init`.")
+    p_run.add_argument("--destructive-ok", action="store_true",
+                       help="Allow DELETE/PUT/PATCH methods AND paths matching destructive "
+                            "regexes in scope.yaml. Default OFF. Use with care on production "
+                            "targets — engine warns at startup; blocked requests still appear "
+                            "in the audit log.")
+    p_run.add_argument("--attestation", default=None,
+                       help="Free-text written authorization statement recorded in the audit "
+                            "log header. Include engagement ID, operator name, change-management "
+                            "ticket. Strongly recommended for any non-local scan.")
+    p_run.add_argument("--session-dir", default=None,
+                       help="Session directory for this scan's artifacts (audit.jsonl, "
+                            "report.json). Default: ~/.cert-x-gen/sessions/pentest-<timestamp>/.")
+    p_run.add_argument("--mutation-retries", type=int, default=2,
+                       help="Maximum times the AI is allowed to mutate a template after "
+                            "AMBIGUOUS triage. Environment-bound AMBIGUOUS (missing role, "
+                            "missing primitive) skip mutation automatically. 0 disables the loop.")
+    p_run.add_argument("--me-path", default="/api/me",
+                       help="Optional identity endpoint hit during pre-flight inspection to "
+                            "extract role/email/id from a JSON response. The landing test is "
+                            "the source of truth for alive/dead — failure here does NOT mark "
+                            "the profile dead. Default /api/me.")
+    p_run.add_argument("--oast", default=None, metavar="HOST",
+                       help="Out-of-band callback host (interactsh, Burp Collaborator, etc.). "
+                            "Exposed to templates as cxg.oast.url(label) for definitive blind-"
+                            "vuln confirmation. Without this, blind probes (SSRF, blind SQLi, "
+                            "blind XXE, blind cmd-injection) fall back to status-code heuristics "
+                            "and the AI is instructed to mark confirmed=false.")
+    p_run.add_argument("--skip-health-check", action="store_true",
+                       help="Skip the pre-flight session health check entirely. Use for multi-"
+                            "tenant apps where the session lives at a subdomain different from "
+                            "--target, or when the app has no stable /me-style endpoint.")
+    p_run.add_argument("--generation-timeout", type=int, default=240,
+                       help="Hard wall-clock timeout per AI generation call. The whole process "
+                            "tree is killed if exceeded. Default 240s. Bump to 600+ for very "
+                            "large codebases the AI has to grep through.")
+    p_run.add_argument("--mitigation-mode", default="any",
+                       choices=["any", "unmitigated", "mitigated"],
+                       help="Hypothesis filter by declared-mitigation status from guardlink. "
+                            "any (default) = all HTTP-testable hypotheses. unmitigated = only "
+                            "threats without a declared @mitigates (find unguarded holes). "
+                            "mitigated = only threats WITH @mitigates declared (verify defenses "
+                            "actually hold at runtime).")
+    p_run.add_argument("--headed", action="store_true",
+                       help="Show Chromium windows during scan instead of running headless. "
+                            "Useful for debugging probes or when WAF bot-detection blocks "
+                            "headless requests.")
+    p_run.add_argument("--output", "-o", default=None,
+                       help="JSON report output path. Default: report.json under --session-dir.")
+
+    args = ap.parse_args()
+    if args.cmd == "auth":
+        from auth import main as auth_main
+        # args.auth_args contains everything after 'auth' on the command line
+        return auth_main(list(args.auth_args))
+    if args.cmd == "scope":
+        if args.scope_cmd == "init":
+            write_example_scope_file(Path(args.output))
+            print(f"wrote example scope to {args.output}")
+            return 0
+        return 1
+
+    if args.cmd == "pentest":
+        # Interactive auth capture FIRST (sync Playwright must run before asyncio loop)
+        if args.interactive_auth and args.interactive_auth > 0:
+            print(f"[auth] launching {args.interactive_auth} headed browser windows for interactive login…")
+            captured = capture_interactive_multi(args.target, args.auth_profile, args.interactive_auth)
+            args.auth = ",".join(p.name for p in captured)
+            print(f"[auth] captured profiles: {args.auth}\n")
+
+        args.auth = [a.strip() for a in args.auth.split(",") if a.strip()]
+        if args.auth_numbers and args.auth_numbers > len(args.auth):
+            print(f"⚠  --auth-numbers={args.auth_numbers} but only {len(args.auth)} profiles given; "
+                  "IDOR-class probes will be skipped.", file=sys.stderr)
+
+        # Re-auth BEFORE entering the asyncio event loop (sync Playwright can't run inside one).
+        if args.creds_file:
+            print(f"[0] re-authenticating profiles from {args.creds_file}")
+            creds_map = {}
+            for line in Path(args.creds_file).read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split(":")
+                if len(parts) < 3:
+                    continue
+                profile, email, pw = parts[0], parts[1], parts[2]
+                label = parts[3] if len(parts) > 3 else profile
+                creds_map[profile] = (email, pw, label)
+            for prof in args.auth:
+                if prof not in creds_map:
+                    print(f"  · no creds for profile '{prof}' — using stored state as-is")
+                    continue
+                email, pw, label = creds_map[prof]
+                try:
+                    capture_scripted(args.target, prof, email, pw, label=label)
+                    print(f"  ✓ refreshed {prof} ({email})")
+                except Exception as e:
+                    print(f"  ✗ refresh failed for {prof}: {e}")
+            print()
+
+        return asyncio.run(run_pentest(args))
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main() or 0)

--- a/pentest/docs/ARCHITECTURE.md
+++ b/pentest/docs/ARCHITECTURE.md
@@ -1,0 +1,446 @@
+# Architecture deep dive
+
+This document explains how the pentest pipeline is structured, what each
+Python module is responsible for, and how data flows through the system.
+
+For a high-level pipeline diagram, see [README.md](../README.md#pipeline-architecture).
+For the template authoring contract, see [TEMPLATES.md](TEMPLATES.md).
+
+## Boundary between Rust and Python
+
+cxg is a Rust binary. The `cxg pentest` subcommand is defined in
+`src/cli.rs` and dispatched in `src/main.rs::run_pentest_command`. The Rust
+side does no orchestration of the pipeline itself — it shells out to a
+Python orchestrator installed at `~/.cert-x-gen/pentest/`, forwarding the
+parsed flags as command-line arguments.
+
+The split exists because:
+
+- The Rust ecosystem doesn't have a mature equivalent of Playwright for
+  driving authenticated browser flows. Python's Playwright bindings are the
+  most reliable headed-Chromium automation in any language.
+- The AI providers (claude-code, codex, gemini) are CLI tools that take
+  prompts on stdin/argv. Either language can shell out to them; Python's
+  `subprocess` story for process-group kills + timeouts is simpler.
+- Rapid iteration on probe semantics and triage logic during early
+  development was easier in Python.
+
+`cxg pentest install` copies the Python sources from the cxg source tree
+to `~/.cert-x-gen/pentest/`. Future re-installs are how you pick up
+upstream changes to the Python orchestrator.
+
+## Module responsibilities
+
+### `cxg_pentest.py` — CLI dispatcher
+
+The Python-side entrypoint invoked by the Rust shim. Parses argparse,
+routes to one of three top-level subcommands:
+
+- `auth` → delegates to `auth.py::main(args)` for profile capture and listing
+- `scope` → writes example scope.yaml via `scope.write_example_scope_file`
+- `pentest` → orchestrates the full pipeline via `run_pentest`
+
+Key responsibilities of `run_pentest`:
+
+1. Loads scope config + opens audit log + writes audit header with attestation.
+2. Loads creds from `--creds-file` if supplied, builds creds_map for
+   re-auth, instantiates `SessionHealthMonitor`.
+3. If `--interactive-auth N` was passed, calls
+   `auth.capture_interactive_multi` BEFORE entering the asyncio loop
+   (sync Playwright must run outside an event loop).
+4. Re-auths profiles from creds_map before the scan (sessions decay).
+5. Enters asyncio and calls `inspect_profiles_async` for pre-flight.
+6. For JS path: calls `js_generator.generate_all` then
+   `js_engine.JsEngine(...).run(templates)`.
+7. For Python path: calls `select_probes` and `BrowserEngine(...).run_probes`.
+8. Writes report.json, closes audit log, returns exit code.
+
+### `auth.py` — Profile capture and storage
+
+Two capture modes:
+
+**Interactive** (`capture_interactive`): opens headed Chromium, waits for
+the operator to log in, captures `storage_state` (cookies + localStorage +
+sessionStorage from every origin the browser touched). Termination via
+ENTER on stdin OR browser-close, whichever comes first. **Sync Playwright
+runs on the main thread; only stdin polling runs on a worker** (sync
+Playwright cannot be called from threads).
+
+**Scripted** (`capture_scripted`): for password-only flows. Opens headless
+Chromium, navigates to `--target`, reads csrf_token cookie if set, POSTs
+JSON `{email, password}` to `--login-path` via the page's own fetch (so
+cookies stick to the browser jar exactly as a real session).
+
+Post-capture, `_verify_captured_session` does a **landing test**: re-opens
+a fresh headless context with the saved state, navigates to `--target`,
+and checks whether the final URL/page looks like a login/SSO redirect
+(DEAD) or the app dashboard (ALIVE). Works without a configured /me
+endpoint. Optional `--verify-url` is a secondary identity check that
+doesn't override the landing verdict.
+
+Multi-profile capture (`capture_interactive_multi`) loops N times,
+prompting for a per-identity label each iteration.
+
+`save_profile` writes two files:
+- `~/.cert-x-gen/auth/<name>.json` — Playwright `storage_state`
+- `~/.cert-x-gen/auth/<name>.meta.json` — name, target, label, extra_headers
+
+`load_profile` reconstructs an `AuthProfile` dataclass that includes
+`extra_headers` (custom HTTP headers like WAF-bypass tokens).
+
+### `guardlink.py` — SARIF + inline annotation parser
+
+Parses two input streams:
+
+**SARIF** (`parse_sarif`): supports two schemas auto-detected by
+`ruleId`:
+
+- **Extended schema** (e.g. an old preview-version SARIF with
+  `properties.guardlink_threat`, `guardlink_severity`,
+  `codegraph_reachability.http_method/http_path`,
+  `taint_path.sanitizers_in_path`, `rlm_hypothesis.confidence`).
+- **Upstream schema** (current guardlink 1.4.3, ruleId in
+  `{guardlink/unmitigated-critical, guardlink/unmitigated-exposure,
+  guardlink/confirmed-exploitable, guardlink/dangling-ref}`, with
+  `properties.{severity, asset, threat, externalRefs}`).
+
+Both shapes map onto the same `Hypothesis` dataclass.
+
+**Inline annotations** (`parse_inline`): walks the codebase for source
+files (`.py`, `.js`, `.ts`, `.tsx`, `.jsx`, `.go`, `.rs`, `.java`, `.rb`,
+`.php`, `.html`), regex-matching `@exposes`, `@mitigates`, `@flows`,
+`@audit`, `@comment` patterns. Returns a list of `InlineAnnotation` objects.
+
+**Route enrichment** (`enrich_routes_by_function`): many SARIF entries
+lack `http_method`/`http_path`. Four-step fallback:
+
+1. Sibling hypothesis on the same `function_name` already has a route → copy.
+2. Sibling at the same `(file, line)` → copy.
+3. Free-text regex: search description for `<METHOD> /path`.
+4. Source-scrape: open the file at SARIF line, scan for Express/Hono/Koa/
+   Fastify (`app.get('/x')`, `router.post("/y")`) or FastAPI/Flask
+   (`@app.get("/x")`) route definitions within `proximity_lines` of the
+   anchor.
+
+**@comment attachment** (`attach_comments_to_hypotheses`): for each
+hypothesis with a `function_name`, locate that function's REAL line in
+the current source by grepping for `def <name>(` (SARIF line numbers are
+often stale because guardlink was run against an older snapshot). Then
+attach inline `@comment` annotations within `proximity_lines` of the
+anchor. Comments provide intent context the AI uses to avoid
+false-positive CONFIRMED findings on by-design exposures.
+
+### `profile_inspect.py` — Pre-flight session inspection
+
+`inspect_profiles_async` opens a fresh headless context per profile and
+runs the **landing test** (same logic as auth-time verifier): navigate
+to `--target`, see if final URL/HTML looks like a login page.
+
+Secondary: optional `--me-path` probe (default `/api/me`) extracts
+role / email / id from a JSON response. Failure here does NOT mark the
+profile dead — landing test is source of truth. When `/me` succeeds, the
+extracted `role` is mapped to a tier via `ROLE_TIER` dict for use in
+smart-runner-selection (privesc probes pick lowest tier).
+
+`coverage_summary` returns a dict describing identity-tier coverage
+(has_low_priv, has_mid_priv, has_high_priv) and notes (e.g. "no
+low-privilege identity captured — IDOR probes will be unfalsifiable").
+
+### `js_engine.py` — JS template runtime
+
+`JsEngine.run(templates)` is the heart of scan-time execution.
+
+Constructor takes: target, profile_names, scope_cfg, audit_log,
+health_monitor, codebase, mutation_retries, profile_infos, oast_host.
+
+`PRIVESC_LIKE_CLASSES` is the set of vuln classes where the lowest-tier
+identity should be the runner (privesc tests are vacuous if run as admin).
+
+**Setup phase:**
+
+1. Pre-validate all templates via `validator.validate`. Rejects with clear
+   reasons recorded to `results.rejected_templates`.
+2. Open N parallel Chromium contexts (one per profile), passing
+   `extra_http_headers` from the profile's metadata for WAF-bypass headers
+   etc.
+3. Inject the cxg JS bridge via `_inject_cxg_bridge`:
+   - `page.expose_function` for `__cxg_fetchAs`, `__cxg_scope_check`,
+     `__cxg_record_response`, `__cxg_audit`, `__cxg_get_cookies`,
+     `__cxg_get_cookies_as`, `__cxg_set_cookies`, `__cxg_add_cookies`,
+     `__cxg_clear_cookies`.
+   - `page.add_init_script(bridge_js)` so `window.__cxg` survives every
+     navigation (the session-health landing test does `page.goto()`
+     between templates which would otherwise wipe injected globals).
+   - `page.evaluate(bridge_js)` for the currently-loaded page (init scripts
+     don't run retroactively).
+   - Stash the bridge JS on `self._bridge_stash[id(page)]` for defensive
+     re-eval if `_ensure_bridge` finds the bridge missing later.
+
+**Run phase:** sort templates by `destructive_priority` ascending so
+read-only probes run first. For each template:
+
+1. **Smart runner selection** — for templates whose `vuln_class` is in
+   `PRIVESC_LIKE_CLASSES`, pick the context whose profile has the
+   lowest tier. Otherwise use `contexts[0]`.
+2. `_ensure_bridge` — defensive re-eval if navigation wiped `window.__cxg`.
+3. **Health check** — if a `SessionHealthMonitor` is configured, call
+   `ensure_alive(ctx)` on each context the template needs. If dead and
+   re-auth fails, skip the template and mark the profile dead.
+4. `_evaluate_template` wraps the template in
+   `async () => { <template body>; return cxgProbe(window.__cxg); }`
+   and runs it via `page.evaluate`. Catches JS exceptions and logs them.
+5. For each emitted finding: classify via `mutator.classify`, route to
+   the correct bucket (confirmed/refuted/ambiguous), audit-log the
+   verdict. Payload-fixable AMBIGUOUS triggers mutation retry up to
+   `mutation_retries` times. Environment-bound AMBIGUOUS skips mutation.
+6. **Retry-then-resolved suppression**: when a `-retry<N>` finding lands
+   in confirmed or refuted, remove the original sibling from
+   `results.ambiguous` and add the original id to
+   `results.retried_then_resolved`.
+
+The cross-context router (`fetch_as_router`) handles `cxg.fetchAs(idx)`
+calls — runs the request inside the target profile's page (full cookie
+jar, extra_http_headers, CSRF semantics intact). Also handles the
+`__GET_COOKIES__` virtual op for `cxg.getCookiesAs(idx)`.
+
+### `js_generator.py` — AI template generation
+
+`generate_all(codebase, hypotheses, goal, ...)` is the top-level entrypoint.
+
+1. `_dedupe_by_probe_shape` collapses hypotheses with identical
+   `(http_method, http_path, function_name)` to one (keeps highest severity,
+   merges vuln_class names into the description).
+2. `rank_hypotheses_by_goal` — when an AI CLI is available, makes ONE call
+   that scores each deduped hypothesis 0-10 against the goal AND identity
+   coverage (passed from profile inspection). Hypotheses scoring <4 are
+   dropped; remaining sorted descending, top-N kept. Without an AI CLI,
+   falls back to keyword-rank.
+3. For each selected hypothesis, `generate_js_template` invokes the AI
+   provider CLI with `cwd=codebase` so the AI can Read/Grep source via its
+   own tools. The prompt (`SYSTEM_PROMPT`) teaches the contract:
+   - JS template shape, meta header, cxg.* API, finding shape
+   - Hard rules (no raw fetch, no destructive paths, no >30 requests)
+   - Cookie API (HttpOnly-aware) and OAST API
+   - Triage signals (when to set confirmed=true vs false)
+   - Respect for `@comment` intent
+   - Blind-vuln confirmation rule
+4. Output is cached at `~/.cert-x-gen/templates/session-<ts>/` keyed by
+   `hash(vuln_class, method, path, function, goal)`.
+
+`_cli_generate` is the unified subprocess wrapper for claude/codex/gemini:
+- Uses `subprocess.Popen` with `start_new_session=True` so SIGTERM kills
+  the whole process group (claude's tool-use loop can spawn workers).
+- 240s hard timeout by default; SIGTERM then SIGKILL.
+- Surfaces clear errors when timeout fires or rc != 0.
+
+### `validator.py` — Static template validator
+
+Pure-function pre-execution checks. Returns a `ValidationResult` with `ok`,
+`errors`, `warnings`, `meta`. Run before any template is loaded into the
+engine. Rejected templates land in `results.rejected_templates` with their
+errors.
+
+See [TEMPLATES.md § Validator rules](TEMPLATES.md#validator-rules) for the
+checklist.
+
+### `scope.py` — Scope guard and audit log
+
+`ScopeConfig` is a dataclass loaded from scope.yaml (or defaults). Fields:
+`url_allowlist`, `url_blocklist`, `method_allowlist`, `destructive_patterns`,
+`destructive_ok`, `max_requests_per_endpoint`, `max_requests_total`,
+`five_xx_streak_threshold`, `authorization_attestation`.
+
+`ScopeGuard.check_request(method, path)` is consulted before every outbound
+HTTP request from a template. Path normalization replaces numeric ID
+segments with `{id}` for budget bucketing (so 100 requests to
+`/api/records/1`, `/api/records/2`, ... count as 100 against
+`/api/records/{id}` not 100 separate endpoints). Returns `(allowed, reason)`.
+
+`ScopeGuard.record_response(status)` is consulted after every response.
+Maintains a consecutive-5xx counter; raises `HardKillSignal` when threshold
+hit.
+
+`AuditLog` writes one JSONL line per event to `<session_dir>/audit.jsonl`.
+Events: `scan_start`, `profile_inspection`, `request`, `blocked`, `finding`,
+`scan_end`. Append-only, line-buffered for crash safety.
+
+`write_example_scope_file` emits a heavily-commented scope.yaml the operator
+edits for an engagement.
+
+### `session_health.py` — Per-template session health
+
+`SessionHealthMonitor.check(ctx)` runs the landing test on the existing
+page (`page.goto(target)`), checks whether the final URL/HTML looks like a
+login page, returns `(alive, status)`. Same heuristic as auth-time + pre-
+flight inspection — login URL patterns, password-input markers, IDP
+hostnames (Okta, Auth0, accounts.google.com, Keycloak, etc.).
+
+`ensure_alive(ctx)` is the wrapper that triggers auto-reauth via
+`_reauth(ctx, email, password)` when the check fails and creds are
+available. POSTs `{email, password}` to `--login-path` via the page's own
+fetch so cookies + CSRF flow correctly. Gives up after
+`max_reauth_attempts` failures and marks the profile permanently dead.
+
+### `mutator.py` — Triage classifier + mutation generation
+
+`classify(finding) -> TriageVerdict` is a pure function. Returns
+`TriageVerdict(kind, reason, reason_kind)` where `kind` is
+`{confirmed, refuted, ambiguous}` and `reason_kind` is
+`{payload, environment, unknown}`.
+
+Decision tree (in order):
+
+1. `confirmed=True` + evidence → CONFIRMED (payload).
+2. `confirmed=True` + no evidence → AMBIGUOUS (payload), "no evidence".
+3. Description matches environment-bound signals (missing role, OAST
+   needed, HttpOnly cookies not exposed) → AMBIGUOUS (environment).
+4. Description matches mitigation-hold signals (parenthetical-tolerant
+   regex over "mitigation ... held/holds/enforced/ignored", explicit
+   `mitigation #foo-bar held`, bare scoping/gate/check/control held,
+   "no exploitation observed", "mitigation appears effective", "no
+   finding raised") → REFUTED (payload).
+5. Status in {401, 403} → REFUTED (auth/RBAC enforced).
+6. Status == 404 → REFUTED (resource hidden or owner-scoping).
+7. Status == 422 → AMBIGUOUS (payload-fixable: schema reject).
+8. Status 2xx + confirmed=false → AMBIGUOUS (payload).
+9. Otherwise → AMBIGUOUS (unknown).
+
+`mutate_template(template_source, finding, verdict, codebase, template_id)`
+invokes the AI provider with the original source + the ambiguous finding +
+the triage reason, asks for a rewrite targeting the specific failure mode.
+Result is cached by `hash(template_id, vuln_class, endpoint, evidence_status,
+description_head)` so duplicate failures don't re-hit the AI.
+
+The mutator is invoked by `JsEngine._run_single_template` when an emitted
+finding triages as `AMBIGUOUS` with `reason_kind=payload`. Environment-bound
+AMBIGUOUS skips mutation.
+
+### `ai_generator.py` — Multi-provider abstraction
+
+Defines `_Provider` base class and five implementations:
+
+- `ClaudeCliProvider` — `claude --print` (no API key)
+- `CodexCliProvider` — `codex exec --skip-git-repo-check --sandbox read-only` (no API key)
+- `GeminiCliProvider` — `gemini --prompt` (no API key)
+- `AnthropicApiProvider` — uses ANTHROPIC_API_KEY via the `anthropic` SDK
+- `OpenAiApiProvider` — uses OPENAI_API_KEY via the `openai` SDK
+
+`pick_provider(name)` resolves `auto` mode (try CLI tools in order
+claude → codex → gemini, then API providers as fallback), or honors an
+explicit choice. `generate_probe_source(hypothesis, provider, ...)` builds
+the prompt and dispatches.
+
+This module is the legacy Python-template generator. The JS-template
+generator (`js_generator.py`) reimplements the subprocess invocation logic
+with stronger timeout handling. Both are used: `js_generator` for the JS
+path, `ai_generator` for the legacy Python path AND for the ranking call
+(which is provider-agnostic).
+
+### `browser_engine.py` + `payloads/` — Legacy Python probe path
+
+When `--template-lang py` is passed (legacy), the engine runs built-in
+Python probes from `payloads/` (idor, csrf, privilege_escalation,
+session_replay, sensitive_data, metrics_disclosure, rate_limit). Each
+probe is a Python class with `vuln_class`, `requires_auth_count`, and an
+`async run(self, ctxs, hypothesis)` method that returns a list of
+`Finding` objects.
+
+This path predates the JS engine and is retained mostly for
+regression-test value. New work should be on the JS path.
+
+## End-to-end data flow
+
+```
+guardlink CLI                                    AI CLI (claude/codex/gemini)
+       │                                                       │
+       │ writes whitebox/findings.sarif                        │
+       ▼                                                       │
+[1] guardlink.parse_sarif                                      │
+       │                                                       │
+       │ Hypothesis[] with file+line; many missing http_path   │
+       ▼                                                       │
+[1] guardlink.parse_inline + enrich_routes_by_function         │
+       │                                                       │
+       │ Hypothesis[] with http_method/http_path + nearby      │
+       │ @comment annotations attached                         │
+       ▼                                                       │
+[1b] profile_inspect.inspect_profiles_async                    │
+       │                                                       │
+       │ ProfileInfo[] (alive/dead, role, tier)                │
+       ▼                                                       │
+[2] js_generator._dedupe_by_probe_shape                        │
+       │                                                       │
+       │ deduped Hypothesis[]                                  │
+       ▼                                                       │
+[2] js_generator._llm_rank ───────────────────────────────────►│
+       │                  (one batched call, scores 0-10)      │
+       │◄──────────────────────────────────────────────────────┤
+       │ top-N Hypothesis[]                                    │
+       ▼                                                       │
+[2] for each hypothesis:                                       │
+    js_generator.generate_js_template ────────────────────────►│
+       │                  (per-template call, AI reads source) │
+       │◄──────────────────────────────────────────────────────┤
+       │ JS source                                             │
+       ▼                                                       │
+[3] js_engine.load_templates + validator.validate              │
+       │                                                       │
+       │ JsTemplate[] (validated)                              │
+       ▼                                                       │
+[4] JsEngine.run                                               │
+       │                                                       │
+       │ for each template:                                    │
+       │   smart-runner-selection                              │
+       │   ensure_bridge                                       │
+       │   health.ensure_alive                                 │
+       │   page.evaluate(wrapper)  ─── browser fires probe ──► target app
+       │                                                       │
+       │ for each finding:                                     │
+       │   mutator.classify  ────────► verdict                 │
+       │   if AMBIGUOUS:                                       │
+       │     mutator.mutate_template ───────────────────────► AI
+       │     validator.validate(mutated)                       │
+       │     re-evaluate                                       │
+       │                                                       │
+       ▼                                                       │
+[5] EngineResults                                              │
+       │                                                       │
+       ▼                                                       │
+[6] write report.json + audit.jsonl                            │
+       │                                                       │
+       ▼                                                       │
+Rust CLI propagates exit code
+```
+
+## Concurrency model
+
+- **Pre-flight** (auth capture, sync re-auth): runs on the main thread
+  with sync Playwright. Cannot run inside the asyncio loop.
+- **Scan** (everything from inspect_profiles_async forward): runs inside
+  `asyncio.run(run_pentest(args))` with async Playwright. Each browser
+  context runs in parallel, but templates within a single context run
+  sequentially (the engine drives them one at a time via `page.evaluate`).
+- **AI generation**: blocking subprocess calls. Templates are generated
+  sequentially. This is the dominant wall-time cost — each call is
+  60-220s.
+
+## What's intentionally out of scope
+
+- **No native browser engine in Rust.** We rely on Python Playwright.
+- **No active web crawler.** Hypotheses come from guardlink; cxg doesn't
+  discover endpoints by spidering.
+- **No mutation engine for static analysis.** cxg consumes guardlink's
+  output; it doesn't run its own SAST.
+- **No automated OAST polling.** The operator inspects their
+  interactsh-client terminal manually. Future work could poll the
+  interactsh API for callbacks and inject them into evidence.
+- **No first-class C2 / lateral movement.** This is a web-app pentest tool,
+  not a red-team framework.
+
+## Future directions documented but not implemented
+
+- Native `engine/browser/` in Rust using `chromiumoxide`.
+- mTLS client cert support for WAF traversal instead of static headers.
+- Interactive REPL (`cxg pentest repl`) for human-in-the-loop probe
+  authoring with AI suggestions.
+- Plugin system for custom triage classifiers and mutation prompts.

--- a/pentest/docs/OPERATOR_GUIDE.md
+++ b/pentest/docs/OPERATOR_GUIDE.md
@@ -1,0 +1,566 @@
+# Operator playbook
+
+This guide walks through using `cxg pentest` end-to-end for a real
+engagement: pre-engagement setup, capturing authentication for SSO/MFA
+flows, running the scan, interpreting results, and post-engagement
+cleanup.
+
+For a quick command reference, see the [README](../README.md). For
+template authoring, see [TEMPLATES.md](TEMPLATES.md). For module
+internals, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Table of contents
+
+- [Before you start](#before-you-start)
+- [Phase 1 — Generate guardlink output](#phase-1--generate-guardlink-output)
+- [Phase 2 — Set up the scope file](#phase-2--set-up-the-scope-file)
+- [Phase 3 — Capture authenticated sessions](#phase-3--capture-authenticated-sessions)
+- [Phase 4 — Pre-flight checks](#phase-4--pre-flight-checks)
+- [Phase 5 — Run the scan](#phase-5--run-the-scan)
+- [Phase 6 — Interpret results](#phase-6--interpret-results)
+- [Phase 7 — Verify confirmed findings out-of-band](#phase-7--verify-confirmed-findings-out-of-band)
+- [Phase 8 — Post-engagement](#phase-8--post-engagement)
+- [Special situations](#special-situations)
+
+## Before you start
+
+`cxg pentest` is offensive tooling against an authenticated target. Three
+non-negotiables:
+
+1. **You have written authorization to test the target.** A Slack message
+   from your engineering manager, a signed engagement letter, a SOC2
+   pentest scope document — whichever your org uses. The `--attestation`
+   flag records this in the audit log header.
+
+2. **Prefer staging over production.** A staging environment that mirrors
+   prod code without the public WAF gives you cleaner results and zero
+   risk to real users. If staging doesn't exist, coordinate with infra
+   BEFORE pointing cxg at prod.
+
+3. **You understand what cxg will do.** Templates fire real HTTP requests
+   against the target. Read the `scope.yaml` you're using. Decide whether
+   `--destructive-ok` is appropriate. Know that DELETE/PUT/PATCH are off
+   by default for a reason.
+
+## Phase 1 — Generate guardlink output
+
+cxg consumes guardlink's SARIF + inline annotations. **Without guardlink
+output, cxg has nothing to scan**.
+
+```bash
+cd /path/to/target/codebase
+
+# Run guardlink across the codebase. Project name is whatever guardlink's
+# config.json declares (usually the repo name).
+guardlink sarif . -p my-project -o whitebox/findings.sarif
+
+# Verify it produced findings
+jq '.runs[0].results | length' whitebox/findings.sarif
+```
+
+Quick sanity check:
+
+```bash
+# How many HTTP-testable hypotheses will cxg actually see?
+python3 -c "
+import sys; sys.path.insert(0, '$HOME/.cert-x-gen/pentest')
+from pathlib import Path
+from guardlink import load
+sarif, inline, surf = load(Path('.'))
+print(f'SARIF: {len(sarif)} hypotheses')
+print(f'  with HTTP path (after enrichment): {sum(1 for h in sarif if h.http_path)}')
+print(f'  unmitigated: {sum(1 for h in sarif if not h.has_mitigation_declared and h.http_path)}')
+print(f'  mitigated: {sum(1 for h in sarif if h.has_mitigation_declared and h.http_path)}')
+"
+```
+
+If `with HTTP path` is 0:
+
+- The codebase may not have routes guardlink can recognize (frontend-only,
+  binary tooling, etc.). cxg's whole model assumes HTTP-reachable surface.
+- Guardlink annotations may not have been added to the route handlers.
+  Run `guardlink status .` and look at the `Comments` and `Flows` counts.
+
+## Phase 2 — Set up the scope file
+
+```bash
+cxg pentest scope-init -o engagement.scope.yaml
+```
+
+Open `engagement.scope.yaml` in your editor. Edit:
+
+- **`authorization_attestation`** — the engagement reference (ticket ID,
+  approval message link). This goes into every audit log header.
+- **`method_allowlist`** — default is `[GET, POST, HEAD, OPTIONS]`. Add
+  `PATCH` and/or `DELETE` only if your engagement specifically authorizes
+  testing destructive routes.
+- **`url_allowlist`** — empty by default (= any URL under target). For
+  high-stakes engagements, add regex patterns that restrict scanning to
+  specific API surfaces (e.g. `^/api/v1/`, `^/auth/`).
+- **`url_blocklist`** — always-deny regexes. Use to carve out endpoints
+  that exist but should never be touched (e.g. the root admin account's
+  ID, billing webhooks, third-party integrations).
+- **`max_requests_per_endpoint`** — default 30. The right value depends
+  on engagement length and target capacity. For short engagements
+  bump down to 10-15; for longer scans 50-100 is fine.
+- **`max_requests_total`** — global budget. Default 1500. Bump to 5000+
+  for an overnight engagement-grade scan.
+- **`five_xx_streak_threshold`** — default 8. Lower this to 3-4 for
+  production targets — three 5xx in a row from a probe is a "stop and
+  let ops know" signal.
+
+The generated scope.yaml has inline comments for every option. Read them.
+
+## Phase 3 — Capture authenticated sessions
+
+### Single identity (most common)
+
+```bash
+cxg pentest auth \
+  --target https://staging.app.example.com \
+  --profile pentest-admin \
+  --label admin
+```
+
+A headed Chromium window opens. You log in by **any means** — SSO redirect
+through Okta/Google/Microsoft Entra, MFA TOTP prompt, hardware key (FIDO2/
+WebAuthn), magic link via email, OAuth consent screen. When the app
+dashboard is showing and you're definitely signed in, switch to the
+terminal and press ENTER.
+
+cxg captures `storage_state` from every origin the browser touched
+(cookies + localStorage + sessionStorage). The post-capture landing test
+re-opens a fresh context and verifies you arrive at a non-login page.
+Expected output:
+
+```
+✓ captured 47 cookies across 12 domains, 8 localStorage items, 0 sessionStorage items
+✓ session verified — landed at https://staging.app.example.com/dashboard (no login redirect)
+```
+
+### Two identities for IDOR / horizontal privesc
+
+```bash
+cxg pentest auth \
+  --target https://staging.app.example.com \
+  --profile pentest --auth-numbers 2
+```
+
+cxg opens two Chromium windows in sequence. For each, it prompts you for
+a label (e.g. "victim", "attacker"). Profiles save as `pentest-1`,
+`pentest-2`. Reference both in the scan: `--auth pentest-1,pentest-2`.
+
+For chained-auth probes like cross-user IDOR, the smart-runner-selection
+logic auto-picks the lowest-tier identity as the actor — so label them
+accurately if you want predictable behavior.
+
+### Multi-tenant apps where SSO scopes cookies to a different subdomain
+
+Some apps log you in at `auth.example.com` but the session cookies live at
+`app.example.com`. The landing test handles this: it navigates to
+`--target` after capture and looks for login-page markers.
+
+If the verifier fails but you're sure the session is alive, pass
+`--skip-health-check` at scan time. The engine will proceed without the
+pre-flight check.
+
+### When the WAF blocks automated traffic
+
+Production WAFs often block headless Chromium based on bot fingerprinting.
+Talk to your infra/security team. They might give you one of:
+
+- **A signed test-traffic header** (e.g. `x-test-automation: <token>`).
+  Pass it to cxg via `--header "x-test-automation:<token>"` at auth time.
+  The header is saved with the profile and sent on every outbound request
+  during the scan. **Treat the token like a credential** — see the
+  Security section of `cxg pentest auth --help`.
+- **IP allowlist** — your test machine's IP is added to a WAF allowlist
+  for the engagement window. No header needed; just run.
+- **Dedicated pentest origin** — a separate CloudFront distribution or
+  load balancer with relaxed WAF rules, mirroring prod backend. Point
+  `--target` there.
+
+### When auth is password-only and you want scripted login
+
+```bash
+cxg pentest auth \
+  --target http://localhost:8000 \
+  --profile test \
+  --creds 'user@example.com:hunter2' \
+  --login-path /api/auth/login
+```
+
+Useful for local dev environments and CI. Won't work for SSO.
+
+## Phase 4 — Pre-flight checks
+
+Before running a long scan, validate everything is set up correctly.
+
+### List profiles
+
+```bash
+cxg pentest auth-list
+```
+
+Confirm each profile shows up with the expected `target` and `label`.
+
+### Dry-run pre-flight inspection
+
+```bash
+# Quick test: do the captured profiles still authenticate?
+python3 -c "
+import asyncio, sys
+sys.path.insert(0, '$HOME/.cert-x-gen/pentest')
+from profile_inspect import inspect_profiles_async, coverage_summary
+
+async def main():
+    infos = await inspect_profiles_async(
+        ['pentest-admin', 'pentest-user'],
+        'https://staging.app.example.com',
+    )
+    for i in infos:
+        print(f'  · {i.short()}')
+        for n in i.notes:
+            print(f'      · {n}')
+    cov = coverage_summary(infos)
+    for note in cov['notes']:
+        print(f'  ⚠ {note}')
+
+asyncio.run(main())
+"
+```
+
+Expected output for a healthy setup:
+
+```
+· pentest-admin label=admin role=admin
+    · landed at https://staging.app.example.com/dashboard (no login redirect)
+· pentest-user label=user role=user
+    · landed at https://staging.app.example.com/dashboard (no login redirect)
+```
+
+If you see `DEAD: status=...` or `landed at <login URL>`, the session
+expired. Re-capture before scanning.
+
+## Phase 5 — Run the scan
+
+### A first short scan to validate setup
+
+```bash
+cxg pentest run \
+  --codebase /path/to/target/codebase \
+  --target https://staging.app.example.com \
+  --auth pentest-admin \
+  --goal "find any unmitigated HTTP threat — read-only confirmation" \
+  --ai --ai-provider claude \
+  --max-templates 3 --mutation-retries 1 \
+  --scope-file engagement.scope.yaml \
+  --attestation "Engagement PT-2026-001, operator J. Doe, scope per CHG-1234" \
+  --session-dir ./pentest-session-validation
+```
+
+3 templates × ~120s generation = ~6 minutes for AI work, plus a few
+seconds of probe execution. Verify the output looks sensible before
+launching the full scan.
+
+### Full engagement scan
+
+```bash
+cxg pentest run \
+  --codebase /path/to/target/codebase \
+  --target https://staging.app.example.com \
+  --auth pentest-admin,pentest-user \
+  --creds-file ./creds.txt \
+  --goal "test all unmitigated threats and verify each declared @mitigates" \
+  --ai --ai-provider claude \
+  --max-templates 20 --mutation-retries 2 \
+  --oast c4ca4238a0b923820dcc.oast.fun \
+  --scope-file engagement.scope.yaml \
+  --attestation "Engagement PT-2026-001, operator J. Doe" \
+  --session-dir ./pentest-session-full
+```
+
+Notable additions:
+
+- `--auth pentest-admin,pentest-user` for chained-auth probes (IDOR cross-user).
+- `--creds-file ./creds.txt` for auto re-auth when a destructive probe
+  kills its own session mid-scan. File format: one `profile:email:password[:label]`
+  line per profile.
+- `--oast` to enable definitive blind-vuln confirmation. Start interactsh-client
+  in another terminal first:
+  ```bash
+  interactsh-client
+  # paste the printed hostname into --oast
+  ```
+- `--max-templates 20` for engagement-grade coverage.
+- `--mutation-retries 2` lets the AI sharpen AMBIGUOUS probes that have
+  payload-fixable failures (e.g. 422 schema rejects).
+
+Wall-time estimate: 20 templates × ~120s = 40 minutes of AI generation,
+plus ~5 minutes execution, plus mutation retries (~20% of templates × 120s).
+Plan for ~75 minutes.
+
+### Variations
+
+**Verify-mitigations-only scan** (well-annotated codebase):
+
+```bash
+cxg pentest run ... --mitigation-mode mitigated --max-templates 16
+```
+
+This skips unmitigated threats and only tests endpoints with declared
+`@mitigates`. The scan verifies whether each declared defense actually
+holds at runtime. Outcome will be heavy on `mitigation_verifications` and
+light on `confirmed_findings` — which is the goal.
+
+**Unmitigated-only scan** (find unguarded holes):
+
+```bash
+cxg pentest run ... --mitigation-mode unmitigated
+```
+
+Only tests threats without a declared `@mitigates`. These are the
+unguarded surfaces guardlink itself flagged as risky. Fewer templates,
+but each one is targeting code the developer hasn't claimed to defend.
+
+**Re-run cached templates without regenerating** (after engine fix):
+
+```bash
+cxg pentest run ... --template-dir ~/.cert-x-gen/templates/session-<ts>/
+```
+
+Useful when an engine bug affected execution but template logic is fine.
+
+## Phase 6 — Interpret results
+
+The report has three buckets:
+
+### `confirmed_findings`
+
+Real exposures. Each one is something an attacker with the same identity
+as the actor could exploit right now.
+
+**Read carefully.** The triage classifier only sets `confirmed=true` when
+the template's own self-assessment is `confirmed: true`. Templates are
+written by AI; the AI sometimes overstates. For each confirmed finding,
+sanity-check:
+
+- Is the evidence actually proof of exploitation? Status code alone is
+  never enough.
+- Does the description match what the evidence shows?
+- Could this be a false positive (e.g. WAF block misread as app response,
+  CDN error misread as origin error)?
+
+If you're not sure, treat it as a candidate for manual verification (see
+Phase 7).
+
+### `mitigation_verifications`
+
+Probes that ran and confirmed a declared mitigation works at runtime.
+These are useful **negative** results — proof that a `@mitigates` claim
+isn't just paperwork.
+
+For each one, check:
+
+- Was the 403/404/etc. from the app's actual RBAC/auth/scoping logic, or
+  was it from a CDN/WAF? Audit log + evidence body excerpt usually
+  disambiguates. CloudFront errors have a distinctive HTML body
+  (`<TITLE>ERROR: The request could not be satisfied</TITLE>`).
+- Was the test even reaching the layer the mitigation is at? If not,
+  this verification is meaningless — the mitigation wasn't actually
+  exercised.
+
+### `ambiguous`
+
+Probes that couldn't reach a verdict. Categorized by `reason_kind`:
+
+- **`payload`** — AI couldn't confirm from the response, OR the request
+  was rejected before reaching the vuln logic (422 schema, etc.).
+  `mutation_retries` should have addressed these; if they're still here
+  after retries, they likely need manual investigation.
+- **`environment`** — missing primitive (HttpOnly cookie inaccessible,
+  no OAST configured, missing role tier). Re-run with the missing
+  prerequisite supplied.
+- **`unknown`** — finding emitted but neither confirmed=true nor matched
+  any refutation pattern. Read the description and evidence.
+
+### `retried_then_resolved`
+
+Finding IDs whose initial AMBIGUOUS result was later resolved by a
+mutation retry. The retry's verdict is in the appropriate bucket
+(confirmed or mitigation_verifications). The original ambiguous was
+suppressed to reduce noise.
+
+### `rejected_templates`
+
+Templates the validator rejected before execution. Each has the validator
+error. Usually one of: AI emitted raw `fetch()`, missing meta header,
+destructive path literal.
+
+### `dead_profiles`
+
+Profiles that became unauthenticated mid-scan and re-auth failed (or
+wasn't configured). Templates needing these profiles were skipped.
+Recover by re-capturing the profile and re-running.
+
+## Phase 7 — Verify confirmed findings out-of-band
+
+For each confirmed finding, before writing it up:
+
+### Reproduce manually with curl
+
+```bash
+# Extract cookies from the saved profile
+COOKIES=$(python3 -c "
+import json
+d = json.load(open('$HOME/.cert-x-gen/auth/pentest-admin.json'))
+print('; '.join(f\"{c['name']}={c['value']}\" for c in d['cookies']
+                if 'app.example.com' in c['domain']))
+")
+
+# Replay the exact request from the report
+curl -i \
+  -H "Cookie: $COOKIES" \
+  -H "x-test-automation: <header-if-applicable>" \
+  -X POST 'https://staging.app.example.com/<endpoint>' \
+  -d '<payload from report>'
+```
+
+If the manual curl reproduces the finding, it's real.
+
+### For blind vulnerabilities, confirm via OAST
+
+If `--oast` was passed during the scan, the template should have planted
+OAST URLs and the report description tells you which label to look for.
+Check your interactsh-client terminal:
+
+- If you see a DNS hit for the label hostname → server made an outbound
+  DNS lookup. Confirmed SSRF (or whichever blind class).
+- If you see an HTTP hit → server actually fetched. Even stronger.
+- If you see nothing → the 502 / 200 / timeout you observed isn't proof.
+  Downgrade `confirmed=true` to `confirmed=false`.
+
+## Phase 8 — Post-engagement
+
+When the engagement ends:
+
+### Rotate / revoke any secrets
+
+- If you used `--header` with a WAF-bypass token, ask infra to rotate it.
+- If your test session was IP-allowlisted, ask infra to remove the rule.
+- If you used a dedicated pentest origin, ask infra to turn it off.
+
+### Clean up local profiles
+
+```bash
+# Remove the captured profiles + their metadata
+ls ~/.cert-x-gen/auth/
+rm ~/.cert-x-gen/auth/pentest-*.json
+rm ~/.cert-x-gen/auth/pentest-*.meta.json
+
+# Or clear everything
+rm -rf ~/.cert-x-gen/auth/
+```
+
+The `.meta.json` files contain extra_headers values. Treat those like
+credentials.
+
+### Archive the audit log and report
+
+```bash
+# Move the session artifacts to engagement records
+mv ./pentest-session-full /engagement-archives/PT-2026-001/
+```
+
+The audit log is the dispute-ready record of what was done. Keep it for
+your org's retention policy duration.
+
+### Disable any debug logging you enabled
+
+If you bumped `--verbose` or piped output to a file in a shared
+directory, clean up.
+
+## Special situations
+
+### Scanning behind a corporate proxy
+
+Playwright respects `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`
+environment variables. Set them before running cxg.
+
+### Long-running scans that outlive session lifetime
+
+Use `--creds-file` so the session-health monitor can auto re-auth. For
+SSO-only apps where scripted re-auth isn't possible, re-capture the
+profile before each scan and keep individual scans short.
+
+### Scanning a containerized target
+
+`--target http://localhost:8000` works against any locally-running
+service. Make sure cxg's Chromium can reach it — if the target is in a
+different Docker network, expose it on the host.
+
+### Running scans in CI
+
+Possible but consider:
+
+- AI generation needs CLI provider auth (claude/codex/gemini logged in)
+  or API key env vars.
+- Playwright requires Chromium installed (`python3 -m playwright install
+  chromium`).
+- Auth profiles are filesystem state — either commit anonymized fixtures
+  or have CI re-capture each run.
+
+### Triaging a CI-broken scan
+
+When CI reports cxg exit code 2 (confirmed findings) or 3 (hard-killed):
+
+```bash
+# Inspect the most recent audit log
+jq -c 'select(._event == "finding" and .triage == "confirmed")' \
+  $session_dir/audit.jsonl
+
+# See what was blocked by scope
+jq -c 'select(._event == "blocked")' $session_dir/audit.jsonl
+
+# Get scope budget consumption per endpoint
+jq -c 'select(._event == "scan_end") | .scope_stats' $session_dir/audit.jsonl
+```
+
+## Quick decision tree
+
+```
+Does the codebase have whitebox/findings.sarif?
+├── No  → run `guardlink sarif . -p <project> -o whitebox/findings.sarif`
+└── Yes → continue
+            │
+            ▼
+Do you have written authorization?
+├── No  → STOP. Get authorization.
+└── Yes → continue
+            │
+            ▼
+Is the target production?
+├── Yes → Is staging available?
+│         ├── Yes → use staging instead
+│         └── No  → coordinate with infra; consider --headed, WAF allowlist,
+│                   or signed bypass header
+└── No  → continue
+            │
+            ▼
+Is auth SSO/MFA?
+├── Yes → use interactive `cxg pentest auth` (NOT --creds)
+└── No  → use scripted `--creds` if you want headless capture
+            │
+            ▼
+Are you testing chained-auth (IDOR cross-user)?
+├── Yes → capture ≥2 profiles via --auth-numbers 2
+└── No  → 1 profile is fine
+            │
+            ▼
+Will you have blind vulns to confirm (SSRF, blind SQLi)?
+├── Yes → start interactsh-client; pass --oast <host>
+└── No  → skip
+            │
+            ▼
+Run cxg pentest run with --scope-file, --attestation, --creds-file
+```

--- a/pentest/docs/TEMPLATES.md
+++ b/pentest/docs/TEMPLATES.md
@@ -1,0 +1,540 @@
+# JS Template Authoring Guide
+
+cxg pentest templates are JavaScript files with a structured header and a
+single `async function cxgProbe(cxg)` definition. They run inside an
+authenticated Chromium page via Playwright's `page.evaluate`, with a
+`window.__cxg` bridge injected before the template body executes.
+
+This document covers:
+
+- [Template anatomy](#template-anatomy)
+- [Meta header reference](#meta-header-reference)
+- [The cxg.* API](#the-cxg-api)
+- [Finding shape](#finding-shape)
+- [Validator rules](#validator-rules)
+- [Worked examples by vuln class](#worked-examples-by-vuln-class)
+- [Triage signals](#triage-signals)
+- [Tips for authoring AI-generated probes](#tips-for-authoring-ai-generated-probes)
+- [Copy-paste console fallback](#copy-paste-console-fallback)
+
+## Template anatomy
+
+```javascript
+// @id: idor-cross-user-records
+// @vuln_class: idor
+// @severity: high
+// @requires_auth_count: 2
+// @destructive_priority: 35
+// @description: User A attempts to PATCH a record owned by User B.
+
+async function cxgProbe(cxg) {
+    const findings = [];
+
+    // [1] Identify which profile is which
+    const attacker = cxg.profile;
+    const victim = cxg.profiles.find(p => p.index !== attacker.index);
+    if (!victim) return [];
+
+    // [2] As victim, enumerate their resources
+    const victimList = await cxg.fetchAs(victim.index, '/api/api-records');
+    if (victimList.status !== 200) return [];
+    const victimRecord = (victimList.body_json || [])[0];
+    if (!victimRecord) return [];
+
+    // [3] As attacker, attempt cross-user PATCH
+    const attack = await cxg.fetch(`/api/api-records/${victimRecord.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ notes: 'cxg-cross-user-probe' }),
+    });
+
+    // [4] Confirm or refute
+    if (attack.status === 200) {
+        findings.push({
+            id: 'idor-records-patch-cross-user',
+            vuln_class: 'idor',
+            severity: 'high',
+            confirmed: true,
+            endpoint: `PATCH /api/api-records/${victimRecord.id}`,
+            description: `${attacker.label} successfully PATCHed record ` +
+                         `owned by ${victim.label} (user_id=${victimRecord.owner_id}).`,
+            evidence: {
+                attacker: attacker.name,
+                victim: victim.name,
+                victim_record_id: victimRecord.id,
+                response_status: attack.status,
+            },
+            payload: `PATCH /api/api-records/${victimRecord.id} body={notes:...}`,
+        });
+    } else if (attack.status === 404) {
+        findings.push({
+            id: 'idor-records-patch-cross-user',
+            vuln_class: 'idor',
+            severity: 'high',
+            confirmed: false,
+            endpoint: `PATCH /api/api-records/${victimRecord.id}`,
+            description: 'Cross-user PATCH returned 404 — owner-scoping mitigation holds.',
+            evidence: { status: 404 },
+            payload: `PATCH /api/api-records/${victimRecord.id} as ${attacker.name}`,
+        });
+    }
+
+    return findings;
+}
+```
+
+## Meta header reference
+
+The meta header is one `// @key: value` comment per line, parsed by
+`js_engine.parse_template`. Both required and optional fields:
+
+| Key | Required | Type | Description |
+|-----|----------|------|-------------|
+| `@id` | yes | kebab-case string | Unique template ID. Findings emitted by the template inherit this if they don't supply their own `id`. |
+| `@vuln_class` | yes | normalized class | One of: `idor`, `csrf`, `xss`, `ssrf`, `command_injection`, `session_replay`, `credential_stuffing`, `rate_limit_bypass`, `privilege_escalation`, `sensitive_data_exposure`, `metrics_info_disclosure`, `clickjacking`, `content_sniffing`, `auth_api`. Unknown classes warn but don't reject. |
+| `@severity` | recommended | enum | `low`, `medium`, `high`, `critical`. Default `medium`. Used as fallback when a finding omits its own severity. |
+| `@requires_auth_count` | recommended | int 1-5 | Minimum auth contexts the template needs. The engine skips templates that need more than `--auth` provides. Default `1`. |
+| `@destructive_priority` | recommended | int 0-100 | `0` = read-only, `100` = session-killing (logout). Engine sorts probes ascending so destructive ones run last and don't poison earlier probes. Default `0`. |
+| `@description` | yes | single line | Plain-text one-liner shown in scan output. |
+
+## The cxg.* API
+
+The engine injects `window.__cxg` before template execution via Playwright's
+`add_init_script` (so it survives navigation) plus a one-shot `page.evaluate`
+for the already-loaded page. The template receives it as the first parameter
+to `cxgProbe`.
+
+### Identity
+
+```javascript
+cxg.profile                  // {name, label, index} — current identity
+cxg.profiles                 // [{name, label, index}, ...] — all identities
+                             //   (count = number passed to --auth or --interactive-auth)
+```
+
+The engine auto-selects the lowest-tier identity as the runner for
+privesc-class templates (vuln_class in {idor, privilege_escalation, csrf,
+session_replay, rate_limit_bypass, sensitive_data_exposure, metrics_info_disclosure}).
+Other templates run as the first captured identity.
+
+### URL helper
+
+```javascript
+cxg.url('/api/records')       // → 'https://target.example.com/api/records'
+cxg.url('https://elsewhere')  // → 'https://elsewhere' (passes absolute URLs through)
+```
+
+### Fetch (this identity)
+
+```javascript
+const r = await cxg.fetch(path, opts);
+// path: relative or absolute URL
+// opts: standard fetch options PLUS Playwright's redirect:'manual'
+//
+// Behavior:
+//   • Auto-adds X-CSRF-Token header from csrf_token cookie on POST/PUT/PATCH/DELETE.
+//   • Body objects auto-serialized to JSON + Content-Type set.
+//   • Sends every header from the profile's extra_headers config.
+//   • Goes through ScopeGuard (returns {status:0, blocked:true, blocked_reason} if
+//     the request is out of scope — does NOT hit the network).
+//   • Records request to audit log.
+//
+// Returns:
+//   {
+//     status: integer,
+//     headers: { ... },           // response headers, lower-case keys
+//     body_text: string,          // raw response body
+//     body_json: object | null,   // JSON.parse(body_text), null if not valid JSON
+//     blocked?: true,             // present only if scope guard blocked the request
+//     blocked_reason?: string,    // human-readable rejection reason
+//   }
+```
+
+### Fetch as another identity
+
+```javascript
+const r = await cxg.fetchAs(profile_idx, path, opts);
+// profile_idx: 0-indexed into cxg.profiles
+// Runs the request inside ANOTHER browser context's page.
+// Same response shape as cxg.fetch.
+```
+
+Critical for chained-auth probes (IDOR, horizontal privesc, session replay).
+
+### Cookie API (HttpOnly-aware)
+
+These wrap Playwright's `context.cookies()` / `add_cookies()` / `clear_cookies()`,
+NOT `document.cookie`. HttpOnly cookies are visible.
+
+```javascript
+const all = await cxg.getCookies();           // current identity
+const cs = await cxg.getCookiesAs(idx);       // another identity
+const one = await cxg.getCookie('access_token');
+
+await cxg.setCookies(newJar);                 // REPLACE entire jar
+await cxg.addCookies([cookie1, cookie2]);     // MERGE
+await cxg.clearCookies();                     // empty
+```
+
+Use case — session-replay probe: capture `access_token` cookie, logout,
+re-inject the captured cookie, attempt an authenticated request. If it
+succeeds, server-side session revocation is broken.
+
+### Out-of-band callback (OAST)
+
+```javascript
+cxg.oast.available           // boolean — true iff --oast was passed
+cxg.oast.host                // OAST hostname or null
+cxg.oast.url(label, scheme?) // 'http://<sanitized-label>.<host>'
+
+// Example: SSRF probe
+const oast = cxg.oast.url('ssrf-attack-1');
+if (!oast) {
+    return [{
+        id: 'ssrf-needs-oast',
+        confirmed: false,
+        description: 'OAST not configured — pass --oast <host> to confirm',
+        // (will be classified as environment-bound AMBIGUOUS, skip mutation)
+    }];
+}
+await cxg.fetch('/api/import', {
+    method: 'POST',
+    body: JSON.stringify({ url: oast }),
+});
+// Then check your interactsh terminal for a hit on label 'ssrf-attack-1'.
+```
+
+## Finding shape
+
+Templates return an array of findings:
+
+```javascript
+return [
+    {
+        id: 'idor-records-patch-cross-user',  // unique within scan; auto-suffixed on retries
+        vuln_class: 'idor',
+        severity: 'high',                     // low|medium|high|critical
+        confirmed: true,                      // strict claim — only when proof is direct
+        endpoint: 'PATCH /api/api-records/42',
+        description: 'plain text including any @mitigation references',
+        evidence: {
+            // any structured proof: response status, body excerpt, cookie diff,
+            // OAST hit details, role observations, etc.
+        },
+        payload: 'request body or attack string',
+    },
+];
+```
+
+Triage logic reads `confirmed` AND scans `description` for mitigation-hold
+patterns. See [Triage signals](#triage-signals) below.
+
+## Validator rules
+
+`validator.py` runs before any template executes. Templates that fail are
+dropped from the scan with a clear reason logged.
+
+| Rule | Behavior |
+|------|----------|
+| Missing required meta | REJECT. Required: `@id`, `@vuln_class`. |
+| `vuln_class` not in standard set | WARN (not reject). |
+| Missing `async function cxgProbe(cxg)` | REJECT. |
+| Raw `fetch(` call | REJECT. Templates must use `cxg.fetch` / `cxg.fetchAs` to get CSRF, audit, and scope-guard wiring. |
+| Destructive path literals | REJECT unless `--destructive-ok` is set. Patterns: `/delete-all`, `/wipe`, `/purge`, `/drop-(db\|database\|table\|all)`, `/reset-(all\|db\|database)`, `/factory-reset`. |
+| Many fetch call sites combined with a loop | WARN. The runtime ScopeGuard's per-endpoint budget is the actual stop. |
+| `requires_auth_count` not int 1-5 | WARN. |
+
+## Worked examples by vuln class
+
+The patterns below are condensed; real AI-generated templates often include
+more defensive code, multi-payload sweeps, and richer evidence.
+
+### IDOR (requires 2 identities)
+
+```javascript
+// @id: idor-records-patch
+// @vuln_class: idor
+// @requires_auth_count: 2
+// @destructive_priority: 35
+async function cxgProbe(cxg) {
+    const attacker = cxg.profile;
+    const victim = cxg.profiles.find(p => p.index !== attacker.index);
+    const vlist = await cxg.fetchAs(victim.index, '/api/records');
+    const vRecord = (vlist.body_json || [])[0];
+    if (!vRecord) return [];
+    const r = await cxg.fetch(`/api/records/${vRecord.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ notes: 'idor-probe' }),
+    });
+    return [{
+        id: 'idor-records-patch',
+        vuln_class: 'idor', severity: 'high',
+        confirmed: r.status === 200,
+        endpoint: `PATCH /api/records/${vRecord.id}`,
+        description: r.status === 200
+            ? `Cross-user PATCH succeeded — owner_id=${vRecord.owner_id}.`
+            : `Cross-user PATCH returned ${r.status} — owner-scoping mitigation holds.`,
+        evidence: { status: r.status, body_excerpt: r.body_text.slice(0,300) },
+    }];
+}
+```
+
+### CSRF
+
+```javascript
+// @id: csrf-mutating-endpoint
+// @vuln_class: csrf
+// @destructive_priority: 20
+async function cxgProbe(cxg) {
+    // Strip CSRF header by calling fetch directly (NOT cxg.fetch which auto-adds it).
+    // Use cxg.fetch but with an explicit empty X-CSRF-Token header to test.
+    const r = await cxg.fetch('/api/records', {
+        method: 'POST',
+        headers: { 'X-CSRF-Token': '' },
+        body: JSON.stringify({ name: 'csrf-probe' }),
+    });
+    return [{
+        id: 'csrf-records-post-no-token',
+        vuln_class: 'csrf', severity: 'high',
+        confirmed: r.status >= 200 && r.status < 300,
+        endpoint: 'POST /api/records',
+        description: r.status === 403
+            ? 'CSRF double-submit mitigation holds (403 without X-CSRF-Token).'
+            : `Mutating request accepted without CSRF token (status ${r.status}).`,
+        evidence: { status: r.status },
+    }];
+}
+```
+
+### SSRF (uses OAST)
+
+```javascript
+// @id: ssrf-import-url
+// @vuln_class: ssrf
+async function cxgProbe(cxg) {
+    if (!cxg.oast.available) {
+        return [{
+            id: 'ssrf-import-url',
+            vuln_class: 'ssrf', severity: 'medium',
+            confirmed: false,
+            endpoint: 'POST /api/import',
+            description: 'OAST not configured — pass --oast <host> to definitively confirm.',
+            evidence: { reason: 'environment' },
+        }];
+    }
+    const oast = cxg.oast.url('ssrf-import-1');
+    const r = await cxg.fetch('/api/import', {
+        method: 'POST',
+        body: JSON.stringify({ sourceUrl: oast }),
+    });
+    // Operator checks interactsh terminal for callback on 'ssrf-import-1'.
+    // (Future: cxg could poll interactsh API directly and confirm in-band.)
+    return [{
+        id: 'ssrf-import-url',
+        vuln_class: 'ssrf', severity: 'critical',
+        // Confirmed only when echo/callback proof exists, never from status alone.
+        confirmed: r.status === 200 && (r.body_text || '').includes('ssrf-import-1'),
+        endpoint: 'POST /api/import',
+        description: `Planted OAST URL ${oast} as sourceUrl. Check OAST server for callback to confirm.`,
+        evidence: { status: r.status, oast_label: 'ssrf-import-1' },
+    }];
+}
+```
+
+### Session replay (uses HttpOnly cookie capture)
+
+```javascript
+// @id: session-replay-after-logout
+// @vuln_class: session_replay
+// @destructive_priority: 100
+async function cxgProbe(cxg) {
+    const access = await cxg.getCookie('access_token');
+    if (!access) return [];
+
+    const before = await cxg.fetch('/api/me');
+    if (before.status !== 200) return [];
+
+    await cxg.fetch('/api/auth/logout', { method: 'POST' });
+
+    await cxg.addCookies([access]);
+    const after = await cxg.fetch('/api/me');
+
+    return [{
+        id: 'session-replay-after-logout',
+        vuln_class: 'session_replay', severity: 'high',
+        confirmed: after.status === 200,
+        endpoint: 'GET /api/me',
+        description: after.status === 200
+            ? 'access_token cookie continues to authenticate AFTER logout — server-side session revocation appears broken.'
+            : `Replay returned ${after.status} — Redis session revocation holds.`,
+        evidence: { pre_status: before.status, post_status: after.status },
+    }];
+}
+```
+
+### Privilege escalation (mass assignment)
+
+```javascript
+// @id: privesc-records-create-mass-assign
+// @vuln_class: privilege_escalation
+// @destructive_priority: 8
+async function cxgProbe(cxg) {
+    // Send benign payload first to confirm route exists + accepts our identity
+    const benign = await cxg.fetch('/api/records', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'cxg-baseline' }),
+    });
+    if (benign.status >= 400) {
+        return [{
+            id: 'privesc-records-baseline-rejected',
+            vuln_class: 'privilege_escalation', severity: 'low',
+            confirmed: false,
+            description: `Baseline POST rejected (${benign.status}); cannot exercise mass-assignment gate.`,
+            evidence: { benign_status: benign.status },
+        }];
+    }
+
+    // Now send privileged-field payload
+    const privileged = await cxg.fetch('/api/records', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'cxg-priv', role: 'admin', owner_id: 999999 }),
+    });
+    const echoed = privileged.body_json || {};
+    const stolen = echoed.role === 'admin' || echoed.owner_id === 999999;
+    return [{
+        id: 'privesc-records-create-mass-assign',
+        vuln_class: 'privilege_escalation', severity: stolen ? 'high' : 'low',
+        confirmed: stolen,
+        endpoint: 'POST /api/records',
+        description: stolen
+            ? `Server honored privileged fields (role=${echoed.role}, owner_id=${echoed.owner_id}).`
+            : 'Privileged fields silently ignored — mass-assignment mitigation holds.',
+        evidence: { echoed_role: echoed.role, echoed_owner_id: echoed.owner_id },
+    }];
+}
+```
+
+### Rate-limit bypass
+
+```javascript
+// @id: rate-limit-login
+// @vuln_class: rate_limit_bypass
+// @destructive_priority: 30
+async function cxgProbe(cxg) {
+    const statuses = [];
+    const start = performance.now();
+    for (let i = 0; i < 10; i++) {
+        const r = await cxg.fetch('/api/auth/login', {
+            method: 'POST',
+            body: JSON.stringify({
+                email: `probe+${i}@example.test`,
+                password: 'wrong-password',
+            }),
+        });
+        statuses.push(r.status);
+    }
+    const elapsed = performance.now() - start;
+    const saw429 = statuses.includes(429);
+    return [{
+        id: 'rate-limit-login',
+        vuln_class: 'rate_limit_bypass', severity: 'medium',
+        confirmed: !saw429,
+        endpoint: 'POST /api/auth/login',
+        description: saw429
+            ? `Throttling kicked in after ${statuses.indexOf(429)} attempts — mitigation holds.`
+            : `10 rapid login attempts in ${Math.round(elapsed)}ms, no 429 observed — no rate limit.`,
+        evidence: { statuses, elapsed_ms: Math.round(elapsed) },
+    }];
+}
+```
+
+## Triage signals
+
+`mutator.classify(finding)` is a pure-function classifier that runs against
+every emitted finding. It maps to one of three buckets:
+
+### CONFIRMED (`confirmed_findings`)
+
+- `finding.confirmed === true` AND `evidence` is non-empty.
+
+The triage classifier defers to the template here. **Templates should mark
+`confirmed=true` only when there's direct proof** — echo, leaked content,
+OAST callback, behavioral diff that's unambiguous. Status codes alone never
+count.
+
+### REFUTED (`mitigation_verifications`)
+
+Any one of:
+
+- Status code: 401/403/404 from app layer.
+- Description matches "mitigation holds" patterns (parenthetical-tolerant):
+  `mitigation appears to hold`, `mitigation held`, `scoping enforced`,
+  `RBAC enforced`, `require_admin enforced`, `fields ignored`,
+  `silently ignored`, `silently stripped`, `forced server-side`,
+  `no exploitation observed`, `no IDOR observed`, `no bypass observed`,
+  `mitigation appears effective`, `<noun> (scoping|gate|check|control|policy) held`,
+  `no finding raised`, `caller-owned rows`, `absent from caller's list`, etc.
+- Pattern `mitigation #foo-bar held|holds|enforced|ignored`.
+
+### AMBIGUOUS (`ambiguous`)
+
+Everything else. Subclassified by `reason_kind`:
+
+| `reason_kind` | When | Mutation retry? |
+|---------------|------|-----------------|
+| `payload` | Status 422 (schema reject), 2xx without confirmation, generic unclear result | Yes — AI rewrites template to fix payload shape |
+| `environment` | Missing role tier, missing primitive, OAST not configured, network unreachable | No — surfaces to operator |
+| `unknown` | confirmed=false without any clear signal | Yes (low confidence retry) |
+
+## Tips for authoring AI-generated probes
+
+The system prompt in `js_generator.SYSTEM_PROMPT` encodes these as hard rules,
+but they're worth knowing if you're hand-tuning templates:
+
+1. **For mass-assignment / role-elevation probes**: send a benign payload
+   first to confirm route + identity → THEN send the privileged payload.
+   Otherwise a 422 from Pydantic / Zod schema validation looks like "mitigation
+   working" when actually the gate was never tested.
+2. **For rate-limit / brute-force probes**: use a VALID email format
+   (`user+probe@gmail.com`) so request bodies pass schema validation and
+   actually exercise the auth path. Otherwise you're measuring the schema
+   validator's throughput, not the rate limiter.
+3. **Respect `@comment` intent**: when guardlink emits a `@comment` saying
+   an exposure is by-design ("operational feature", "intentionally
+   authenticated"), don't declare a CONFIRMED high-severity vuln. Mark
+   `severity=info` or omit the finding.
+4. **Blind-vuln rule**: For `vuln_class in {ssrf, blind_sqli, blind_xxe,
+   command_injection, blind_ssti, log4shell}`, `confirmed=true` requires
+   direct echo, OAST callback, or ≥3σ timing separation. Status codes alone
+   are never confirmation.
+
+## Copy-paste console fallback
+
+Templates are designed to be paste-runnable in DevTools console with a stub:
+
+```javascript
+// In a browser DevTools console, paste this stub first:
+window.__cxg = window.__cxg || {
+  profile: { name: 'console', label: 'console', index: 0 },
+  profiles: [{ name: 'console', label: 'console', index: 0 }],
+  url: (p) => p.startsWith('http') ? p : location.origin + (p.startsWith('/') ? p : '/' + p),
+  fetch: async (path, opts) => {
+    const url = window.__cxg.url(path);
+    const r = await fetch(url, Object.assign({ credentials: 'include' }, opts || {}));
+    const text = await r.text();
+    let body_json = null; try { body_json = JSON.parse(text); } catch(e){}
+    const respHeaders = {}; r.headers.forEach((v,k)=>respHeaders[k]=v);
+    return { status: r.status, headers: respHeaders, body_text: text, body_json };
+  },
+  fetchAs: async () => { throw new Error('fetchAs requires the cxg engine'); },
+  getCookies: async () => document.cookie.split('; ').map(c => {
+    const [name, ...rest] = c.split('='); return { name, value: rest.join('=') };
+  }),
+  oast: { available: false, host: null, url: () => null },
+};
+
+// Then paste the template body, then:
+cxgProbe(window.__cxg).then(console.log);
+```
+
+`fetchAs` won't work outside the engine (needs cross-context routing). HttpOnly
+cookies will be invisible to the stub's `getCookies`. Everything else works.

--- a/pentest/docs/TROUBLESHOOTING.md
+++ b/pentest/docs/TROUBLESHOOTING.md
@@ -1,0 +1,322 @@
+# Troubleshooting and FAQ
+
+This document catalogs the failures we've actually observed during real
+scans and how to fix them.
+
+## Pre-scan failures
+
+### `[gen] selected 0/0 hypotheses for AI synthesis` / `no templates available — exiting`
+
+cxg loaded the SARIF but found nothing testable. Three causes:
+
+| Cause | Check | Fix |
+|-------|-------|-----|
+| Guardlink output is missing | `ls <codebase>/whitebox/findings.sarif` | Run `guardlink sarif . -p <project> -o whitebox/findings.sarif` |
+| SARIF exists but has no HTTP-routed hypotheses | `jq '.runs[0].results \| map(select(.properties.codegraph_reachability.http_path)) \| length' whitebox/findings.sarif` | If 0, the codebase may not have HTTP routes guardlink can recognize. The route-enrichment heuristic in `guardlink.py` will scrape Express/FastAPI/Hono/Flask routes from source but needs anchored SARIF lines. |
+| `--mitigation-mode unmitigated` selected, but every hypothesis has `@mitigates` declared | Run with `--mitigation-mode any` to see the full list | Either the codebase is well-defended (the right outcome) or `@mitigates` claims aren't actually enforced (try `--mitigation-mode mitigated` to verify) |
+
+### `pentest orchestrator not installed`
+
+```
+Pentest orchestrator not installed at /Users/<you>/.cert-x-gen/pentest/cxg_pentest.py
+Run: cxg pentest install
+```
+
+The Rust shim couldn't find the Python orchestrator. Run `cxg pentest
+install`. If installing fails ("could not locate pentest source dir"), set
+`CXG_SOURCE` to the cxg repo root before running install.
+
+### `python3 not found on PATH`
+
+The Rust shim invokes `python3` (or `python`). Install Python 3.10+ or
+set `CXG_PYTHON=/path/to/python3`.
+
+### `playwright + anthropic not installed`
+
+```bash
+pip3 install --break-system-packages playwright anthropic
+python3 -m playwright install chromium
+```
+
+The `--break-system-packages` is needed on macOS Homebrew Python 3.12+
+because system packages are PEP-668 managed. If you're using a virtual
+env, activate it before installing.
+
+## Auth capture failures
+
+### Capture hangs on `↩ Press ENTER when logged in (or close the browser):`
+
+You opened the prompt but the browser flow isn't done. Either complete
+the login in the browser, or close the window. cxg waits up to 10 minutes,
+then captures whatever state exists at that point. If the captured state
+is from a partially-logged-in flow, the post-capture verifier will warn:
+
+```
+⚠ session VERIFICATION FAILED: landed at https://auth.example.com/login
+   That URL or page content looks like a login/SSO page — your captured
+   cookies aren't authenticating against https://app.example.com.
+```
+
+Re-run capture and complete login before pressing ENTER.
+
+### `(initial goto warning: Page.goto: Timeout 15000ms exceeded)`
+
+The target URL didn't respond within 15s when the browser opened. Reasons:
+
+- The app isn't running.
+- VPN required.
+- Wrong protocol (`http://` vs `https://`).
+- Corporate proxy not set in env vars (Playwright respects
+  `HTTPS_PROXY`).
+
+The capture continues anyway — log in manually, press ENTER. The session
+will still be captured if you reach the dashboard.
+
+### `Exception in callback ... greenlet.error: cannot switch to a different thread`
+
+You're on an older orchestrator version that called sync Playwright from
+a worker thread. Fix:
+
+```bash
+cxg pentest install --force
+```
+
+This pulls in the current `auth.py` which moves stdin polling to a
+thread and keeps Playwright on the main thread.
+
+### `session VERIFICATION FAILED: landed at <login URL>`
+
+The captured cookies don't authenticate against `--target`. Common causes
+ranked by likelihood:
+
+1. **You closed the browser before login fully completed.** Some SSO flows
+   do a final back-redirect that sets a session cookie at the app origin
+   — closing during that redirect loses the cookie. Re-capture, wait for
+   the dashboard to fully render, then press ENTER.
+
+2. **Multi-tenant SSO scoped cookies to a different subdomain.** Your
+   org's app may be at `tenant-7.app.example.com` while you tried to
+   capture at `app.example.com`. The cookies are on `tenant-7.app.example.com`
+   only. Pass that as `--target` instead, or use `--skip-health-check`.
+
+3. **The WAF blocked the verifier's headless probe even though your
+   interactive capture worked.** Headed Chromium has a stronger
+   fingerprint than headless. The session IS alive in the captured state
+   — the verifier just can't replay it. Pass `--skip-health-check` at scan
+   time. Templates that use the JS bridge often work even when the
+   verifier doesn't, because they run inside the same browser context
+   shape Playwright already had.
+
+### `⚠ session VERIFICATION FAILED: <verify-url> → 403`
+
+(Older messaging, pre-landing-test.) Same as above. Re-install the
+orchestrator.
+
+## Scan-time failures
+
+### `Cannot read properties of undefined (reading 'fetch')`
+
+The template ran but `window.__cxg` wasn't defined when it executed.
+Causes:
+
+- **Orchestrator predates the `add_init_script` bridge fix.** Re-install:
+  `cxg pentest install --force`.
+- **The page navigated between bridge injection and template execution,
+  AND `_ensure_bridge` didn't re-inject.** This shouldn't happen in
+  current code; if it does, file a bug with the audit log.
+
+### `claude CLI rc=1` with empty stderr
+
+The Claude CLI subprocess returned non-zero with no diagnostic. Causes:
+
+- **Claude session expired.** Run `claude --help` interactively in a
+  terminal — if it prompts you to log in, do that and retry.
+- **Prompt was too long.** Templates with very rich `@comment` context
+  can exceed Claude's input limit. Reduce `--max-templates` or set
+  `proximity_lines` in `guardlink.attach_comments_to_hypotheses` to a
+  smaller value.
+- **Network glitch.** Just retry.
+
+### `claude CLI timed out after 240s`
+
+The AI took longer than 240s for one generation call. Either:
+
+- The codebase is very large and the AI is doing deep grep cycles. Bump
+  `--generation-timeout 600`.
+- The Claude CLI is stuck in a tool-use loop. The orchestrator kills the
+  entire process group on timeout, so cxg continues to the next template.
+  The skipped template is recorded as `✗ <vuln_class>: <provider> CLI
+  timed out`.
+
+### `[AMBIGUOUS:unknown] ... AI returned confirmed=false without clear refutation signal`
+
+The template ran, observed something, but neither claimed exploitation
+nor matched any refutation pattern. Two angles:
+
+- **The AI is being honest** — the response is genuinely unclear (e.g.
+  a 502 that could be either an SSRF outbound failure or a generic error).
+  Treat as a manual-review candidate.
+- **The mitigation-hold language in the description doesn't match the
+  classifier's regex.** This is a `mutator.py` bug — open one. Workaround:
+  read the description manually.
+
+### `[AMBIGUOUS:environment] ... environment-bound`
+
+The probe needs something the engine couldn't give it. Common cases:
+
+| Environment shortfall | Fix |
+|----------------------|-----|
+| HttpOnly cookie can't be read by JS | The current bridge DOES support HttpOnly via `cxg.getCookie()`. If you see this, the template is using `document.cookie` instead of `cxg.getCookie` — that's a generation bug. Re-run; the mutator should catch this. |
+| Out-of-band callback needed | Pass `--oast <interactsh-host>` |
+| Missing role tier (e.g. low-priv identity not captured) | Capture an additional profile with the right role and add to `--auth` |
+| OAuth/SSO scope not granted | The probe needs a different identity. Capture one with the right scope. |
+
+### `template <id> threw: <error>`
+
+The JS template raised an uncaught exception. The error message is in the
+audit log. Common causes:
+
+- Template hit a `null.something` because a fetch returned an unexpected
+  shape (e.g. CloudFront HTML where it expected JSON).
+- Template referenced a property the AI hallucinated (e.g. `cxg.foo`
+  where `foo` doesn't exist).
+
+The engine continues to the next template. If retries are configured, the
+mutator usually fixes hallucinated APIs.
+
+### `5xx streak threshold reached ... Halting scan.`
+
+The ScopeGuard saw 8 consecutive 5xx responses and triggered HardKillSignal.
+Either:
+
+- The target is genuinely overloaded — back off, coordinate with ops.
+- A probe is sending malformed requests that crash the handler. Look at
+  the audit log to find which template triggered the 5xx run, then file
+  a bug or refine that probe.
+
+Exit code 3.
+
+### `per-endpoint budget exhausted (30/30 for POST /api/foo)`
+
+ScopeGuard blocked a probe from sending more requests to one endpoint.
+Either:
+
+- The template's loop is unintentionally explosive — fix the template.
+- The budget is too tight for the engagement — bump
+  `max_requests_per_endpoint` in scope.yaml.
+
+Each blocked request is recorded in the audit log as
+`_event: blocked`.
+
+## CloudFront / WAF specific
+
+### Every response body starts with `<!DOCTYPE HTML PUBLIC ... ERROR: The request could not be satisfied`
+
+That's CloudFront's WAF error page. Your traffic is being blocked at the
+edge, never reaching the application. Three options:
+
+1. **Get a WAF bypass header from infra.** Pass it via `--header` at auth
+   time. The header is saved with the profile.
+
+2. **Get your IP allowlisted.** Coordinate with whoever owns the
+   CloudFront / WAF distribution. They add your IP for the engagement
+   window.
+
+3. **Run from a different network position.** If your org has a pentest
+   bastion or VPC, run from there. Or point `--target` at staging which
+   may not have the same WAF.
+
+### Some endpoints reach the app, others get CloudFront 403
+
+That's normal — different paths have different WAF rules. The bot-protection
+rule that blocks `/api/*` may not block `/slack/webhooks` because Slack
+needs unauthenticated access to webhook endpoints. The audit log will show
+which is which (CloudFront HTML body vs. app JSON body).
+
+If only some endpoints work, your scan results for the blocked endpoints
+are testing the WAF, not the app. The engine's triage might misclassify
+CloudFront 403s as "RBAC enforced". Treat with skepticism.
+
+## OAST callback issues
+
+### I passed `--oast` but the interactsh terminal shows nothing
+
+Confirm in order:
+
+1. The template was generated with `--oast` present — old cached templates
+   from before `--oast` was added won't use `cxg.oast.url()`. Drop
+   `--template-dir`, let the AI regenerate.
+2. The OAST hostname you passed is the live one from your current
+   interactsh-client session, not a stale one.
+3. The target actually made an outbound request. Check the audit log for
+   the relevant probe — `_event: request` for the outbound payload. If the
+   request succeeded (200) but no callback fired, the target didn't make
+   the outbound request → no SSRF.
+4. The OAST host is reachable from the target's network. Some isolated
+   VPCs block outbound to public OAST hosts. Try interactsh's HTTP variant
+   (default) versus DNS-only.
+
+### Interactsh shows a hit but I'm not sure it's mine
+
+Each OAST URL contains a label you control (`cxg.oast.url('ssrf-attack-1')`).
+The interactsh-client UI shows the full hostname of each hit, including
+your label.
+
+## Reporting / verification
+
+### Confirmed findings include CloudFront 403 responses as "RBAC enforced"
+
+The triage classifier's mitigation-hold patterns include `403 (auth/RBAC
+enforced)`. A CloudFront 403 ALSO matches. Distinguish manually:
+
+```bash
+# In the audit.jsonl
+jq '.evidence.body_excerpt' $session_dir/audit.jsonl | grep -i cloudfront
+```
+
+If the body excerpt is CloudFront's HTML, the 403 was a CDN block, not
+an app-level mitigation.
+
+### The AI says the same thing in different runs but classifies differently
+
+The triage classifier is deterministic on the **description text**. If
+the AI emits slightly different wording across runs, the same vuln state
+may classify differently. The fix is to broaden the classifier's regex
+in `mutator.py` to match the new wording — both fixes are valid; the AI
+isn't going to be deterministic across runs.
+
+### Confirmed finding has empty `evidence`
+
+The AI marked `confirmed=true` but supplied no evidence. The classifier
+catches this and downgrades to AMBIGUOUS (payload), reason "no evidence
+provided". The mutator will rewrite the template to include evidence on
+retry. If you still see this in the final report, the AI is being
+non-cooperative — file a bug or rewrite the template manually.
+
+## When in doubt
+
+Read the audit log. Every request, every blocked request, every finding,
+every triage verdict is recorded.
+
+```bash
+session_dir=~/.cert-x-gen/sessions/pentest-<latest>
+jq -c '.' $session_dir/audit.jsonl | less
+```
+
+Useful one-liners:
+
+```bash
+# All requests for a given template
+jq -c 'select(._event == "request" and .template_id == "ssrf-import-url")' \
+  $session_dir/audit.jsonl
+
+# All blocked requests with their reasons
+jq -c 'select(._event == "blocked")' $session_dir/audit.jsonl
+
+# All findings with their triage verdicts
+jq -c 'select(._event == "finding") | {id, triage, triage_reason, description}' \
+  $session_dir/audit.jsonl
+
+# Scope budget consumption summary
+jq -c 'select(._event == "scan_end") | .scope_stats' $session_dir/audit.jsonl
+```

--- a/pentest/guardlink.py
+++ b/pentest/guardlink.py
@@ -1,0 +1,502 @@
+"""Parse guardlink output into normalized Hypothesis objects the pentest agent consumes.
+
+Two inputs:
+  1. SARIF file (whitebox/findings.sarif) — primary, has structured fields
+  2. Inline @exposes / @mitigates / @flows annotations in source — for context enrichment
+
+Output: list of Hypothesis(vuln_class, http_method, http_path, confidence, ...)
+ready for probe selection.
+"""
+from __future__ import annotations
+import json
+import re
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+
+# Inline annotation regexes — match the syntax documented in .cursor/rules/guardlink.mdc
+_RE_EXPOSES = re.compile(
+    r"@exposes\s+(?P<asset>#[\w-]+)\s+to\s+(?P<threat>#[\w-]+)"
+    r"(?:\s+\[(?P<sev>[A-Z]?\d+)\])?(?:\s+cwe:(?P<cwe>CWE-\d+))?"
+    r"(?:\s+owasp:(?P<owasp>[A-Z0-9:]+))?(?:\s*--\s*\"(?P<desc>[^\"]*)\")?"
+)
+_RE_MITIGATES = re.compile(
+    r"@mitigates\s+(?P<asset>#[\w-]+)\s+against\s+(?P<threat>#[\w-]+)"
+    r"\s+using\s+(?P<control>#[\w-]+)(?:\s*--\s*\"(?P<desc>[^\"]*)\")?"
+)
+_RE_FLOWS = re.compile(
+    r"@flows\s+(?P<src>#?[\w.-]+)\s*->\s*(?P<dst>#[\w-]+)\s+via\s+(?P<channel>[\w.-]+)"
+    r"(?:\s*--\s*\"(?P<desc>[^\"]*)\")?"
+)
+_RE_AUDIT = re.compile(r"@audit\s+(?P<asset>#[\w-]+)(?:\s*--\s*\"(?P<desc>[^\"]*)\")?")
+# @comment annotations are free-text intent notes. They often clarify "this is by design"
+# / "operational feature, not a public endpoint" / etc. — critical context for the AI to
+# avoid declaring design choices as vulnerabilities.
+_RE_COMMENT = re.compile(r"@comment(?:\s+(?P<asset>#[\w-]+))?\s*--\s*\"(?P<desc>[^\"]*)\"")
+
+
+@dataclass
+class InlineAnnotation:
+    kind: str  # exposes | mitigates | flows | audit
+    file: str
+    line: int
+    raw: str
+    fields: dict
+
+
+@dataclass
+class Hypothesis:
+    """A pentest target derived from guardlink data."""
+    id: str
+    vuln_class: str           # e.g. "idor", "csrf", "xss", "session_replay", "credential_stuffing"
+    threat: str               # guardlink threat id, e.g. "#idor"
+    asset: str                # guardlink asset, e.g. "#users-api"
+    http_method: Optional[str]
+    http_path: Optional[str]  # may contain {var} placeholders
+    function_name: Optional[str]
+    file: Optional[str]
+    line: Optional[int]
+    severity: str             # P0/P1/P2/P3 or low/medium/high
+    cwe: Optional[str]
+    description: str
+    confidence: float
+    has_mitigation_declared: bool  # whether guardlink saw an @mitigates
+    payload_hint: str = ""
+    playwright_required: bool = False
+    # @comment annotations near the route handler — captures intent ("by design")
+    nearby_comments: list[str] = field(default_factory=list)
+    raw: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+_SEV_MAP = {"P0": "critical", "P1": "high", "P2": "medium", "P3": "low",
+            "high": "high", "medium": "medium", "low": "low", "critical": "critical"}
+
+
+def _normalize_vuln_class(threat_or_rule: str) -> str:
+    s = threat_or_rule.lower().lstrip("#").replace("-", "_")
+    # SARIF ruleIds look like guardlink-exposes-credential_stuffing — strip prefix
+    for prefix in ("guardlink_exposes_", "guardlink-exposes-"):
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+    return s
+
+
+def parse_inline(codebase: Path) -> list[InlineAnnotation]:
+    """Walk the codebase, return all inline guardlink annotations."""
+    out: list[InlineAnnotation] = []
+    text_exts = {".py", ".js", ".ts", ".tsx", ".jsx", ".go", ".rs", ".java", ".rb", ".php", ".html"}
+    skip_dirs = {".git", "node_modules", "__pycache__", ".venv", "venv", "dist", "build", ".next"}
+    for p in codebase.rglob("*"):
+        if not p.is_file() or p.suffix not in text_exts:
+            continue
+        if any(part in skip_dirs for part in p.parts):
+            continue
+        try:
+            for lineno, line in enumerate(p.read_text(errors="ignore").splitlines(), 1):
+                for kind, rx in (("exposes", _RE_EXPOSES), ("mitigates", _RE_MITIGATES),
+                                 ("flows", _RE_FLOWS), ("audit", _RE_AUDIT),
+                                 ("comment", _RE_COMMENT)):
+                    m = rx.search(line)
+                    if m:
+                        out.append(InlineAnnotation(
+                            kind=kind, file=str(p), line=lineno, raw=line.strip(),
+                            fields={k: v for k, v in m.groupdict().items() if v is not None},
+                        ))
+        except Exception:
+            continue
+    return out
+
+
+_FUNC_DEF_RX = re.compile(r"^\s*(?:async\s+)?def\s+(\w+)\s*\(", re.MULTILINE)
+
+
+def _find_function_line(file_path: str, func_name: str) -> Optional[int]:
+    """Scan file for `def <func_name>(` and return its 1-indexed line, or None.
+    Handles `async def` too. Returns the FIRST match (we assume unique names)."""
+    try:
+        text = Path(file_path).read_text(errors="ignore")
+    except Exception:
+        return None
+    for m in _FUNC_DEF_RX.finditer(text):
+        if m.group(1) == func_name:
+            return text[:m.start()].count("\n") + 1
+    return None
+
+
+def attach_comments_to_hypotheses(hyps: list, inline: list,
+                                   proximity_lines: int = 30) -> list:
+    """For each hypothesis, attach nearby @comment descriptions so the AI can weigh
+    intent ("by design", "operational feature") before declaring a CONFIRMED finding.
+
+    Strategy:
+      1. If hypothesis has a function_name, find that function's REAL line in the
+         current source by grepping for `def <name>(`. SARIF line numbers are often
+         stale because the SARIF was generated against an older snapshot.
+      2. Search @comments within `proximity_lines` of the real function line,
+         scanning DOWNWARD only (most route comments come below the def, not above).
+      3. Fall back to SARIF line if the function can't be found.
+    """
+    # Group comments by file basename for fast lookup
+    comments_by_basename: dict[str, list[InlineAnnotation]] = {}
+    for ann in inline:
+        if ann.kind != "comment":
+            continue
+        bn = Path(ann.file).name
+        comments_by_basename.setdefault(bn, []).append(ann)
+
+    for h in hyps:
+        if not h.file:
+            continue
+        h_basename = Path(h.file).name
+        candidates = comments_by_basename.get(h_basename, [])
+        if not candidates:
+            continue
+
+        # Find the actual current-source line of this hypothesis's function
+        anchor_line = None
+        if h.function_name:
+            # function_name may be "module.py::func_name" — extract bare name
+            bare = h.function_name.split("::")[-1].split(".")[-1]
+            # The file path in `inline` matches what we walked, so re-derive a path
+            # from one of the @comments in the same basename.
+            sample_file = candidates[0].file
+            anchor_line = _find_function_line(sample_file, bare)
+
+        if anchor_line is None:
+            anchor_line = h.line  # fall back to SARIF line
+
+        if anchor_line is None:
+            continue
+
+        nearby = []
+        for ann in candidates:
+            # Look mostly downward (route comments are usually below the def)
+            delta = ann.line - anchor_line
+            if -3 <= delta <= proximity_lines:
+                desc = ann.fields.get("desc", "").strip()
+                if desc:
+                    nearby.append((delta, desc))
+        # Sort by proximity (closer comments first)
+        nearby.sort(key=lambda x: abs(x[0]))
+        # dedupe preserving order
+        seen = set(); deduped = []
+        for _, c in nearby:
+            if c not in seen:
+                seen.add(c); deduped.append(c)
+        h.nearby_comments = deduped[:6]
+    return hyps
+
+
+def parse_sarif(sarif_path: Path) -> list[Hypothesis]:
+    """Extract structured hypotheses from a guardlink-emitted SARIF file.
+
+    Supports TWO schemas:
+      - **old/extended** (preview-version SARIF with bravos-style rule IDs): has
+        properties.guardlink_threat, .guardlink_severity, .codegraph_reachability.*,
+        .taint_path.*, .rlm_hypothesis.*  — rich, route-aware.
+      - **upstream guardlink 1.4.3** (current standard): emits SARIF with ruleId
+        guardlink/{unmitigated-critical,unmitigated-exposure,confirmed-exploitable,
+        dangling-ref} and properties.{severity,asset,threat,externalRefs} — minimal.
+
+    Both schemas are mapped onto the same Hypothesis shape so downstream code doesn't
+    care which guardlink version produced the SARIF.
+    """
+    data = json.loads(sarif_path.read_text())
+    out: list[Hypothesis] = []
+    for run in data.get("runs", []):
+        for i, r in enumerate(run.get("results", [])):
+            props = r.get("properties", {}) or {}
+            rule_id = r.get("ruleId", "")
+
+            # Skip pure diagnostics (parse errors, dangling refs aren't testable threats)
+            if rule_id == "guardlink/dangling-ref":
+                continue
+
+            # Source-of-truth fields: prefer extended schema, fall back to upstream
+            rlm = props.get("rlm_hypothesis", {}) or {}
+            cg = props.get("codegraph_reachability", {}) or {}
+            taint = props.get("taint_path", {}) or {}
+
+            threat_id = (
+                props.get("guardlink_threat")
+                or props.get("threat")        # upstream schema
+                or ""
+            )
+            asset = (
+                props.get("guardlink_asset")
+                or props.get("asset")          # upstream schema
+                or ""
+            )
+            vuln_class = _normalize_vuln_class(
+                rlm.get("vuln_class") or threat_id or rule_id
+            )
+
+            sev_raw = (
+                props.get("guardlink_severity")
+                or props.get("severity")       # upstream schema
+                or "P2"
+            )
+            severity = _SEV_MAP.get(sev_raw, sev_raw.lower() if isinstance(sev_raw, str) else "low")
+
+            loc = (r.get("locations") or [{}])[0].get("physicalLocation", {}) or {}
+            file_uri = (loc.get("artifactLocation") or {}).get("uri", "")
+            start_line = (loc.get("region") or {}).get("startLine")
+
+            # CWE: prefer guardlink_cwe, fall back to first cwe: in externalRefs
+            cwe = props.get("guardlink_cwe")
+            if not cwe:
+                ext_refs = props.get("externalRefs", []) or []
+                if isinstance(ext_refs, list):
+                    for ref in ext_refs:
+                        if isinstance(ref, str) and ref.lower().startswith("cwe:"):
+                            cwe = ref[4:]
+                            break
+
+            # Mitigation status: extended schema has taint.sanitizers_in_path; upstream
+            # encodes it in the ruleId itself (unmitigated-* vs guardlink/mitigated-*
+            # which doesn't currently exist, so we treat both unmitigated-* ruleIds as
+            # "no @mitigates declared near this exposure").
+            if taint.get("sanitizers_in_path") is not None:
+                mitigations_declared = bool(taint.get("sanitizers_in_path"))
+            elif rule_id.startswith("guardlink/unmitigated"):
+                mitigations_declared = False
+            elif rule_id == "guardlink/confirmed-exploitable":
+                mitigations_declared = False  # confirmed means defenses don't hold
+            else:
+                # Unknown ruleId — be conservative, assume mitigated
+                mitigations_declared = True
+
+            hypo = Hypothesis(
+                id=f"gl-{i}-{vuln_class}",
+                vuln_class=vuln_class,
+                threat=threat_id or "",
+                asset=asset,
+                http_method=cg.get("http_method"),
+                http_path=cg.get("http_path"),
+                function_name=cg.get("enclosing_function"),
+                file=file_uri,
+                line=start_line,
+                severity=severity,
+                cwe=cwe,
+                description=(r.get("message") or {}).get("text", "") or props.get("guardlink_description", ""),
+                confidence=float(rlm.get("confidence", 0.5)),
+                has_mitigation_declared=mitigations_declared,
+                payload_hint=str(rlm.get("payload_hint", "")),
+                playwright_required=bool(rlm.get("playwright_required", False)),
+                raw=props,
+            )
+            out.append(hypo)
+    return out
+
+
+def attack_surface(sarif: list[Hypothesis], inline: list[InlineAnnotation]) -> dict:
+    """Build a compact attack-surface summary the LLM (or a human) can read."""
+    endpoints: dict[str, dict] = {}
+    for h in sarif:
+        if not h.http_path:
+            continue
+        key = f"{h.http_method or 'ANY'} {h.http_path}"
+        e = endpoints.setdefault(key, {"method": h.http_method, "path": h.http_path,
+                                       "vuln_classes": set(), "max_sev": "low",
+                                       "function": h.function_name, "mitigations": False})
+        e["vuln_classes"].add(h.vuln_class)
+        sev_order = ["low", "medium", "high", "critical"]
+        if sev_order.index(h.severity if h.severity in sev_order else "low") > sev_order.index(e["max_sev"]):
+            e["max_sev"] = h.severity
+        if h.has_mitigation_declared:
+            e["mitigations"] = True
+
+    out_endpoints = []
+    for k, v in sorted(endpoints.items()):
+        out_endpoints.append({
+            "endpoint": k, "function": v["function"],
+            "vuln_classes": sorted(v["vuln_classes"]),
+            "max_severity": v["max_sev"],
+            "has_declared_mitigations": v["mitigations"],
+        })
+    return {
+        "endpoint_count": len(out_endpoints),
+        "endpoints": out_endpoints,
+        "total_hypotheses": len(sarif),
+        "inline_annotation_count": len(inline),
+    }
+
+
+# Free-text "METHOD /path" pattern for description-string fallback.
+_RE_ROUTE_IN_TEXT = re.compile(
+    r"\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(/[A-Za-z0-9/_\-\{\}\.:]*)"
+)
+
+# Route-definition patterns inside actual source files. We scan UP from the SARIF
+# line until we find one of these.
+_ROUTE_PATTERNS = [
+    # Express / Hono / Koa / Fastify / Restify:
+    # app.get('/api/foo', ...)   router.post("/x")
+    re.compile(r"""(?x)
+        (?:app|router|api|server|fastify|hono|koa)
+        \s*\.\s*
+        (get|post|put|patch|delete|head|options|all)
+        \s*\(\s*
+        ['"`]([^'"`]+)['"`]
+    """, re.IGNORECASE),
+    # Next.js App Router file-based routes: file path BECOMES the route.
+    # Caller should pass the file path; we handle that separately in extract_route_from_file.
+    # FastAPI / Flask: @app.get("/path") or @router.delete("/x/{id}")
+    re.compile(r"""(?x)
+        @(?:app|router|api)
+        \s*\.\s*
+        (get|post|put|patch|delete|head|options)
+        \s*\(\s*
+        ['"`]([^'"`]+)['"`]
+    """, re.IGNORECASE),
+]
+
+
+def _extract_route_from_source(file_path: str, line_number: Optional[int],
+                                 scan_radius: int = 60) -> Optional[tuple[str, str]]:
+    """Open the source file and scan within `scan_radius` lines of `line_number` for
+    an Express/Next/Hono/FastAPI route definition. Returns (METHOD, /path) or None.
+
+    Strategy: scan UPWARD from line_number first (route def is usually above the
+    handler body where the threat lives), then downward as a fallback.
+    """
+    try:
+        text = Path(file_path).read_text(errors="ignore")
+    except Exception:
+        return None
+    lines = text.splitlines()
+    if not lines:
+        return None
+
+    if line_number is None or line_number < 1:
+        # No anchor — just take the first route definition in the file
+        scan_lines = enumerate(lines, 1)
+        for _, line in scan_lines:
+            for rx in _ROUTE_PATTERNS:
+                m = rx.search(line)
+                if m:
+                    return (m.group(1).upper(), m.group(2))
+        return None
+
+    # Scan upward then downward from the anchor
+    center = min(line_number, len(lines)) - 1  # 0-indexed
+    upper_bound = max(0, center - scan_radius)
+    lower_bound = min(len(lines), center + scan_radius)
+
+    # Upward
+    for i in range(center, upper_bound - 1, -1):
+        for rx in _ROUTE_PATTERNS:
+            m = rx.search(lines[i])
+            if m:
+                return (m.group(1).upper(), m.group(2))
+    # Downward
+    for i in range(center + 1, lower_bound):
+        for rx in _ROUTE_PATTERNS:
+            m = rx.search(lines[i])
+            if m:
+                return (m.group(1).upper(), m.group(2))
+
+    return None
+
+
+def enrich_routes_by_function(hyps: list, codebase: Optional[Path] = None) -> list:
+    """For hypotheses missing http_method/http_path, fill them in by trying, in order:
+      1. Sibling hypothesis on the same function_name (most reliable)
+      2. Sibling on the same (file, line) — same source location, different threat
+      3. Regex over the free-text description (e.g. "POST /api/auth/login" mentioned)
+      4. Scan the source file at SARIF (file, line) for an Express/Next/Hono/Flask
+         route definition near that line — handles SARIFs that lack route metadata
+         entirely (upstream guardlink 1.4.3 output).
+
+    Fixes guardlink's habit of dropping route metadata on certain rule emissions.
+    """
+    # Indices for sibling lookup
+    route_by_func: dict[str, tuple[str, str]] = {}
+    route_by_loc: dict[tuple[str, int], tuple[str, str]] = {}
+    for h in hyps:
+        if not h.http_path:
+            continue
+        if h.function_name and h.function_name not in route_by_func:
+            route_by_func[h.function_name] = (h.http_method or "", h.http_path)
+        if h.file and h.line:
+            key = (h.file, h.line)
+            if key not in route_by_loc:
+                route_by_loc[key] = (h.http_method or "", h.http_path)
+
+    # File paths in SARIF can be either absolute (e.g. /Users/.../app/main.py) or
+    # relative to the codebase root (e.g. src/server/handlers/auth.js).
+    # We need both forms to attempt source-scrape.
+    def _resolve_file(f: str) -> Optional[Path]:
+        if not f:
+            return None
+        p = Path(f)
+        if p.is_absolute() and p.exists():
+            return p
+        if codebase:
+            p2 = codebase / f
+            if p2.exists():
+                return p2
+        return None
+
+    for h in hyps:
+        if h.http_path:
+            continue
+        # (1) same function_name
+        if h.function_name:
+            sib = route_by_func.get(h.function_name)
+            if sib:
+                h.http_method = h.http_method or sib[0]
+                h.http_path = sib[1]
+                continue
+        # (2) same source location
+        if h.file and h.line:
+            sib = route_by_loc.get((h.file, h.line))
+            if sib:
+                h.http_method = h.http_method or sib[0]
+                h.http_path = sib[1]
+                continue
+        # (3) regex over description text
+        m = _RE_ROUTE_IN_TEXT.search(h.description or "")
+        if m:
+            h.http_method = h.http_method or m.group(1)
+            h.http_path = m.group(2)
+            continue
+        # (4) source-scrape near SARIF (file, line)
+        resolved = _resolve_file(h.file)
+        if resolved is not None:
+            scraped = _extract_route_from_source(str(resolved), h.line)
+            if scraped:
+                h.http_method = h.http_method or scraped[0]
+                h.http_path = scraped[1]
+    return hyps
+
+
+def load(codebase: Path) -> tuple[list[Hypothesis], list[InlineAnnotation], dict]:
+    """One-call entry point: returns (sarif_hypotheses, inline_annotations, surface_summary).
+
+    Also attaches nearby @comment annotations to each Hypothesis so the AI has intent
+    context when generating probes and judging confirmation."""
+    sarif_path = codebase / "whitebox" / "findings.sarif"
+    sarif = parse_sarif(sarif_path) if sarif_path.exists() else []
+    inline = parse_inline(codebase)
+    sarif = enrich_routes_by_function(sarif, codebase=codebase)
+    sarif = attach_comments_to_hypotheses(sarif, inline)
+    surface = attack_surface(sarif, inline)
+    return sarif, inline, surface
+
+
+if __name__ == "__main__":
+    import sys
+    cb = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    sarif, inline, surface = load(cb)
+    print(f"SARIF hypotheses: {len(sarif)}")
+    print(f"Inline annotations: {len(inline)}")
+    print(f"Endpoints in attack surface: {surface['endpoint_count']}")
+    print()
+    for e in surface["endpoints"]:
+        mit = " [mitigated]" if e["has_declared_mitigations"] else ""
+        print(f"  [{e['max_severity']:8s}] {e['endpoint']:40s} {','.join(e['vuln_classes']):40s}{mit}")

--- a/pentest/js_engine.py
+++ b/pentest/js_engine.py
@@ -1,0 +1,690 @@
+"""JS template engine — runs JavaScript probe templates inside authenticated browser contexts.
+
+Template contract (copy-paste-able into DevTools console, ALSO runnable by cxg):
+
+    // @id: my-probe
+    // @vuln_class: idor
+    // @severity: high
+    // @requires_auth_count: 2
+    // @description: <one-liner>
+    async function cxgProbe(cxg) {
+        // cxg.profile       -> {name, label, index}
+        // cxg.profiles      -> [{name, label, index}, ...]   all identities in this run
+        // cxg.url(path)     -> full target URL
+        // cxg.fetch(path, opts)   -> fetch in THIS identity (auto-CSRF on mutations)
+        // cxg.fetchAs(idx, path, opts)  -> fetch in another identity (idx into cxg.profiles)
+        const findings = [];
+        // ... probe logic ...
+        return findings;     // [{id, severity, confirmed, endpoint, description, evidence, payload}]
+    }
+
+For DevTools console fallback (no cxg bridge), the template can detect:
+    const cxg = (typeof window.__cxg !== 'undefined') ? window.__cxg : { fetch, url:(p)=>p,
+        profile:{name:'console',label:'console',index:0}, profiles:[],
+        fetchAs:(i,p,o)=>fetch(p, {...o, credentials:'include'}) };
+
+cxg's runner wires up the real `window.__cxg` and the cxgProbe is called automatically.
+"""
+from __future__ import annotations
+import asyncio
+import json
+import re
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional, Any
+
+from auth import AuthProfile, load_profile
+from browser_engine import Finding
+from scope import ScopeGuard, ScopeConfig, ScopeError, HardKillSignal, AuditLog
+from validator import validate as validate_template
+from session_health import SessionHealthMonitor
+from mutator import classify as triage_classify, mutate_template
+
+
+_META_RX = re.compile(r"//\s*@(\w+):\s*(.*)")
+
+
+@dataclass
+class JsTemplate:
+    path: Path
+    source: str
+    meta: dict
+
+    @property
+    def vuln_class(self) -> str:
+        return self.meta.get("vuln_class", "unknown")
+
+    @property
+    def requires_auth_count(self) -> int:
+        try:
+            return int(self.meta.get("requires_auth_count", "1"))
+        except Exception:
+            return 1
+
+    @property
+    def id(self) -> str:
+        return self.meta.get("id", self.path.stem)
+
+    @property
+    def severity(self) -> str:
+        return self.meta.get("severity", "medium")
+
+
+def parse_template(path: Path) -> JsTemplate:
+    src = path.read_text()
+    meta = {}
+    for line in src.splitlines():
+        m = _META_RX.match(line.strip())
+        if m:
+            meta[m.group(1).lower()] = m.group(2).strip()
+    return JsTemplate(path=path, source=src, meta=meta)
+
+
+def load_templates(dir_path: Path) -> list[JsTemplate]:
+    if not dir_path.exists():
+        return []
+    out = []
+    for p in sorted(dir_path.glob("*.js")):
+        try:
+            out.append(parse_template(p))
+        except Exception as e:
+            print(f"  ⚠ failed to parse {p.name}: {e}")
+    return out
+
+
+@dataclass
+class EngineResults:
+    confirmed_findings: list[Finding] = field(default_factory=list)
+    mitigation_verifications: list[Finding] = field(default_factory=list)
+    ambiguous: list[Finding] = field(default_factory=list)
+    rejected_templates: list[dict] = field(default_factory=list)  # {id, reason}
+    dead_profiles: list[str] = field(default_factory=list)
+    scope_stats: dict = field(default_factory=dict)
+    hard_killed: bool = False
+    hard_kill_reason: str = ""
+    # IDs of original findings that were superseded by a mutation retry's definitive verdict.
+    # Used to suppress original-ambiguous-then-retry-succeeded noise from final output.
+    retried_then_resolved: list[str] = field(default_factory=list)
+
+
+class JsEngine:
+    """Runs JS templates against N parallel authenticated Chromium contexts.
+
+    Now with runtime intelligence:
+      - Template static validation BEFORE execution (validator.py)
+      - ScopeGuard on every request (scope.py)
+      - SessionHealthMonitor before each template, auto re-auth on death (session_health.py)
+      - Retry-with-mutation on AMBIGUOUS results (mutator.py)
+      - AuditLog of every HTTP request issued
+      - Split results into confirmed_findings vs mitigation_verifications
+    """
+
+    # Vuln classes where the meaningful probe target is a LOW-PRIVILEGE identity
+    # (admins can do everything by design; running these probes as admin proves nothing).
+    PRIVESC_LIKE_CLASSES = {
+        "idor", "privilege_escalation", "rate_limit_bypass",
+        "users_api", "records_api", "transactions_api",
+        "sensitive_data_exposure",   # "can a low-priv user see this?"
+        "security_events_api", "service_health_api", "stats_api",
+        "metrics_info_disclosure",
+        "csrf", "session_replay",
+    }
+
+    def __init__(self, target: str, profile_names: list[str], headless: bool = True,
+                 scope_cfg: Optional[ScopeConfig] = None,
+                 audit_log: Optional[AuditLog] = None,
+                 health_monitor: Optional[SessionHealthMonitor] = None,
+                 codebase: Optional[Path] = None,
+                 mutation_retries: int = 2,
+                 profile_infos: Optional[list] = None,
+                 oast_host: Optional[str] = None):
+        self.target = target.rstrip("/")
+        self.profiles = [load_profile(n) for n in profile_names]
+        self.headless = headless
+        self.scope = ScopeGuard(scope_cfg or ScopeConfig(target=target))
+        self.audit = audit_log
+        self.health = health_monitor
+        self.codebase = codebase
+        self.mutation_retries = mutation_retries
+        # Map profile name → tier so we can pick lowest-priv runner for privesc-like probes.
+        self.profile_tier: dict[str, int] = {}
+        if profile_infos:
+            for info in profile_infos:
+                self.profile_tier[info.profile_name] = getattr(info, "tier", 50)
+        self.oast_host = (oast_host or "").strip().rstrip("/")
+
+    async def _open_context(self, p, profile: AuthProfile, index: int):
+        browser = await p.chromium.launch(headless=self.headless)
+        ctx_kwargs = {"storage_state": profile.storage_state}
+        if getattr(profile, "extra_headers", None):
+            ctx_kwargs["extra_http_headers"] = profile.extra_headers
+        ctx = await browser.new_context(**ctx_kwargs)
+        page = await ctx.new_page()
+        try:
+            await page.goto(self.target, wait_until="domcontentloaded", timeout=15000)
+        except Exception as e:
+            print(f"[js-engine] warn: goto({self.target}) for {profile.name}: {e}")
+        return browser, ctx, page
+
+    async def _inject_cxg_bridge(self, page, ctx, profile, index, all_profiles, fetch_as_router,
+                                  current_template_id_ref):
+        """Expose Python helpers as page functions, then install window.__cxg.
+
+        current_template_id_ref is a single-element list that we mutate to track which
+        template is currently running, so the scope guard + audit log can tag requests.
+        """
+
+        async def _do_fetch_as(profile_idx: int, method: str, path: str,
+                               body: Any = None, headers: Optional[dict] = None) -> dict:
+            return await fetch_as_router(profile_idx, method, path, body, headers,
+                                         current_template_id_ref[0])
+
+        async def _scope_check(method: str, path: str) -> dict:
+            """JS-callable: scope guard. Returns {allowed, reason}."""
+            allowed, reason = self.scope.check_request(method, path)
+            return {"allowed": allowed, "reason": reason}
+
+        async def _record_response(status: int):
+            try:
+                self.scope.record_response(status)
+            except HardKillSignal as e:
+                # Propagate via setting a flag the JS can poll? Simpler: raise so
+                # Playwright surfaces it as an evaluate-side error.
+                raise
+            return None
+
+        async def _audit_request(method: str, url: str, status: int,
+                                 duration_ms: float, blocked_reason: str = ""):
+            if self.audit:
+                self.audit.request(profile.name, current_template_id_ref[0] or "?",
+                                   method, url, status, duration_ms, blocked_reason)
+            return None
+
+        # Cookie primitives — backed by Playwright ctx.cookies/add_cookies/clear_cookies.
+        # These bypass document.cookie so HttpOnly cookies (access_token etc.) ARE visible
+        # to templates, which unlocks session replay / fixation / cookie-manipulation probes.
+        async def _get_cookies():
+            return await ctx.cookies()
+
+        async def _get_cookies_as(profile_idx: int):
+            # Resolve the routed context via the same router used by fetchAs
+            return await fetch_as_router("__GET_COOKIES__", profile_idx, "", "", None,
+                                         current_template_id_ref[0])
+
+        async def _set_cookies(cookies: list):
+            if not isinstance(cookies, list):
+                return {"ok": False, "error": "cookies arg must be a list"}
+            try:
+                await ctx.clear_cookies()
+                await ctx.add_cookies(cookies)
+                return {"ok": True, "count": len(cookies)}
+            except Exception as e:
+                return {"ok": False, "error": str(e)}
+
+        async def _add_cookies(cookies: list):
+            if not isinstance(cookies, list):
+                return {"ok": False, "error": "cookies arg must be a list"}
+            try:
+                await ctx.add_cookies(cookies)
+                return {"ok": True, "count": len(cookies)}
+            except Exception as e:
+                return {"ok": False, "error": str(e)}
+
+        async def _clear_cookies():
+            try:
+                await ctx.clear_cookies()
+                return {"ok": True}
+            except Exception as e:
+                return {"ok": False, "error": str(e)}
+
+        # expose_function persists across navigations (Playwright binds at the context
+        # level), so we only set these once.
+        await page.expose_function("__cxg_fetchAs", _do_fetch_as)
+        await page.expose_function("__cxg_scope_check", _scope_check)
+        await page.expose_function("__cxg_record_response", _record_response)
+        await page.expose_function("__cxg_audit", _audit_request)
+        await page.expose_function("__cxg_get_cookies", _get_cookies)
+        await page.expose_function("__cxg_get_cookies_as", _get_cookies_as)
+        await page.expose_function("__cxg_set_cookies", _set_cookies)
+        await page.expose_function("__cxg_add_cookies", _add_cookies)
+        await page.expose_function("__cxg_clear_cookies", _clear_cookies)
+
+        bridge_js = """
+        (() => {
+            const TARGET = %s;
+            const PROFILE = %s;
+            const PROFILES = %s;
+
+            async function readCsrf() {
+                const m = document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);
+                return m ? decodeURIComponent(m[1]) : null;
+            }
+
+            async function cxgFetch(path, opts) {
+                opts = opts || {};
+                const headers = Object.assign({}, opts.headers || {});
+                const method = (opts.method || 'GET').toUpperCase();
+                const url = path.startsWith('http') ? path : TARGET + (path.startsWith('/') ? path : '/' + path);
+
+                // SCOPE CHECK (refused requests return a synthetic response, never hit the network).
+                const sc = await window.__cxg_scope_check(method, path);
+                if (!sc.allowed) {
+                    await window.__cxg_audit(method, url, 0, 0, sc.reason);
+                    return {status: 0, headers: {}, body_text: '', body_json: null,
+                            blocked: true, blocked_reason: sc.reason};
+                }
+
+                if (['POST','PUT','PATCH','DELETE'].includes(method)) {
+                    const csrf = await readCsrf();
+                    if (csrf && !headers['X-CSRF-Token']) headers['X-CSRF-Token'] = csrf;
+                }
+                if (opts.body && typeof opts.body !== 'string') {
+                    opts.body = JSON.stringify(opts.body);
+                    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+                }
+                const t0 = performance.now();
+                const r = await fetch(url, Object.assign({}, opts, {credentials: 'include', headers}));
+                const dur = performance.now() - t0;
+                const text = await r.text();
+                let bodyJson = null; try { bodyJson = JSON.parse(text); } catch(e){}
+                const respHeaders = {}; r.headers.forEach((v,k)=>respHeaders[k]=v);
+                await window.__cxg_record_response(r.status);
+                await window.__cxg_audit(method, url, r.status, dur, '');
+                return {status: r.status, headers: respHeaders, body_text: text, body_json: bodyJson};
+            }
+
+            async function cxgFetchAs(idx, path, opts) {
+                opts = opts || {};
+                const method = (opts.method || 'GET').toUpperCase();
+                const body = (opts.body && typeof opts.body !== 'string')
+                    ? opts.body
+                    : (typeof opts.body === 'string' ? (function(){try{return JSON.parse(opts.body);}catch(e){return opts.body;}})() : null);
+                return await window.__cxg_fetchAs(idx, method, path, body, opts.headers || null);
+            }
+
+            // Cookie primitives — Playwright-backed, so HttpOnly cookies ARE accessible.
+            // Returns: [{name, value, domain, path, expires, httpOnly, secure, sameSite}]
+            async function cxgGetCookies() { return await window.__cxg_get_cookies(); }
+            async function cxgGetCookiesAs(idx) { return await window.__cxg_get_cookies_as(idx); }
+            // Convenience: find a cookie by name in the current context
+            async function cxgGetCookie(name) {
+                const all = await cxgGetCookies();
+                return all.find(c => c.name === name) || null;
+            }
+            // setCookies REPLACES the entire jar; addCookies merges; clearCookies empties.
+            async function cxgSetCookies(cookies) { return await window.__cxg_set_cookies(cookies); }
+            async function cxgAddCookies(cookies) { return await window.__cxg_add_cookies(cookies); }
+            async function cxgClearCookies() { return await window.__cxg_clear_cookies(); }
+
+            const OAST_HOST = %s;  // empty string if --oast not given
+
+            // OOB callback URL builder. Returns null when no oast host is configured —
+            // templates that depend on OOB confirmation should check for null and
+            // skip-with-AMBIGUOUS rather than fabricate confirmation from timing alone.
+            //
+            //   cxg.oast.url('ssrf-1')       -> 'http://ssrf-1.<host>'
+            //   cxg.oast.url('xxe', 'https') -> 'https://xxe.<host>'
+            //   cxg.oast.available           -> true if --oast was passed
+            const cxgOast = {
+                host: OAST_HOST || null,
+                available: !!OAST_HOST,
+                url: function(label, scheme) {
+                    if (!OAST_HOST) return null;
+                    const s = scheme || 'http';
+                    // sanitize label: only [a-z0-9-], collapse runs
+                    const safeLabel = String(label || 'probe').toLowerCase()
+                        .replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40)
+                        || 'probe';
+                    return s + '://' + safeLabel + '.' + OAST_HOST;
+                },
+            };
+
+            window.__cxg = {
+                profile: PROFILE,
+                profiles: PROFILES,
+                url: (p) => p.startsWith('http') ? p : TARGET + (p.startsWith('/') ? p : '/' + p),
+                fetch: cxgFetch,
+                fetchAs: cxgFetchAs,
+                // Cookie API (HttpOnly-aware — uses Playwright cookie jar, not document.cookie)
+                getCookies: cxgGetCookies,
+                getCookiesAs: cxgGetCookiesAs,
+                getCookie: cxgGetCookie,
+                setCookies: cxgSetCookies,
+                addCookies: cxgAddCookies,
+                clearCookies: cxgClearCookies,
+                // Out-of-band callback host for blind-vuln confirmation (SSRF, blind SQLi,
+                // blind XXE, blind cmd injection). null when --oast was not passed.
+                oast: cxgOast,
+            };
+        })();
+        """ % (
+            json.dumps(self.target),
+            json.dumps({"name": profile.name, "label": profile.label, "index": index}),
+            json.dumps([{"name": p.name, "label": p.label, "index": i} for i, p in enumerate(all_profiles)]),
+            json.dumps(self.oast_host or ""),
+        )
+        # CRITICAL: install the bridge as an init-script so it survives every navigation
+        # (the session-health landing test does page.goto() between templates, which would
+        # otherwise destroy window.__cxg).
+        try:
+            await page.add_init_script(bridge_js)
+        except Exception as e:
+            print(f"  ⚠ add_init_script for bridge failed: {e}")
+        # Also evaluate once for the CURRENT page (add_init_script only fires on next nav).
+        await page.evaluate(bridge_js)
+        # Stash for _ensure_bridge defensive re-eval
+        if not hasattr(self, "_bridge_stash"):
+            self._bridge_stash = {}
+        self._bridge_stash[id(page)] = bridge_js
+
+    async def _ensure_bridge(self, page):
+        """If window.__cxg has been wiped by a navigation, re-evaluate the bridge JS.
+        Cheap idempotent check; safe to call before every template run."""
+        try:
+            has_bridge = await page.evaluate(
+                "() => typeof window.__cxg === 'object' && typeof window.__cxg.fetch === 'function'"
+            )
+        except Exception:
+            has_bridge = False
+        if not has_bridge:
+            # The bridge JS is stored on the engine when first installed; we keep a copy
+            # so we can re-inject without rebuilding it.
+            stash = getattr(self, "_bridge_stash", {}).get(id(page))
+            if stash:
+                try:
+                    await page.evaluate(stash)
+                except Exception as e:
+                    print(f"  ⚠ bridge re-eval failed: {e}")
+
+    async def _evaluate_template(self, page, tpl: JsTemplate) -> list[dict]:
+        # Run the template body, then call cxgProbe(window.__cxg) and return the result.
+        wrapper = """
+        async () => {
+            try {
+                %s
+                if (typeof cxgProbe !== 'function') {
+                    return {__cxg_err: 'template did not define async function cxgProbe(cxg)'};
+                }
+                const result = await cxgProbe(window.__cxg);
+                return {__cxg_ok: true, findings: result || []};
+            } catch (e) {
+                return {__cxg_err: String(e && e.stack || e)};
+            }
+        }
+        """ % tpl.source
+        result = await page.evaluate(wrapper)
+        if result.get("__cxg_err"):
+            print(f"  ✗ template {tpl.id} threw: {result['__cxg_err'][:300]}")
+            return []
+        return result.get("findings", []) or []
+
+    def _finding_from_dict(self, f: dict, tpl: JsTemplate) -> Finding:
+        return Finding(
+            id=f.get("id") or f"{tpl.vuln_class}-finding",
+            vuln_class=f.get("vuln_class") or tpl.vuln_class,
+            severity=f.get("severity") or tpl.severity,
+            confirmed=bool(f.get("confirmed", False)),
+            target=self.target,
+            endpoint=f.get("endpoint", ""),
+            description=f.get("description", ""),
+            evidence=f.get("evidence", {}) or {},
+            payload=str(f.get("payload")) if f.get("payload") is not None else None,
+            hypothesis_id=tpl.id,
+        )
+
+    async def _run_single_template(self, runner_page, tpl: JsTemplate,
+                                    current_id_ref: list, results: EngineResults,
+                                    seen_finding_ids: set, contexts: list,
+                                    retry_count: int = 0) -> None:
+        """Run one template (or a mutated retry). Updates results in-place."""
+        current_id_ref[0] = tpl.id
+        # AUDIT: template start
+        if self.audit:
+            self.audit.request("engine", tpl.id, "TEMPLATE_START", "", 0, 0)
+
+        try:
+            raw_findings = await self._evaluate_template(runner_page, tpl)
+        except HardKillSignal as e:
+            results.hard_killed = True
+            results.hard_kill_reason = str(e)
+            print(f"  ⛔ HARD KILL: {e}")
+            raise
+        except Exception as e:
+            print(f"  ✗ template {tpl.id} raised: {e}")
+            return
+
+        for f in raw_findings:
+            fid = f.get("id") or f"{tpl.vuln_class}-finding"
+            # tag retries with suffix so retried+original aren't dedup-collided
+            if retry_count > 0:
+                fid = f"{fid}-retry{retry_count}"
+                f["id"] = fid
+            if fid in seen_finding_ids:
+                continue
+            seen_finding_ids.add(fid)
+            finding = self._finding_from_dict(f, tpl)
+            verdict = triage_classify(f)
+            if self.audit:
+                self.audit.finding({**finding.to_dict(), "triage": verdict.kind, "triage_reason": verdict.reason})
+
+            # Helper: if this finding is from a retry AND lands as a definitive verdict,
+            # remove the original ambiguous sibling (same base id) from results.ambiguous.
+            def _suppress_original_if_retry(definitive_finding: Finding):
+                if not definitive_finding.id.endswith(("-retry1", "-retry2", "-retry3")):
+                    return
+                # Extract base id by stripping the -retryN suffix
+                base = re.sub(r"-retry\d+$", "", definitive_finding.id)
+                kept = []
+                removed_any = False
+                for f in results.ambiguous:
+                    if f.id == base:
+                        results.retried_then_resolved.append(base)
+                        removed_any = True
+                        continue
+                    kept.append(f)
+                if removed_any:
+                    results.ambiguous = kept
+                    print(f"    ⓘ suppressed original ambiguous '{base}' "
+                          f"(retry produced definitive verdict)")
+
+            if verdict.kind == "confirmed":
+                results.confirmed_findings.append(finding)
+                _suppress_original_if_retry(finding)
+                print(f"    [CONFIRMED] {finding.vuln_class:25s} {finding.endpoint} — {verdict.reason}")
+            elif verdict.kind == "refuted":
+                results.mitigation_verifications.append(finding)
+                _suppress_original_if_retry(finding)
+                print(f"    [REFUTED  ] {finding.vuln_class:25s} {finding.endpoint} — {verdict.reason}")
+            else:
+                # AMBIGUOUS — maybe retry
+                results.ambiguous.append(finding)
+                rk = getattr(verdict, "reason_kind", "unknown")
+                tag = f"[AMBIGUOUS:{rk}]"
+                print(f"    {tag} {finding.vuln_class:25s} {finding.endpoint} — {verdict.reason}")
+                # Environment-bound ambiguity isn't fixable by re-prompting AI — skip the loop.
+                if rk == "environment":
+                    print(f"    ⓘ skipping mutation: cause is environmental, not payload-shaped")
+                    continue
+                if (retry_count < self.mutation_retries
+                        and self.codebase is not None
+                        and self.codebase.exists()):
+                    mutated_src = mutate_template(
+                        tpl.source, f, verdict, self.codebase, tpl.id,
+                    )
+                    if mutated_src:
+                        # build a temp JsTemplate for the mutation, run it through the same path
+                        from tempfile import NamedTemporaryFile
+                        tmp = NamedTemporaryFile(mode="w", suffix=".js", delete=False)
+                        tmp.write(mutated_src); tmp.close()
+                        mutated_tpl = parse_template(Path(tmp.name))
+                        # Validate the mutation BEFORE running it
+                        vr = validate_template(mutated_src, destructive_ok=self.scope.cfg.destructive_ok)
+                        if not vr.ok:
+                            print(f"    ⚠ mutation rejected by validator: {vr.errors[0] if vr.errors else 'unknown'}")
+                            continue
+                        print(f"    ↻ retry #{retry_count+1} with mutated template")
+                        await self._run_single_template(
+                            runner_page, mutated_tpl, current_id_ref, results,
+                            seen_finding_ids, contexts, retry_count + 1,
+                        )
+
+    async def run(self, templates: list[JsTemplate]) -> EngineResults:
+        from playwright.async_api import async_playwright
+
+        results = EngineResults()
+
+        # 1. Pre-validate templates — drop bad ones before opening browsers
+        validated: list[JsTemplate] = []
+        for tpl in templates:
+            vr = validate_template(tpl.source, destructive_ok=self.scope.cfg.destructive_ok)
+            if not vr.ok:
+                reason = "; ".join(vr.errors)
+                print(f"  ✗ REJECT template {tpl.id}: {reason}")
+                results.rejected_templates.append({"id": tpl.id, "path": str(tpl.path),
+                                                    "errors": vr.errors, "warnings": vr.warnings})
+                continue
+            if vr.warnings:
+                for w in vr.warnings:
+                    print(f"  ⚠ {tpl.id}: {w}")
+            validated.append(tpl)
+        print(f"  validated {len(validated)}/{len(templates)} templates")
+        if not validated:
+            return results
+
+        async with async_playwright() as p:
+            contexts = []
+            for i, prof in enumerate(self.profiles):
+                browser, ctx, page = await self._open_context(p, prof, i)
+                contexts.append({"browser": browser, "ctx": ctx, "page": page, "profile": prof, "index": i})
+
+            current_id_ref = [""]  # mutable closure-shared
+
+            async def fetch_as_router(profile_idx, method: str, path: str,
+                                      body: Any, headers: Optional[dict],
+                                      template_id: str) -> Any:
+                # First arg may be a virtual sentinel (str "__GET_COOKIES__") for cookie-as ops.
+                # In that case profile_idx is in the second position (method slot).
+                if isinstance(profile_idx, str) and profile_idx == "__GET_COOKIES__":
+                    real_idx = method if isinstance(method, int) else 0
+                    if real_idx < 0 or real_idx >= len(contexts):
+                        return []
+                    try:
+                        return await contexts[real_idx]["ctx"].cookies()
+                    except Exception:
+                        return []
+                if profile_idx < 0 or profile_idx >= len(contexts):
+                    return {"status": 0, "error": f"invalid profile index {profile_idx}"}
+                # scope check the cross-context call too
+                allowed, reason = self.scope.check_request(method, path)
+                if not allowed:
+                    if self.audit:
+                        self.audit.request(contexts[profile_idx]["profile"].name, template_id,
+                                           method, self.target + path, 0, 0, reason)
+                    return {"status": 0, "blocked": True, "blocked_reason": reason,
+                            "body_text": "", "body_json": None, "headers": {}}
+                tgt = contexts[profile_idx]
+                t0 = time.time()
+                result = await tgt["page"].evaluate(
+                    """async ({url, method, body, headers}) => {
+                        const opts = {method, credentials:'include', headers: headers || {}};
+                        if (['POST','PUT','PATCH','DELETE'].includes(method)) {
+                            const m = document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);
+                            if (m && !opts.headers['X-CSRF-Token']) opts.headers['X-CSRF-Token']=decodeURIComponent(m[1]);
+                        }
+                        if (body !== null && body !== undefined) {
+                            opts.headers['Content-Type'] = opts.headers['Content-Type'] || 'application/json';
+                            opts.body = (typeof body === 'string') ? body : JSON.stringify(body);
+                        }
+                        const r = await fetch(url, opts);
+                        const text = await r.text();
+                        const respHeaders = {}; r.headers.forEach((v,k)=>respHeaders[k]=v);
+                        let j = null; try { j = JSON.parse(text); } catch(e){}
+                        return {status:r.status, headers:respHeaders, body_text:text, body_json:j};
+                    }""",
+                    {"url": self.target + (path if path.startswith("/") else "/" + path),
+                     "method": method, "body": body, "headers": headers or {}},
+                )
+                dur_ms = (time.time() - t0) * 1000
+                try:
+                    self.scope.record_response(result.get("status", 0))
+                except HardKillSignal:
+                    raise
+                if self.audit:
+                    self.audit.request(tgt["profile"].name, template_id, method,
+                                       self.target + path, result.get("status", 0), dur_ms, "")
+                return result
+
+            try:
+                for c in contexts:
+                    await self._inject_cxg_bridge(c["page"], c["ctx"], c["profile"],
+                                                  c["index"], self.profiles, fetch_as_router,
+                                                  current_id_ref)
+
+                def _prio(t):
+                    try: return int(t.meta.get("destructive_priority", "0"))
+                    except: return 0
+                templates_sorted = sorted(validated, key=_prio)
+
+                seen_finding_ids: set[str] = set()
+                for tpl in templates_sorted:
+                    need = tpl.requires_auth_count
+                    if need > len(contexts):
+                        print(f"  · skip {tpl.id}: needs {need} auth ctxs, have {len(contexts)}")
+                        continue
+
+                    # HEALTH CHECK before each template
+                    if self.health is not None:
+                        for c in contexts[:need]:
+                            pseudo = type("P", (), {"page": c["page"], "ctx": c["ctx"], "profile": c["profile"]})
+                            alive, msg = await self.health.ensure_alive(pseudo)
+                            if not alive:
+                                print(f"    ⚠ profile {c['profile'].name} dead: {msg}")
+                                if c["profile"].name not in results.dead_profiles:
+                                    results.dead_profiles.append(c["profile"].name)
+                        # Skip template if any required profile is dead
+                        if any(c["profile"].name in results.dead_profiles for c in contexts[:need]):
+                            print(f"  · skip {tpl.id}: required profile(s) dead")
+                            continue
+
+                    # Smart runner selection: for privesc-like probes, run as the
+                    # LOWEST-tier authenticated identity available so the test is
+                    # actually meaningful. Admins can do everything by design —
+                    # checking "can admin escalate" proves nothing.
+                    runner = contexts[0]
+                    runner_reason = "default first profile"
+                    # Defensive: re-ensure the JS bridge is present on the runner page.
+                    # The session-health landing test does a page.goto() which can wipe
+                    # window.__cxg unless add_init_script ran during the navigation.
+                    for c in contexts:
+                        await self._ensure_bridge(c["page"])
+                    if tpl.vuln_class in self.PRIVESC_LIKE_CLASSES and self.profile_tier:
+                        # rank contexts by tier ascending; pick the lowest
+                        eligible = [(self.profile_tier.get(c["profile"].name, 50), c)
+                                    for c in contexts[:need + max(0, len(contexts) - need)]]
+                        eligible.sort(key=lambda x: x[0])
+                        if eligible:
+                            runner = eligible[0][1]
+                            runner_reason = f"lowest tier ({eligible[0][0]}) for {tpl.vuln_class}"
+                    print(f"  ▶ {tpl.id} (vuln_class={tpl.vuln_class}) as "
+                          f"{runner['profile'].label or runner['profile'].name} [{runner_reason}]")
+                    # Each context already had the bridge installed at startup with its OWN
+                    # cxg.profile, so picking runner = contexts[2] automatically gives the
+                    # template the correct identity in window.__cxg.profile.
+
+                    try:
+                        await self._run_single_template(
+                            runner["page"], tpl, current_id_ref, results,
+                            seen_finding_ids, contexts, retry_count=0,
+                        )
+                    except HardKillSignal:
+                        break  # already populated results.hard_killed
+            finally:
+                for c in contexts:
+                    try:
+                        await c["browser"].close()
+                    except Exception:
+                        pass
+
+        results.scope_stats = self.scope.stats()
+        return results

--- a/pentest/js_generator.py
+++ b/pentest/js_generator.py
@@ -1,0 +1,517 @@
+"""Generate JS pentest templates by invoking claude CLI (or other CLI provider) inside
+the target codebase directory.
+
+Key trick: we run `claude --print --cwd <codebase>` so claude uses its own Read/Grep/Glob
+tools to inspect source. This is the whitebox part — the AI sees the actual code, not
+just guardlink summaries.
+
+Each template is saved as a real .js file with a meta header (id, vuln_class, severity,
+requires_auth_count) so it's copy-paste-runnable in DevTools AND consumable by js_engine.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+
+TEMPLATE_ROOT = Path.home() / ".cert-x-gen" / "templates"
+
+
+SYSTEM_PROMPT = """\
+You are a pentest payload author working inside cert-x-gen. You are running inside a
+target application's source code directory. You can read files freely with your Read,
+Grep, and Glob tools to understand the actual code before writing payloads.
+
+Your job:
+  Given (1) a natural-language pentest goal from the operator,
+        (2) one guardlink hypothesis (vuln class, route, function, severity),
+  output ONE JavaScript template that probes whether the vuln is exploitable at runtime
+  in an authenticated browser session.
+
+The template MUST follow this exact shape (so it's runnable both inside cxg's JS engine
+AND copy-paste-able into the browser DevTools console):
+
+```javascript
+// @id: <kebab-case unique id matching the threat>
+// @vuln_class: <normalized class: idor | csrf | xss | privilege_escalation | sensitive_data_exposure | rate_limit_bypass | session_replay | metrics_info_disclosure | ssrf | command_injection | clickjacking>
+// @severity: <low | medium | high | critical>
+// @requires_auth_count: <1 or 2>      -- use 2 for chained-auth probes (IDOR, etc.)
+// @destructive_priority: <0..100>     -- 0=read-only, 100=session-killing (logout etc.)
+// @description: <one-line summary>
+
+async function cxgProbe(cxg) {
+    // cxg.profile         -> {name, label, index}  current identity
+    // cxg.profiles        -> [{name,label,index},...] all identities in this run
+    // cxg.url(path)       -> full target URL helper
+    // cxg.fetch(path, opts)         -> fetch in THIS identity; auto-includes X-CSRF-Token
+    //                                  on POST/PUT/PATCH/DELETE.
+    //                                  Returns {status, headers, body_text, body_json}
+    // cxg.fetchAs(idx, path, opts)  -> fetch in another identity's context (cross-session)
+    //
+    // Cookie primitives (HttpOnly-aware — backed by Playwright cookie jar, NOT document.cookie):
+    // cxg.getCookies()              -> [{name, value, domain, path, httpOnly, secure, sameSite, ...}]
+    // cxg.getCookiesAs(idx)         -> same, for another identity
+    // cxg.getCookie(name)           -> single cookie or null
+    // cxg.setCookies(arr)           -> REPLACE entire jar with arr; returns {ok, count}
+    // cxg.addCookies(arr)           -> MERGE arr into existing jar
+    // cxg.clearCookies()            -> empty the jar
+    //
+    // For session-replay / cookie-theft tests: capture a cookie with cxg.getCookie('access_token'),
+    // then logout, then cxg.addCookies([capturedCookie]) and re-issue a request — if the response
+    // is 200 the server-side revocation is broken.
+    //
+    // OUT-OF-BAND CALLBACK API (cxg.oast) — definitive blind-vuln confirmation:
+    // cxg.oast.available             -> true iff --oast was passed by the operator
+    // cxg.oast.host                  -> the OAST hostname, or null
+    // cxg.oast.url(label, scheme?)   -> "http://<label>.<host>" (default scheme 'http')
+    //
+    // Use for SSRF, blind SQLi, blind XXE, blind cmd injection, log4shell-style probes:
+    //   1. Plant cxg.oast.url('ssrf-attack1') into the payload sink.
+    //   2. After response, the operator (or pollOast(), see below) checks if the OAST
+    //      server received a callback for label 'ssrf-attack1'.
+    //   3. Callback received = DEFINITIVE confirmed=true. No callback = mark
+    //      confirmed=false (server may not have made the outbound request).
+    //
+    // IF cxg.oast.available IS FALSE: blind-vuln probes should mark confirmed=false
+    // with description="OAST host not configured — re-run with --oast <host> to confirm"
+    // (reason_kind=environment). DO NOT fabricate confirmation from timing alone.
+    //
+    // Return an array of findings. Each finding:
+    //   {id, vuln_class, severity, confirmed: bool, endpoint, description, evidence, payload}
+    //
+    // Mark confirmed=true ONLY when you have direct proof (correct response payload, not
+    // just a status code that could mean anything). For ambiguous results, return
+    // confirmed=false with a description explaining what would confirm it.
+
+    const findings = [];
+
+    // ... your probe logic ...
+
+    return findings;
+}
+```
+
+HARD RULES (violations = template rejected):
+1. NEVER send DELETE/PUT/PATCH against any path matching /admin, /reset, /wipe, /purge,
+   /drop, /destroy. If guardlink suggests a destructive route, observe with GET only.
+2. NEVER send more than 30 requests TOTAL per probe run.
+3. NEVER define non-cxgProbe functions (no helpers at top level — keep state inside cxgProbe).
+4. Use cxg.fetch / cxg.fetchAs ONLY. Do not use raw fetch() — credentials/CSRF wiring
+   won't be right.
+4a. For session-replay / cookie tests, ALWAYS use cxg.getCookie/getCookies, NEVER
+    document.cookie (HttpOnly cookies are invisible to document.cookie by browser design;
+    cxg.getCookies routes through Playwright and IS HttpOnly-aware).
+5. For mass-assignment / role-elevation probes: send a benign payload first (no privileged
+   fields) to confirm the route exists and accepts your identity, THEN send the privileged
+   payload. This avoids the 422-validation-reject trap (where the body fails Pydantic
+   before the auth/RBAC logic runs).
+6. For rate-limit / brute-force probes: use a VALID email format (e.g. user+probe@gmail.com)
+   so request bodies pass schema validation and actually exercise the auth path. Otherwise
+   you're just measuring the schema validator's throughput.
+7. INTENT MATTERS — RESPECT @comment ANNOTATIONS: if the hypothesis includes a "Nearby
+   @comment" block that says the exposure is by-design ("operational feature", "authenticated
+   admin/analyst view by design", "not a public endpoint"), DO NOT declare it a CONFIRMED
+   high-severity vuln. The right verdict in those cases is:
+     - confirmed=true severity=info if you want to surface "data is reachable as documented"
+     - OR don't emit a finding at all, return [] — guardlink already knows about it.
+   If the @comment indicates a STRICTER policy than the code shows (e.g. comment says
+   admin-only but code allows analyst), THAT discrepancy IS a real finding.
+8. BLIND-VULN CONFIRMATION RULE: for vuln_class in {ssrf, blind_sqli, blind_xxe,
+   command_injection, blind_ssti, log4shell}: confirmed=true REQUIRES one of:
+   (a) Direct evidence in the response (echo, leaked file contents, etc.) — strongest, OR
+   (b) An OAST callback via cxg.oast.url('label') — definitive, OR
+   (c) Two independent timing measurements with clear separation (≥3σ from baseline).
+   Status codes alone (502, 504, 200) are NOT confirmation. 502 on attacker host while
+   localhost gets 403 is suggestive but should be confirmed=false until OAST callback or
+   echo is observed. If cxg.oast.available is false, emit confirmed=false with
+   description="OAST not configured — pass --oast <interactsh-host> to definitively confirm".
+
+READING THE CODEBASE:
+Before writing the probe, use your Read/Grep/Glob tools to:
+- Find the route handler matching the guardlink hypothesis.
+- Identify the request schema (which fields are required/optional/forbidden).
+- Identify the response shape (so you know what to assert on).
+- Identify any declared @mitigates that's supposed to block the attack — your probe
+  should specifically test that the mitigation actually holds, not just guess.
+
+OUTPUT FORMAT:
+Return ONLY the JavaScript code block (```javascript ... ```). No prose, no commentary,
+no second code block.
+"""
+
+
+def _cache_key(hypothesis, goal: str) -> str:
+    payload = json.dumps({
+        "vuln_class": hypothesis.vuln_class,
+        "http_method": hypothesis.http_method,
+        "http_path": hypothesis.http_path,
+        "function_name": hypothesis.function_name,
+        "goal": goal or "",
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:12]
+
+
+def _extract_js_block(text: str) -> Optional[str]:
+    m = re.search(r"```(?:javascript|js)\s*\n(.*?)```", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    # Fallback: any fenced block
+    m = re.search(r"```\s*\n(.*?)```", text, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def _cli_generate(codebase: Path, system: str, user: str,
+                   provider: str = "claude", timeout_s: int = 240) -> str:
+    """Invoke a CLI AI provider with cwd=codebase so it can read source via its own tools.
+
+    Supported providers: claude, codex, gemini. Each is run with a hard subprocess timeout
+    (kills the whole process tree if it hangs).
+    """
+    import os
+    import signal
+
+    bin_ = shutil.which(provider)
+    if not bin_:
+        raise RuntimeError(f"{provider} CLI not on PATH")
+    prompt = f"{system}\n\n--- TASK ---\n\n{user}"
+
+    if provider == "claude":
+        argv = [bin_, "--print", "--permission-mode", "acceptEdits", prompt]
+    elif provider == "codex":
+        argv = [bin_, "exec", "--skip-git-repo-check", "--sandbox", "read-only", prompt]
+    elif provider == "gemini":
+        argv = [bin_, "--prompt", prompt]
+    else:
+        raise RuntimeError(f"unsupported AI provider: {provider}")
+
+    # Use Popen + own process group so we can SIGTERM the whole tree on timeout
+    # (subprocess.run's timeout only kills the immediate child; wrapper scripts and
+    # subprocess-of-subprocess workers like claude's tool-use loop survive).
+    try:
+        p = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             cwd=str(codebase), text=True, start_new_session=True)
+        try:
+            out, err = p.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            # SIGTERM the whole group, then SIGKILL if it didn't die
+            try:
+                os.killpg(p.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                out, err = p.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(p.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                out, err = "", ""
+            raise RuntimeError(f"{provider} CLI timed out after {timeout_s}s")
+    except FileNotFoundError as e:
+        raise RuntimeError(f"{provider} CLI failed to spawn: {e}")
+
+    if p.returncode != 0:
+        raise RuntimeError(f"{provider} CLI rc={p.returncode}: {(err or '').strip()[:400]}")
+    return out
+
+
+def _claude_cli_generate(codebase: Path, system: str, user: str, timeout_s: int = 240) -> str:
+    """Back-compat alias."""
+    return _cli_generate(codebase, system, user, provider="claude", timeout_s=timeout_s)
+
+
+def generate_js_template(codebase: Path, session_dir: Path, hypothesis, goal: str,
+                         provider: str = "claude", timeout_s: int = 240) -> Optional[Path]:
+    """Generate a JS template for one hypothesis. Returns Path to the saved .js file.
+
+    provider: one of 'claude' | 'codex' | 'gemini' — honors --ai-provider.
+    timeout_s: hard wall-clock cap. If exceeded the whole process tree is killed.
+    """
+    session_dir.mkdir(parents=True, exist_ok=True)
+    key = _cache_key(hypothesis, goal)
+    fname = f"{hypothesis.vuln_class}-{key}.js"
+    out_path = session_dir / fname
+    if out_path.exists():
+        return out_path  # cached
+
+    comments = getattr(hypothesis, "nearby_comments", []) or []
+    comments_block = ""
+    if comments:
+        joined = "\n".join(f"  - {c}" for c in comments)
+        comments_block = (
+            f"\n## Nearby @comment annotations (INTENT context — read carefully)\n"
+            f"These free-text notes were placed near the route handler by the codebase\n"
+            f"authors to explain INTENT. They are critical for telling design from bug.\n"
+            f"If a comment says the exposure is by-design (operational feature, etc.),\n"
+            f"DO NOT flag a CONFIRMED high-severity vuln; see HARD RULE #7.\n"
+            f"{joined}\n"
+        )
+
+    user_msg = (
+        f"## Operator goal (natural language)\n{goal or '(no specific goal — broad coverage)'}\n\n"
+        f"## Guardlink hypothesis\n"
+        f"- vuln_class: {hypothesis.vuln_class}\n"
+        f"- threat: {hypothesis.threat}\n"
+        f"- http_method: {hypothesis.http_method}\n"
+        f"- http_path: {hypothesis.http_path}\n"
+        f"- function_name: {hypothesis.function_name}\n"
+        f"- severity: {hypothesis.severity}\n"
+        f"- cwe: {hypothesis.cwe}\n"
+        f"- description: {hypothesis.description}\n"
+        f"- has_mitigation_declared: {hypothesis.has_mitigation_declared}\n"
+        f"{comments_block}\n"
+        f"Read the codebase to understand the route handler and any declared @mitigates,\n"
+        f"then write the JS template per the contract."
+    )
+
+    print(f"  ⚙  generating ({provider}, timeout={timeout_s}s): {hypothesis.vuln_class:25s} "
+          f"{hypothesis.http_method or '?'} {hypothesis.http_path or '?'}", flush=True)
+    t0 = time.time()
+    try:
+        raw = _cli_generate(codebase, SYSTEM_PROMPT, user_msg, provider=provider, timeout_s=timeout_s)
+    except RuntimeError as e:
+        elapsed = time.time() - t0
+        print(f"  ✗ {hypothesis.vuln_class}: {e} ({elapsed:.1f}s)")
+        return None
+    elapsed = time.time() - t0
+    js = _extract_js_block(raw)
+    if not js:
+        print(f"  ✗ {hypothesis.vuln_class}: no JS block in {provider} output ({len(raw)} chars, {elapsed:.1f}s)")
+        return None
+    out_path.write_text(js)
+    print(f"  ✓ {hypothesis.vuln_class} → {out_path.name} ({len(js)} chars, {elapsed:.1f}s)")
+    return out_path
+
+
+RANKING_PROMPT = """\
+You are triaging a list of guardlink-emitted vulnerability hypotheses for a pentest engagement.
+The operator wants you to PICK THE %(top_n)d MOST IMPORTANT hypotheses to test, based on the
+stated goal AND the captured identities (you can only verify a vuln you have the right
+identity for).
+
+Operator goal: %(goal)s
+
+%(profile_context)s
+
+For each hypothesis below, output one line: "<index> <score>" where score is 0-10.
+
+Score 0 = irrelevant to goal, fully mitigated, OR UNFALSIFIABLE with the captured identities
+         (e.g. IDOR/horizontal-privesc when only one identity is captured; admin-only-bypass
+         when no low-priv identity is captured)
+Score 10 = directly matches goal, no declared mitigation, AND the captured identities
+          can decisively prove or refute it
+Boost: severity, no declared mitigation, vuln_class explicitly mentioned in goal,
+       identity coverage matches the probe's needs.
+Penalize: vuln class outside goal, already mitigated by declared @mitigates,
+          missing identity tier required to test it.
+
+Output format (one per line, no extra text):
+0 7
+1 3
+2 9
+...
+
+Hypotheses:
+%(hypotheses)s
+"""
+
+
+def _format_profile_context(profile_infos: list) -> str:
+    """Build the profile context block injected into the ranking prompt."""
+    if not profile_infos:
+        return "Captured identities: (none — running on bare guardlink data)"
+    lines = ["Captured identities:"]
+    for info in profile_infos:
+        if not info.alive:
+            lines.append(f"  - {info.profile_name} (DEAD: status={info.me_status})")
+            continue
+        bits = [info.profile_name]
+        if info.role:
+            bits.append(f"role={info.role}")
+        if info.email:
+            bits.append(f"({info.email})")
+        if info.tier:
+            bits.append(f"tier={info.tier}")
+        lines.append(f"  - {' '.join(bits)}")
+    # Coverage warnings
+    has_low = any(getattr(i, "tier", 0) <= 30 and i.alive for i in profile_infos)
+    has_high = any(getattr(i, "tier", 0) > 70 and i.alive for i in profile_infos)
+    if not has_low:
+        lines.append("  ⚠ no LOW-PRIV identity — IDOR / horizontal-privesc / RBAC-bypass "
+                     "probes have nothing to attack with (deprioritize them)")
+    if not has_high:
+        lines.append("  ⚠ no HIGH-PRIV identity — admin-endpoint behavior can be verified "
+                     "as denied but not the allowed path")
+    return "\n".join(lines)
+
+
+def _llm_rank(hypotheses: list, goal: str, top_n: int, provider_name: str = "claude",
+              profile_infos: Optional[list] = None) -> list:
+    """One LLM call ranks all hypotheses 0-10 against the goal. Returns top_n."""
+    import shutil, subprocess
+    bin_ = shutil.which(provider_name) if provider_name in ("claude", "codex", "gemini") else None
+    if not bin_:
+        # No CLI provider — fall back to keyword rank
+        return _keyword_rank(hypotheses, goal, top_n)
+    # Concise lines per hypothesis
+    lines = []
+    for i, h in enumerate(hypotheses):
+        mit = " [mitigated]" if h.has_mitigation_declared else ""
+        lines.append(
+            f"  [{i}] sev={h.severity} class={h.vuln_class} "
+            f"{h.http_method or '?'} {h.http_path or '?'} "
+            f"asset={h.asset or '?'}{mit} — {(h.description or '')[:140]}"
+        )
+    prompt = RANKING_PROMPT % {
+        "top_n": top_n, "goal": goal,
+        "profile_context": _format_profile_context(profile_infos or []),
+        "hypotheses": "\n".join(lines),
+    }
+    try:
+        cmd = [bin_, "--print", prompt] if provider_name == "claude" else None
+        if provider_name == "codex":
+            cmd = [bin_, "exec", "--skip-git-repo-check", "--sandbox", "read-only", prompt]
+        elif provider_name == "gemini":
+            cmd = [bin_, "--prompt", prompt]
+        if cmd is None:
+            return _keyword_rank(hypotheses, goal, top_n)
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if r.returncode != 0:
+            print(f"  ⚠ LLM ranking failed (rc={r.returncode}); falling back to keyword rank")
+            return _keyword_rank(hypotheses, goal, top_n)
+        scores = {}
+        for line in r.stdout.splitlines():
+            m = re.match(r"\s*(\d+)\s+(\d+(?:\.\d+)?)\s*$", line)
+            if m:
+                idx = int(m.group(1))
+                if 0 <= idx < len(hypotheses):
+                    scores[idx] = float(m.group(2))
+        if not scores:
+            print(f"  ⚠ LLM returned no parseable scores; falling back to keyword rank")
+            return _keyword_rank(hypotheses, goal, top_n)
+        ranked_indices = sorted(scores, key=lambda i: -scores[i])
+        # Only include hypotheses with score >= 4 (cut clearly-irrelevant ones)
+        selected = [hypotheses[i] for i in ranked_indices if scores[i] >= 4][:top_n]
+        if not selected:
+            selected = [hypotheses[i] for i in ranked_indices][:top_n]
+        print(f"  ✓ LLM ranked {len(scores)}/{len(hypotheses)} hypotheses, selected {len(selected)}")
+        return selected
+    except Exception as e:
+        print(f"  ⚠ LLM ranking exception: {e}; falling back to keyword rank")
+        return _keyword_rank(hypotheses, goal, top_n)
+
+
+def _keyword_rank(hypotheses, goal: str, top_n: int) -> list:
+    """Naive keyword fallback when LLM unavailable."""
+    if not goal:
+        return [h for h in hypotheses if h.http_path][:top_n]
+    g = goal.lower()
+    scored = []
+    keywords = re.findall(r"[a-z][a-z_-]+", g)
+    for h in hypotheses:
+        if not h.http_path:
+            continue
+        text = " ".join(filter(None, [h.vuln_class, h.threat, h.asset, h.description,
+                                       h.function_name, h.http_path])).lower()
+        score = sum(text.count(kw) for kw in keywords)
+        if h.vuln_class.replace("_", " ") in g or h.vuln_class.replace("_", "-") in g:
+            score += 5
+        scored.append((score, h))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    selected = [h for s, h in scored if s > 0][:top_n]
+    if not selected:
+        selected = [h for s, h in scored][:top_n]
+    return selected
+
+
+def _dedupe_by_probe_shape(hyps: list) -> list:
+    """Collapse hypotheses with identical (http_method, http_path, function_name).
+    Keep the one with the highest severity (critical>high>medium>low>info) and merge
+    vuln_class into a comma-separated string on the surviving entry's `description`.
+    """
+    sev_order = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0,
+                 "informational": 0, "unknown": 0}
+    bucket: dict[tuple, list] = {}
+    for h in hyps:
+        key = (h.http_method or "", h.http_path or "", h.function_name or "")
+        bucket.setdefault(key, []).append(h)
+    out = []
+    for key, group in bucket.items():
+        if len(group) == 1:
+            out.append(group[0])
+            continue
+        winner = max(group, key=lambda h: sev_order.get((h.severity or "").lower(), 0))
+        merged_classes = sorted({h.vuln_class for h in group if h.vuln_class})
+        if len(merged_classes) > 1:
+            note = f" [merged classes: {','.join(merged_classes)}]"
+            if note not in (winner.description or ""):
+                winner.description = (winner.description or "") + note
+        out.append(winner)
+    return out
+
+
+def rank_hypotheses_by_goal(hypotheses, goal: str, top_n: int = 8,
+                            provider_name: str = "claude", use_llm: bool = True,
+                            profile_infos: Optional[list] = None,
+                            mitigation_mode: str = "any") -> list:
+    """LLM-based ranking when goal is set; keyword fallback otherwise.
+
+    mitigation_mode:
+      "any"          — all hypotheses with HTTP paths (default)
+      "unmitigated"  — only hypotheses WITHOUT a declared @mitigates (find unguarded holes)
+      "mitigated"    — only hypotheses WITH a declared @mitigates (verify defenses hold)
+    """
+    # Pre-filter: only hypotheses with concrete http_path are runnable by JS engine
+    runnable = [h for h in hypotheses if h.http_path]
+    if mitigation_mode == "unmitigated":
+        runnable = [h for h in runnable if not h.has_mitigation_declared]
+    elif mitigation_mode == "mitigated":
+        runnable = [h for h in runnable if h.has_mitigation_declared]
+    if not runnable:
+        return []
+    # Dedupe BEFORE ranking — saves Claude call budget by not asking it to rank duplicates
+    deduped = _dedupe_by_probe_shape(runnable)
+    if not goal or not use_llm:
+        return _keyword_rank(deduped, goal, top_n)
+    return _llm_rank(deduped, goal, top_n, provider_name=provider_name,
+                     profile_infos=profile_infos)
+
+
+def generate_all(codebase: Path, hypotheses, goal: str, session_dir: Optional[Path] = None,
+                 provider: str = "claude", top_n: int = 8,
+                 profile_infos: Optional[list] = None,
+                 generation_timeout_s: int = 240,
+                 mitigation_mode: str = "any") -> Path:
+    """Top-level: pick hypotheses → generate JS templates → return template directory."""
+    if session_dir is None:
+        session_dir = TEMPLATE_ROOT / time.strftime("session-%Y%m%d-%H%M%S")
+    session_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[gen] session dir: {session_dir}")
+
+    selected = rank_hypotheses_by_goal(hypotheses, goal, top_n=top_n,
+                                        provider_name=provider, profile_infos=profile_infos,
+                                        mitigation_mode=mitigation_mode)
+    print(f"[gen] goal: {goal or '(none)'}")
+    print(f"[gen] mitigation mode: {mitigation_mode}")
+    print(f"[gen] selected {len(selected)}/{len(hypotheses)} hypotheses for AI synthesis")
+    for h in selected:
+        print(f"  · {h.vuln_class:25s} {(h.http_method or '?'):6s} {h.http_path or '?':40s} [{h.severity}]")
+    print()
+
+    generated = []
+    for h in selected:
+        try:
+            p = generate_js_template(codebase, session_dir, h, goal,
+                                      provider=provider, timeout_s=generation_timeout_s)
+            if p:
+                generated.append(p)
+        except Exception as e:
+            print(f"  ✗ {h.vuln_class}: {e}")
+    print(f"[gen] {len(generated)}/{len(selected)} templates written to {session_dir}")
+    return session_dir

--- a/pentest/mutator.py
+++ b/pentest/mutator.py
@@ -1,0 +1,304 @@
+"""Retry-with-mutation loop for AMBIGUOUS template results.
+
+Workflow:
+  1. Template runs, returns findings.
+  2. Classify each: CONFIRMED (confirmed=true with strong evidence)
+                  / REFUTED (confirmed=false AND status codes indicate mitigation held)
+                  / AMBIGUOUS (confirmed=false BUT evidence is unclear, e.g. 422 schema reject)
+  3. For AMBIGUOUS: feed back to AI provider with the observed evidence + ask for a
+     mutation that addresses the specific failure mode. Max 3 retries per template.
+  4. Mutations are cached so the same (template_id, failure_signature) doesn't re-call AI.
+
+The classifier is deterministic. The mutator is AI. Splits responsibility clearly.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+MUTATION_CACHE = Path.home() / ".cert-x-gen" / "mutations"
+
+
+@dataclass
+class TriageVerdict:
+    kind: str       # "confirmed" | "refuted" | "ambiguous"
+    reason: str
+    reason_kind: str = "unknown"  # "payload" | "environment" | "unknown"
+    #   payload: ambiguity the AI can fix by rewriting (422 reject, 2xx without clear proof)
+    #   environment: ambiguity the AI CANNOT fix by retrying (missing role tier,
+    #                missing runtime primitive, server-side state we can't observe)
+
+
+_ENV_BOUND_SIGNALS = (
+    # missing identity tier
+    "re-run with", "needs a low", "unprivileged", "needs an unprivileged",
+    "no low-privilege", "needs a different role", "requires admin", "requires low-priv",
+    "all probed identities have", "only one identity",
+    # missing runtime primitive (HttpOnly cookies, headers we can't see, etc.)
+    "not exposed by", "not exposed to", "could not be captured",
+    "not visible to", "browser security model", "httponly",
+    "not exposed in the response", "response headers not exposed",
+    "raw token value", "raw cookie value", "set-cookie response header",
+    # missing observability for blind/oob vulns
+    "out-of-band", "blind", "no callback url", "no oob",
+    # cross-origin / scope issues
+    "cross-origin", "scoped to a different",
+)
+
+
+def classify(finding: dict) -> TriageVerdict:
+    """Pure-function classifier — no AI."""
+    if finding.get("confirmed") is True:
+        # Sanity: a "confirmed" finding without evidence is suspicious
+        if not finding.get("evidence"):
+            return TriageVerdict("ambiguous",
+                                 "marked confirmed but no evidence provided",
+                                 reason_kind="payload")
+        return TriageVerdict("confirmed",
+                             "AI marked confirmed and supplied evidence",
+                             reason_kind="payload")
+
+    # confirmed=false — check what we actually observed
+    # Defensive: AI sometimes emits evidence as a string instead of a dict.
+    ev_raw = finding.get("evidence") or {}
+    if isinstance(ev_raw, dict):
+        ev = ev_raw
+    else:
+        # Wrap stringy evidence so the rest of classify() still works
+        ev = {"_raw_evidence": str(ev_raw)}
+    status = ev.get("status") or ev.get("benign_status") or ev.get("escalate_status")
+    desc = (finding.get("description") or "").lower()
+
+    # AI-described mitigation-holds. When the model writes "mitigation holds",
+    # "rejected", "ignored", "blocked", "scoping enforced" in the description,
+    # treat as REFUTED even if the HTTP status was 2xx (e.g. mass-assignment
+    # probe where the server returned 201 but stripped the privileged fields).
+    _MITIGATION_HOLD_SIGNALS = (
+        # Direct "mitigation holds" phrasings
+        "mitigation holds", "mitigation appears to hold", "mitigation held",
+        "appears to hold",
+        # Owner-scoping
+        "owner-scoping enforced", "owner-scoping held", "owner-scoping appears",
+        "owner_scoping respected", "owner_scoping held",
+        "respected owner_scoping", "respected owner-scoping",
+        # RBAC
+        "rbac enforced", "require_admin enforced",
+        "require_admin holds", "require_admin appears intact",
+        # Fields ignored / stripped / forced
+        "fields ignored", "fields were ignored", "field ignored",
+        "fields were silently ignored", "silently ignored",
+        "silently dropped", "silently stripped",
+        "owner_id ignored", "ignored privileged", "ignored the privileged",
+        "forced owner=caller", "forced owner_id", "forced owner=",
+        "owner=caller", "owner_id forced server-side", "owner forced server-side",
+        "stripped server-side", "stripped by pydantic", "stripped by the schema",
+        "not declared in", "not in the schema",
+        "schema stripped", "stripped by",
+        # General "no exploit" phrasings
+        "rejected by", "no evidence of exploitation", "appears to function",
+        "appears safe", "did not reflect", "no escalation observed",
+        "no role/permission/is_active escalation",
+        # Cross-user invisibility confirmations
+        "only caller-owned", "caller-owned rows", "absent from user's list",
+        "absent from caller's", "not visible to caller",
+        "visible to other but absent",
+        # Privileged fields explicitly not reflected
+        "privileged fields were silently",
+        "privileged fields were ignored",
+        "privileged_fields_ignored",
+    )
+
+    # Pattern: "mitigation [#foo-bar] [parenthetical] held" — allow up to ~200 chars
+    # between "mitigation" and "hold[s]"/"held"/"enforced"/"ignored" so parentheticals
+    # like "(owner_id forced server-side, role not declared)" don't break the match.
+    if re.search(r"\bmitigation\b[^.\n]{0,200}\b(?:holds?|held|enforced|ignored|intact)\b",
+                 desc):
+        return TriageVerdict("refuted",
+                             "AI description references a mitigation that held "
+                             "(matched parenthetical-tolerant regex)",
+                             reason_kind="payload")
+
+    # Pattern: "mitigation #foo-bar held" / "mitigation #foo-bar appears to hold"
+    if re.search(r"mitigation\s+#[\w-]+\s+(?:held|holds|ignored|enforced|appears)", desc):
+        return TriageVerdict("refuted",
+                             "AI description references a specific mitigation that held",
+                             reason_kind="payload")
+
+    # Pattern: bare "<noun> (scoping|gate|check|control|policy|guard|rbac) (held|holds|...)"
+    # catches things like "owner scoping held", "require_admin gate held", "RBAC check enforced".
+    # Doesn't require the literal word "mitigation".
+    if re.search(
+        r"\b(?:owner[-_ ]?scoping|owner[-_ ]?check|scoping|rbac|require_admin|"
+        r"require_current_user|require_mutable_record|gate|policy|guard|control|check|"
+        r"authorization)\s+"
+        r"(?:held|holds|enforced|effective|active|works|intact|appears to hold|appears intact)\b",
+        desc,
+    ):
+        return TriageVerdict("refuted",
+                             "AI description states an access control / scoping check held",
+                             reason_kind="payload")
+
+    # Pattern: "no IDOR observed", "no privilege escalation", "no exploitation"
+    if re.search(r"\bno\s+(?:idor|privilege[- ]?escalation|escalation|exploitation|"
+                 r"cross[- ]?user|cross[- ]?owner|mass[- ]?assignment|leak|"
+                 r"bypass|open[- ]?redirect|injection|ssrf)\b"
+                 r"(?:\s+(?:observed|detected|possible|found|seen|achieved|raised))?",
+                 desc):
+        return TriageVerdict("refuted",
+                             "AI description states no exploitation observed",
+                             reason_kind="payload")
+
+    # Pattern: "<mitigation reference> appears effective" / "is effective"
+    # Catches: "PI-14678 mitigation appears effective", "the validation is effective",
+    #          "throttling is effective", "the gate is effective", etc.
+    if re.search(r"\b(?:mitigation|validation|throttling|gate|guard|control|check|filter|"
+                 r"sanitiz\w+|encod\w+)\s+(?:appears\s+to\s+be\s+|appears\s+|is\s+|"
+                 r"was\s+|seems\s+)?(?:effective|working|in\s+place|enforced|"
+                 r"functioning|adequate)\b", desc):
+        return TriageVerdict("refuted",
+                             "AI description states the mitigation is effective",
+                             reason_kind="payload")
+
+    # Pattern: explicit "no finding raised against the application"
+    if re.search(r"\bno\s+finding\s+raised\b", desc):
+        return TriageVerdict("refuted",
+                             "AI explicitly stated no finding raised against the app",
+                             reason_kind="payload")
+    if any(sig in desc for sig in _MITIGATION_HOLD_SIGNALS):
+        return TriageVerdict("refuted",
+                             "AI description explicitly states the mitigation held",
+                             reason_kind="payload")
+
+    # Environment-bound ambiguity — re-prompting AI won't help; surface to operator.
+    if any(sig in desc for sig in _ENV_BOUND_SIGNALS):
+        return TriageVerdict("ambiguous",
+                             "environment-bound: AI cannot fix this by retrying "
+                             "(missing role tier, missing runtime primitive, OOB needed)",
+                             reason_kind="environment")
+
+    # Common refuted patterns by status code
+    if isinstance(status, int):
+        if status in (401, 403):
+            return TriageVerdict("refuted",
+                                 f"server returned {status} (auth/RBAC enforced)",
+                                 reason_kind="payload")
+        if status == 404:
+            return TriageVerdict("refuted",
+                                 "server returned 404 (resource hidden or owner-scoping)",
+                                 reason_kind="payload")
+        if status == 422:
+            # Pydantic schema reject — payload never reached the vuln logic
+            return TriageVerdict("ambiguous",
+                                 "422 schema reject — payload was rejected before reaching the "
+                                 "vulnerable code path; mutate to fix request shape",
+                                 reason_kind="payload")
+        if 200 <= status < 300:
+            # 2xx but AI said not confirmed — likely the AI couldn't tell from evidence
+            return TriageVerdict("ambiguous",
+                                 f"received {status} but AI couldn't confirm exploitation from response",
+                                 reason_kind="payload")
+
+    # No clear status, no confirmation — ambiguous
+    return TriageVerdict("ambiguous",
+                         "AI returned confirmed=false without clear refutation signal",
+                         reason_kind="unknown")
+
+
+def _signature(template_id: str, finding: dict) -> str:
+    payload = json.dumps({
+        "tpl": template_id,
+        "vuln_class": finding.get("vuln_class"),
+        "endpoint": finding.get("endpoint"),
+        "evidence_status": (finding.get("evidence") or {}).get("status"),
+        "description_head": (finding.get("description") or "")[:80],
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:12]
+
+
+MUTATION_PROMPT = """\
+You previously wrote a JS pentest template. It ran but returned AMBIGUOUS results — the
+payload didn't reach the vulnerable code path, OR the response didn't clearly confirm
+exploitation.
+
+The triage classifier said: %(triage)s
+
+Original template source:
+```javascript
+%(source)s
+```
+
+Observed finding the template emitted:
+```json
+%(finding)s
+```
+
+Write a MUTATED version of the template that addresses the specific failure. Common moves:
+- If 422 schema reject: re-read the schema in the codebase (you can Read/Grep) and fix
+  the request body to pass Pydantic validation BEFORE testing the vuln.
+- If 2xx but unconfirmed: tighten the confirmation check — look at the actual response
+  body shape, compare against what the route handler should return for an attacker vs.
+  a legitimate user, set confirmed=true only when the response proves access.
+- If 404 cross-user: try a different target id, or try a different endpoint family,
+  or accept that the mitigation holds and lower severity.
+
+Constraints (same as before): use only cxg.fetch / cxg.fetchAs, no destructive paths,
+≤30 requests, output ONLY a fenced javascript code block.
+"""
+
+
+def _claude_cli_mutate(codebase: Path, prompt: str, timeout_s: int = 240) -> str:
+    bin_ = shutil.which("claude")
+    if not bin_:
+        raise RuntimeError("claude CLI not on PATH")
+    r = subprocess.run(
+        [bin_, "--print", "--permission-mode", "acceptEdits", prompt],
+        capture_output=True, text=True, timeout=timeout_s, cwd=str(codebase),
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"claude CLI rc={r.returncode}: {r.stderr.strip()[:300]}")
+    return r.stdout
+
+
+def _extract_js(text: str) -> Optional[str]:
+    m = re.search(r"```(?:javascript|js)\s*\n(.*?)```", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    m = re.search(r"```\s*\n(.*?)```", text, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def mutate_template(template_source: str, finding: dict, verdict: TriageVerdict,
+                    codebase: Path, template_id: str = "") -> Optional[str]:
+    """Returns mutated JS source, or None on failure."""
+    sig = _signature(template_id or "", finding)
+    MUTATION_CACHE.mkdir(parents=True, exist_ok=True)
+    cache_path = MUTATION_CACHE / f"{template_id}_{sig}.js"
+    if cache_path.exists():
+        return cache_path.read_text()
+
+    prompt = MUTATION_PROMPT % {
+        "triage": verdict.reason,
+        "source": template_source,
+        "finding": json.dumps(finding, indent=2, default=str)[:2000],
+    }
+    try:
+        t0 = time.time()
+        raw = _claude_cli_mutate(codebase, prompt)
+        dur = time.time() - t0
+    except Exception as e:
+        print(f"  ✗ mutation failed: {e}")
+        return None
+    mutated = _extract_js(raw)
+    if not mutated:
+        print(f"  ✗ mutation produced no JS block ({len(raw)} chars, {dur:.1f}s)")
+        return None
+    cache_path.write_text(mutated)
+    print(f"  ↻ mutation written: {cache_path.name} ({len(mutated)} chars, {dur:.1f}s)")
+    return mutated

--- a/pentest/payloads/__init__.py
+++ b/pentest/payloads/__init__.py
@@ -1,0 +1,26 @@
+"""Built-in probe library. Each probe maps a guardlink vuln_class to a concrete runtime test.
+
+Add a new probe by writing a class with:
+  - vuln_class: str   (matches normalized guardlink class)
+  - requires_auth_count: int   (default 1)
+  - async def run(self, ctxs, hypothesis) -> list[Finding]
+
+Then add it to ALL_PROBES below.
+"""
+from .idor import IdorProbe
+from .csrf import CsrfProbe
+from .sensitive_data import SensitiveDataProbe
+from .privilege_escalation import PrivEscProbe
+from .session_replay import SessionReplayProbe
+from .metrics_disclosure import MetricsDisclosureProbe
+from .rate_limit import RateLimitProbe
+
+ALL_PROBES = [
+    IdorProbe(),
+    CsrfProbe(),
+    PrivEscProbe(),
+    SessionReplayProbe(),
+    SensitiveDataProbe(),
+    MetricsDisclosureProbe(),
+    RateLimitProbe(),
+]

--- a/pentest/payloads/csrf.py
+++ b/pentest/payloads/csrf.py
@@ -1,0 +1,55 @@
+"""CSRF probe: does a state-changing endpoint accept a request *without* CSRF token?
+
+The app uses CSRF double-submit (cookie + X-CSRF-Token header). We probe by sending
+a state-changing request from an authenticated session but stripping the X-CSRF-Token
+header. If the server still accepts it, the mitigation is missing.
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class CsrfProbe:
+    vuln_class = "csrf"
+    requires_auth_count = 1
+    destructive_priority = 20  # one of the probe targets is logout
+
+    STATE_CHANGING = [
+        ("POST",   "/api/api-records",                {"endpoint_url": "https://x.test", "auth_type": "Bearer",
+                                                       "credential_hint": "csrf-probe", "notes": "csrf probe"}),
+        ("POST",   "/api/transactions",               {"description": "csrf-probe", "amount": 0.01,
+                                                       "kind": "test", "status": "pending"}),
+        ("DELETE", "/api/api-records/999999",         None),
+        ("POST",   "/api/auth/logout",                None),
+    ]
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        a = ctxs[0]
+        for method, path, body in self.STATE_CHANGING:
+            # Strip CSRF header by issuing through a fetch that DOESN'T inject it.
+            res = await a.page.evaluate(
+                """async ({url, method, body}) => {
+                    const opts = {method, credentials:'include', headers:{}};
+                    if (body) {opts.headers['Content-Type']='application/json'; opts.body=JSON.stringify(body);}
+                    const r = await fetch(url, opts);
+                    const text = await r.text();
+                    return {status:r.status, body:text.slice(0,300)};
+                }""",
+                {"url": a.url(path), "method": method, "body": body},
+            )
+            # 2xx (or 204) without CSRF header = mitigation absent.
+            # 403/401 = mitigation works.
+            if res["status"] in (200, 201, 204):
+                findings.append(Finding(
+                    id=f"csrf-{method.lower()}-{path.replace('/','-').strip('-')}",
+                    vuln_class="csrf",
+                    severity="high",
+                    confirmed=True,
+                    target=a.target,
+                    endpoint=f"{method} {path}",
+                    description=f"{method} {path} accepted without X-CSRF-Token header (status {res['status']}). "
+                                "Double-submit cookie defense missing or not enforced for this route.",
+                    evidence={"status": res["status"], "body": res["body"]},
+                    payload=f"{method} {path} with cookies but NO X-CSRF-Token",
+                ))
+        return findings

--- a/pentest/payloads/idor.py
+++ b/pentest/payloads/idor.py
@@ -1,0 +1,113 @@
+"""IDOR probe: with two authenticated identities A and B, can A read/modify B's resources?
+
+Strategy:
+  1. As B, enumerate B's resources via list endpoints (e.g. GET /api/api-records).
+  2. Capture an ID belonging to B.
+  3. As A (different identity), attempt GET /api/api-records/{B_id} and DELETE /api/api-records/{B_id}.
+  4. If A gets 2xx (read) or successful mutation, that's IDOR.
+
+Requires --auth-numbers >= 2.
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class IdorProbe:
+    vuln_class = "idor"
+    requires_auth_count = 2
+    destructive_priority = 5  # may DELETE victim resources, but doesn't kill our own session
+
+    # Endpoints we know are owner-scoped. Could be inferred from guardlink in future;
+    # for now we map the well-known IDOR surface.
+    # Note: many apps only expose PATCH/DELETE on item routes (no GET), so we probe those.
+    OWNED_RESOURCES = [
+        ("/api/api-records",  "/api/api-records/{id}",  ["PATCH", "DELETE"]),
+        ("/api/transactions", "/api/transactions/{id}", ["PATCH", "DELETE"]),
+    ]
+    # Sample PATCH body — small mutation that doesn't break the record's shape.
+    PATCH_BODIES = {
+        "/api/api-records":  {"notes": "cxg-idor-probe"},
+        "/api/transactions": {"description": "cxg-idor-probe"},
+    }
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        # Limit each probe instance to one resource family — match the hypothesis if path is set
+        path_hint = (hypothesis.http_path or "").lower()
+        targets = [r for r in self.OWNED_RESOURCES if not path_hint or r[0] in path_hint or r[1].split("{")[0] in path_hint]
+        if not targets:
+            targets = self.OWNED_RESOURCES
+
+        a, b = ctxs[0], ctxs[1]  # actor A vs victim B
+        a_label = a.profile.label or a.profile.name
+        b_label = b.profile.label or b.profile.name
+
+        # First, identify which records belong to whom by listing as each side.
+        # Same `owner_id` shouldn't appear in the other user's list (proper scoping).
+        for list_path, item_template, methods in targets:
+            list_resp_b = await b.api("GET", list_path)
+            list_resp_a = await a.api("GET", list_path)
+            if list_resp_b["status"] != 200 or list_resp_a["status"] != 200:
+                continue
+            items_b = list_resp_b.get("body_json") or []
+            items_a = list_resp_a.get("body_json") or []
+            if not isinstance(items_b, list) or not items_b:
+                continue
+            b_owner_ids = {it.get("owner_id") for it in items_b if isinstance(it, dict)}
+            a_owner_ids = {it.get("owner_id") for it in items_a if isinstance(it, dict)}
+
+            # Pick a record owned by B that's NOT in A's owner set.
+            target_record = next(
+                (it for it in items_b if isinstance(it, dict)
+                 and it.get("owner_id") in (b_owner_ids - a_owner_ids)),
+                None,
+            )
+            if not target_record or target_record.get("id") is None:
+                continue
+            victim_id = target_record["id"]
+            victim_owner = target_record.get("owner_id")
+            target_url = item_template.format(id=victim_id)
+
+            # READ-via-listing leak: did A's list contain a record owned by someone else?
+            cross_in_a = [it for it in items_a if isinstance(it, dict) and it.get("owner_id") != target_record.get("owner_id")
+                          and it.get("owner_id") not in a_owner_ids]
+            # (kept for completeness; typically empty if RBAC works)
+
+            # PATCH attempt — does A successfully modify B's resource?
+            if "PATCH" in methods:
+                r = await a.api("PATCH", target_url, body=self.PATCH_BODIES.get(list_path, {"notes": "cxg-probe"}))
+                if r["status"] in (200, 204):
+                    findings.append(Finding(
+                        id=f"idor-patch-{list_path.strip('/').replace('/','-')}",
+                        vuln_class="idor",
+                        severity="high",
+                        confirmed=True,
+                        target=a.target,
+                        endpoint=f"PATCH {target_url}",
+                        description=f"{a_label} successfully PATCHED record {victim_id} owned by "
+                                    f"user_id={victim_owner} (probably {b_label}).",
+                        evidence={"actor_profile": a.profile.name, "victim_profile": b.profile.name,
+                                  "victim_resource_id": victim_id, "victim_owner_id": victim_owner,
+                                  "status": r["status"], "response_excerpt": (r["body_text"] or "")[:300]},
+                        payload=f"PATCH {target_url} as {a_label}",
+                    ))
+
+            # DELETE attempt — destructive, only fire if PATCH didn't already confirm.
+            if "DELETE" in methods and not any(f.id == f"idor-patch-{list_path.strip('/').replace('/','-')}" for f in findings):
+                r = await a.api("DELETE", target_url)
+                if r["status"] in (200, 204):
+                    findings.append(Finding(
+                        id=f"idor-delete-{list_path.strip('/').replace('/','-')}",
+                        vuln_class="idor",
+                        severity="critical",
+                        confirmed=True,
+                        target=a.target,
+                        endpoint=f"DELETE {target_url}",
+                        description=f"{a_label} successfully DELETED record {victim_id} owned by "
+                                    f"user_id={victim_owner} (probably {b_label}).",
+                        evidence={"actor_profile": a.profile.name, "victim_profile": b.profile.name,
+                                  "victim_resource_id": victim_id, "victim_owner_id": victim_owner,
+                                  "status": r["status"]},
+                        payload=f"DELETE {target_url} as {a_label}",
+                    ))
+        return findings

--- a/pentest/payloads/metrics_disclosure.py
+++ b/pentest/payloads/metrics_disclosure.py
@@ -1,0 +1,40 @@
+"""Metrics info disclosure: /metrics is unauthenticated and exposes route templates,
+status counts, latency buckets — guardlink flags this explicitly.
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class MetricsDisclosureProbe:
+    vuln_class = "metrics_info_disclosure"
+    requires_auth_count = 1
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        c = ctxs[0]
+        # Use an unauthenticated request by clearing cookies temporarily? Simpler:
+        # just observe whether /metrics responds at all to *any* fetch. If yes, that
+        # confirms guardlink's @audit (no auth required).
+        res = await c.page.evaluate(
+            """async (url) => {
+                // No-credentials fetch — simulates an unauthenticated attacker.
+                const r = await fetch(url, {credentials:'omit'});
+                const text = await r.text();
+                return {status:r.status, body:text.slice(0,800)};
+            }""",
+            c.url("/metrics"),
+        )
+        if res["status"] == 200 and ("http_requests_total" in res["body"] or "# HELP" in res["body"]):
+            findings.append(Finding(
+                id="metrics-info-disclosure-unauth",
+                vuln_class="metrics_info_disclosure",
+                severity="medium",
+                confirmed=True,
+                target=c.target,
+                endpoint="GET /metrics",
+                description="/metrics is reachable without authentication and exposes route templates, "
+                            "request counts, latency histograms, and security-event counters.",
+                evidence={"status": 200, "body_excerpt": res["body"][:400]},
+                payload="GET /metrics with credentials omitted",
+            ))
+        return findings

--- a/pentest/payloads/privilege_escalation.py
+++ b/pentest/payloads/privilege_escalation.py
@@ -1,0 +1,91 @@
+"""Privilege escalation probe: can a low-priv user reach admin-only endpoints, or
+mutate fields that should be admin-only (role, is_active)?
+
+Strategy:
+  1. Try GET /api/users as a non-admin context.
+  2. Try POST/PATCH on /api/users/{id} with role=admin payload as a non-admin.
+  3. Try creating a record with elevated fields (role / is_active set).
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class PrivEscProbe:
+    vuln_class = "privilege_escalation"
+    requires_auth_count = 1
+    destructive_priority = 8
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        # Prefer the LEAST-privileged context for this test; reuse all available.
+        # Heuristic: profile name containing "user" or "analyst" is non-admin.
+        non_admin = next(
+            (c for c in ctxs if "admin" not in (c.profile.label or c.profile.name).lower()),
+            ctxs[0],
+        )
+        c = non_admin
+
+        # 1. List users — admin-only per guardlink. Non-admin should get 403.
+        r = await c.api("GET", "/api/users")
+        if r["status"] == 200:
+            findings.append(Finding(
+                id="privesc-list-users",
+                vuln_class="privilege_escalation",
+                severity="high",
+                confirmed=True,
+                target=c.target,
+                endpoint="GET /api/users",
+                description=f"{c.profile.label or c.profile.name} (non-admin) successfully listed users. "
+                            "manage_users RBAC bypass.",
+                evidence={"status": 200, "response_excerpt": (r["body_text"] or "")[:300]},
+                payload=f"GET /api/users as {c.profile.name}",
+            ))
+
+        # 2. Try to mutate another user's role to admin.
+        # Get a target user_id first via /api/me (we'd need someone else's id, but /api/me at
+        # least gives us a real one to attempt against ourselves — escalating own role is still bad).
+        me = await c.api("GET", "/api/me")
+        my_id = (me.get("body_json") or {}).get("id")
+        if my_id is not None:
+            for method in ("PATCH", "PUT", "POST"):
+                r = await c.api(method, f"/api/users/{my_id}", body={"role": "admin", "is_active": True})
+                if r["status"] in (200, 204):
+                    # Verify by re-reading /api/me
+                    me2 = await c.api("GET", "/api/me")
+                    new_role = (me2.get("body_json") or {}).get("role")
+                    if new_role == "admin":
+                        findings.append(Finding(
+                            id=f"privesc-self-elevate-{method.lower()}",
+                            vuln_class="privilege_escalation",
+                            severity="critical",
+                            confirmed=True,
+                            target=c.target,
+                            endpoint=f"{method} /api/users/{my_id}",
+                            description=f"{c.profile.name} self-elevated to admin via {method} /api/users/{my_id}.",
+                            evidence={"status": r["status"], "new_role": new_role},
+                            payload=f'{method} /api/users/{my_id} body={{"role":"admin"}}',
+                        ))
+                        break
+
+        # 3. Attempt mass-assignment via the create-record endpoint (privilege_escalation
+        # was guardlink-tagged on create_api_record specifically).
+        r = await c.api("POST", "/api/api-records", body={
+            "endpoint_url": "https://privesc-probe.test", "auth_type": "Bearer",
+            "credential_hint": "x", "notes": "privesc",
+            "role": "admin", "is_active": True, "owner_id": 1,  # extra fields that shouldn't be honored
+        })
+        if r["status"] in (200, 201) and isinstance(r.get("body_json"), dict):
+            body = r["body_json"]
+            if body.get("role") == "admin" or body.get("owner_id") == 1:
+                findings.append(Finding(
+                    id="privesc-mass-assign-create-record",
+                    vuln_class="privilege_escalation",
+                    severity="high",
+                    confirmed=True,
+                    target=c.target,
+                    endpoint="POST /api/api-records",
+                    description="Server honored mass-assigned privileged fields (role/owner_id) on record create.",
+                    evidence={"status": r["status"], "echoed_body": {k: body.get(k) for k in ("role", "owner_id", "is_active")}},
+                    payload='POST /api/api-records body includes role=admin, owner_id=1',
+                ))
+        return findings

--- a/pentest/payloads/rate_limit.py
+++ b/pentest/payloads/rate_limit.py
@@ -1,0 +1,55 @@
+"""Rate-limit bypass probe: hammer the login endpoint with bad creds and see if
+throttling kicks in. Defensive ceiling — we only send N requests, not infinite.
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class RateLimitProbe:
+    vuln_class = "rate_limit_bypass"
+    requires_auth_count = 1
+    destructive_priority = 30  # may trip server throttling
+    MAX_TRIES = 20
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        c = ctxs[0]
+        # Only probe login. We do NOT probe destructive endpoints (delete-all, etc).
+        target_path = "/api/auth/login"
+        statuses = []
+        for i in range(self.MAX_TRIES):
+            res = await c.page.evaluate(
+                """async ({url, body}) => {
+                    const r = await fetch(url, {
+                        method:'POST', credentials:'omit',
+                        headers:{'Content-Type':'application/json'},
+                        body: JSON.stringify(body)
+                    });
+                    return r.status;
+                }""",
+                {"url": c.url(target_path),
+                 # use a valid-looking email so the request body passes Pydantic validation
+                 # and actually exercises the login path (not just a 422 schema reject).
+                 "body": {"email": f"cxg.ratelimit.probe+{i}@gmail.com", "password": "wrong-password-cxg-probe"}},
+            )
+            statuses.append(res)
+
+        # If we never see 429 or 403-block in 20 attempts AND the server kept processing
+        # the login attempts (i.e. we saw at least one 401), no rate limit is enforced.
+        unique = set(statuses)
+        saw_login_processing = any(s in (401, 400) for s in statuses)
+        if saw_login_processing and 429 not in unique and not any(s == 403 for s in statuses[-5:]):
+            findings.append(Finding(
+                id="rate-limit-bypass-login",
+                vuln_class="rate_limit_bypass",
+                severity="medium",
+                confirmed=True,
+                target=c.target,
+                endpoint=f"POST {target_path}",
+                description=f"Sent {self.MAX_TRIES} bad-credential login attempts in rapid succession; "
+                            f"server never returned 429/throttled response. Statuses seen: {sorted(unique)}.",
+                evidence={"attempts": self.MAX_TRIES, "statuses_seen": sorted(unique),
+                          "last_5_statuses": statuses[-5:]},
+                payload=f"{self.MAX_TRIES}x POST /api/auth/login with rotating fake emails",
+            ))
+        return findings

--- a/pentest/payloads/sensitive_data.py
+++ b/pentest/payloads/sensitive_data.py
@@ -1,0 +1,76 @@
+"""Sensitive data exposure probe: does a low-priv context see other users' data,
+or do response bodies leak data the user shouldn't see?
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class SensitiveDataProbe:
+    vuln_class = "sensitive_data_exposure"
+    requires_auth_count = 1
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        c = ctxs[0]
+        is_low_priv = "admin" not in (c.profile.label or c.profile.name).lower()
+
+        # 1. /api/security/events — guardlink flags as IDOR/sensitive surface
+        r = await c.api("GET", "/api/security/events")
+        if is_low_priv and r["status"] == 200:
+            body = r.get("body_json") or []
+            n = len(body) if isinstance(body, list) else len(body.get("events", []) or [])
+            if n > 0:
+                findings.append(Finding(
+                    id="sde-security-events-non-admin",
+                    vuln_class="sensitive_data_exposure",
+                    severity="medium",
+                    confirmed=True,
+                    target=c.target,
+                    endpoint="GET /api/security/events",
+                    description=f"Non-admin ({c.profile.name}) retrieved {n} security event records.",
+                    evidence={"status": 200, "row_count": n,
+                              "sample": (body[0] if isinstance(body, list) and body else None)},
+                    payload=f"GET /api/security/events as {c.profile.name}",
+                ))
+
+        # 2. /api/system/services — service-health-api flagged for sensitive_data
+        r = await c.api("GET", "/api/system/services")
+        if is_low_priv and r["status"] == 200:
+            body_text = r.get("body_text") or ""
+            interesting = any(k in body_text.lower() for k in
+                              ("version", "host", "internal", "redis", "postgres", "uptime"))
+            if interesting:
+                findings.append(Finding(
+                    id="sde-system-services-non-admin",
+                    vuln_class="sensitive_data_exposure",
+                    severity="medium",
+                    confirmed=True,
+                    target=c.target,
+                    endpoint="GET /api/system/services",
+                    description=f"Non-admin ({c.profile.name}) sees internal service health details "
+                                "(versions, hosts, infrastructure components).",
+                    evidence={"status": 200, "body_excerpt": body_text[:400]},
+                    payload=f"GET /api/system/services as {c.profile.name}",
+                ))
+
+        # 3. /api/api-records — does the response leak credential_hint (guardlink CWE-200)?
+        r = await c.api("GET", "/api/api-records")
+        if r["status"] == 200:
+            body = r.get("body_json") or []
+            if isinstance(body, list) and body:
+                sample = body[0]
+                if isinstance(sample, dict) and sample.get("credential_hint"):
+                    findings.append(Finding(
+                        id="sde-credential-hint-in-list",
+                        vuln_class="sensitive_data_exposure",
+                        severity="medium",
+                        confirmed=True,
+                        target=c.target,
+                        endpoint="GET /api/api-records",
+                        description="Records list response exposes credential_hint field — guardlink "
+                                    "@exposes records-api → sensitive-data-exposure (CWE-200) confirmed.",
+                        evidence={"sample_keys": list(sample.keys())[:20],
+                                  "credential_hint_present": True},
+                        payload="GET /api/api-records — inspect credential_hint field",
+                    ))
+        return findings

--- a/pentest/payloads/session_replay.py
+++ b/pentest/payloads/session_replay.py
@@ -1,0 +1,54 @@
+"""Session replay probe: does the access_token cookie remain valid AFTER logout?
+
+If yes, the server-side session-revocation control is missing / broken: a stolen cookie
+keeps working even after the legitimate user logs out.
+"""
+from __future__ import annotations
+from browser_engine import Finding
+
+
+class SessionReplayProbe:
+    vuln_class = "session_replay"
+    requires_auth_count = 1
+    destructive_priority = 100  # logout always kills the session — must run absolutely last
+
+    async def run(self, ctxs, hypothesis):
+        findings: list[Finding] = []
+        c = ctxs[0]
+
+        # 1. Snapshot the cookies that authenticate us.
+        cookies_before = await c.ctx.cookies()
+        access_before = next((x for x in cookies_before if x["name"] == "access_token"), None)
+        if not access_before:
+            return findings  # not a cookie session — skip
+
+        # 2. Confirm /api/me works.
+        me1 = await c.api("GET", "/api/me")
+        if me1["status"] != 200:
+            return findings
+        original_user = (me1["body_json"] or {}).get("email")
+
+        # 3. Logout. (CSRF-token aware via our ProbeContext.api.)
+        await c.api("POST", "/api/auth/logout")
+
+        # 4. Restore the captured access_token cookie (simulating a stolen, replayed cookie).
+        await c.ctx.add_cookies([access_before])
+        me2 = await c.api("GET", "/api/me")
+        if me2["status"] == 200 and (me2["body_json"] or {}).get("email") == original_user:
+            findings.append(Finding(
+                id="session-replay-after-logout",
+                vuln_class="session_replay",
+                severity="high",
+                confirmed=True,
+                target=c.target,
+                endpoint="GET /api/me",
+                description="access_token cookie continues to authenticate AFTER explicit logout — "
+                            "Redis-backed session revocation appears non-functional or bypassable by cookie replay.",
+                evidence={
+                    "user": original_user,
+                    "post_logout_status": me2["status"],
+                    "post_logout_email": (me2["body_json"] or {}).get("email"),
+                },
+                payload="Replay captured access_token cookie after POST /api/auth/logout",
+            ))
+        return findings

--- a/pentest/profile_inspect.py
+++ b/pentest/profile_inspect.py
@@ -1,0 +1,242 @@
+"""Pre-flight inspection of captured auth profiles.
+
+For each profile, spin up a quick headless browser context with the saved storage_state
+and probe a small set of well-known endpoints to learn:
+
+  - Whether the session is alive at all
+  - The identity (role, email, id) from a /me-style endpoint
+  - Which "tier" the role is at (admin > analyst > user > other)
+  - Which permission flags the server reports (if /me returns them)
+
+This information is then fed into the LLM hypothesis ranker AND into the per-template
+evaluation so that:
+  - Hypotheses that require an identity we don't have (e.g. IDOR needs a low-priv profile
+    and we only have admin) get DEPRIORITIZED at ranking time
+  - Templates that depend on cross-role checks know exactly which profile index is which tier
+
+Pure inspection — no destructive calls, just a single GET /api/me per profile.
+"""
+from __future__ import annotations
+import asyncio
+from dataclasses import dataclass, field, asdict
+from typing import Optional
+
+from auth import AuthProfile, load_profile
+
+
+# Heuristic tiering. Higher number = more privileged.
+ROLE_TIER = {
+    "admin": 100, "superadmin": 110, "owner": 90, "root": 110,
+    "analyst": 60, "auditor": 60, "manager": 70,
+    "user": 20, "member": 20, "viewer": 10, "guest": 5,
+}
+
+
+@dataclass
+class ProfileInfo:
+    profile_name: str
+    label: Optional[str]
+    target: str
+    alive: bool
+    me_status: int = 0
+    user_id: Optional[int | str] = None
+    email: Optional[str] = None
+    role: Optional[str] = None
+    tier: int = 0
+    permissions: dict = field(default_factory=dict)
+    raw_me: dict = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+
+    def short(self) -> str:
+        if not self.alive:
+            return f"{self.profile_name} (DEAD: status={self.me_status})"
+        bits = [self.profile_name]
+        if self.label and self.label != self.profile_name:
+            bits.append(f"label={self.label}")
+        if self.role:
+            bits.append(f"role={self.role}")
+        if self.email:
+            bits.append(f"email={self.email}")
+        if self.user_id is not None:
+            bits.append(f"id={self.user_id}")
+        return " ".join(bits)
+
+
+def _looks_like_login_page(final_url: str, html: str) -> bool:
+    """Heuristic: is this page asking us to log in, or is it the dashboard?"""
+    u = (final_url or "").lower()
+    # URL-based signals
+    if any(s in u for s in ("/login", "/signin", "/sign-in", "/auth/login",
+                              "/oauth/authorize", "/sso", "/saml",
+                              "auth.ac", "okta.com", "auth0.com", "accounts.google.com",
+                              "/keycloak", "/realms/")):
+        return True
+    # Content-based signals (case-insensitive substring on the first ~64 KB)
+    h = (html or "")[:65536].lower()
+    login_markers = (
+        "<input type=\"password\"", "<input type='password'", "type=password",
+        'name="password"', "name='password'",
+        "sign in to", "log in to", "please sign in", "please log in",
+        ">login</", ">sign in</",
+    )
+    score = sum(1 for m in login_markers if m in h)
+    return score >= 2  # need two signals to call it a login page
+
+
+async def _inspect_one(p, profile: AuthProfile, target: str,
+                       me_path: str = "/api/me") -> ProfileInfo:
+    """Two-pronged session check:
+
+      1. **Landing test (primary)**: navigate to `target` with the saved cookies and see
+         where we land after all redirects. If the final URL / page content looks like
+         a login page, the session is dead. Otherwise alive.
+
+      2. **Identity probe (secondary)**: best-effort fetch of `me_path` to extract
+         role / email / id. If this 401/403s but the landing test said alive, we trust
+         the landing test — many apps just don't have a canonical /me endpoint, or it
+         requires CSRF / different scope than the verifier provides.
+
+    The landing test mirrors what the captured session does in real use, so it's the
+    most reliable single signal.
+    """
+    info = ProfileInfo(profile_name=profile.name, label=profile.label, target=target,
+                        alive=False)
+    try:
+        browser = await p.chromium.launch(headless=True)
+        ctx_kwargs = {"storage_state": profile.storage_state}
+        if getattr(profile, "extra_headers", None):
+            ctx_kwargs["extra_http_headers"] = profile.extra_headers
+        ctx = await browser.new_context(**ctx_kwargs)
+        page = await ctx.new_page()
+
+        # Phase 1: landing test
+        landed_url = ""
+        landed_html = ""
+        try:
+            resp = await page.goto(target, wait_until="domcontentloaded", timeout=15000)
+            # Let any post-load JS redirect settle (SPAs often redirect to /login client-side)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=5000)
+            except Exception:
+                pass
+            landed_url = page.url
+            try:
+                landed_html = await page.content()
+            except Exception:
+                pass
+        except Exception as e:
+            info.notes.append(f"goto({target}) failed: {e}")
+
+        looks_login = _looks_like_login_page(landed_url, landed_html)
+        # Treat alive iff we DID NOT bounce to login. This is a stronger signal than /me.
+        if landed_url and not looks_login:
+            info.alive = True
+            info.notes.append(f"landed at {landed_url} (no login redirect)")
+        elif looks_login:
+            info.notes.append(f"landed at {landed_url} which looks like a login/SSO page")
+        else:
+            info.notes.append(f"could not determine landing page state")
+
+        # Phase 2: best-effort identity probe (only used to populate role/email/id —
+        # never used to override the landing-test verdict)
+        try:
+            res = await page.evaluate(
+                """async (path) => {
+                    try {
+                        const r = await fetch(path, {credentials:'include'});
+                        let body = null;
+                        try { body = await r.json(); } catch (e) {
+                            try { body = {_text: await r.text()}; } catch (e2) { body = null; }
+                        }
+                        return {status: r.status, body};
+                    } catch (e) { return {status: 0, error: String(e)}; }
+                }""",
+                me_path,
+            )
+        except Exception:
+            res = {"status": 0}
+        info.me_status = res.get("status", 0)
+        body = res.get("body") or {}
+        info.raw_me = body if isinstance(body, dict) else {"_raw": body}
+
+        if 200 <= info.me_status < 300 and isinstance(body, dict):
+            # me_path worked — extract identity details
+            info.user_id = body.get("id") or body.get("user_id") or body.get("uid")
+            info.email = body.get("email") or body.get("username") or body.get("user_email")
+            info.role = (body.get("role") or body.get("user_role")
+                         or (body.get("user") or {}).get("role")
+                         or body.get("group"))
+            if isinstance(info.role, str):
+                info.tier = ROLE_TIER.get(info.role.lower(), 30)
+            perms: dict = {}
+            for k, v in body.items():
+                if isinstance(v, bool):
+                    perms[k] = v
+            if isinstance(body.get("permissions"), dict):
+                perms.update({f"perm.{k}": v for k, v in body["permissions"].items()})
+            info.permissions = perms
+        elif info.alive:
+            # Session is alive per landing test, but me_path probe failed — common for
+            # apps without a stable /me endpoint, or where /me requires CSRF / a different
+            # scope. We trust the landing test; just note we don't have role/email/id.
+            info.notes.append(f"{me_path} returned {info.me_status} but landing test "
+                              "says session is alive; identity details unknown")
+            # Without role info, we can't tier; default to mid (30) so privesc probes
+            # still consider this profile usable.
+            info.tier = 30
+        elif info.me_status in (401, 403):
+            info.notes.append(f"{me_path} returned {info.me_status}")
+
+        await browser.close()
+        return info
+    except Exception as e:
+        info.notes.append(f"inspection raised: {e}")
+        return info
+
+
+async def inspect_profiles_async(profile_names: list[str], target: str,
+                                  me_path: str = "/api/me") -> list[ProfileInfo]:
+    from playwright.async_api import async_playwright
+    profs = [load_profile(n) for n in profile_names]
+    out: list[ProfileInfo] = []
+    async with async_playwright() as p:
+        for prof in profs:
+            info = await _inspect_one(p, prof, target, me_path)
+            out.append(info)
+    return out
+
+
+def inspect_profiles(profile_names: list[str], target: str,
+                     me_path: str = "/api/me") -> list[ProfileInfo]:
+    """Sync wrapper for use outside an event loop."""
+    return asyncio.run(inspect_profiles_async(profile_names, target, me_path))
+
+
+def coverage_summary(infos: list[ProfileInfo]) -> dict:
+    """What roles/tiers do we have? What's missing for common probe classes?"""
+    alive = [i for i in infos if i.alive]
+    roles = {i.role for i in alive if i.role}
+    tiers = sorted({i.tier for i in alive})
+    has_low = any(i.tier <= 30 for i in alive)
+    has_mid = any(30 < i.tier <= 70 for i in alive)
+    has_high = any(i.tier > 70 for i in alive)
+    notes: list[str] = []
+    if not has_low and (has_mid or has_high):
+        notes.append("no low-privilege identity captured — IDOR / RBAC-bypass / "
+                     "horizontal-privesc probes will be unfalsifiable")
+    if not has_high and (has_low or has_mid):
+        notes.append("no high-privilege identity captured — admin-only-endpoint coverage "
+                     "will be limited (can verify denials, not the allowed path)")
+    if len(alive) < 2:
+        notes.append("only one live identity — chained-auth probes (IDOR cross-user, "
+                     "session-replay-against-victim) need >=2 profiles")
+    return {
+        "live_count": len(alive),
+        "total_count": len(infos),
+        "roles": sorted(roles),
+        "tier_distribution": tiers,
+        "has_low_priv": has_low,
+        "has_mid_priv": has_mid,
+        "has_high_priv": has_high,
+        "notes": notes,
+    }

--- a/pentest/scope.py
+++ b/pentest/scope.py
@@ -1,0 +1,251 @@
+"""Scope enforcement + per-scan audit log.
+
+A pentest scan should NEVER:
+  - touch destructive paths (regex-matched) without --destructive-ok
+  - issue DELETE/PUT/PATCH unless explicitly whitelisted
+  - hammer one endpoint past max_requests_per_endpoint
+  - keep running after server returns 5xx_streak_threshold consecutive 5xx (likely WAF/lockout)
+
+ScopeGuard is consulted by both py and js engines before every outgoing request.
+AuditLog writes one JSONL line per request (timestamp, identity, method, path, status, template_id).
+"""
+from __future__ import annotations
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+import threading
+
+try:
+    import yaml as _yaml  # optional — scope file is yaml
+except ImportError:
+    _yaml = None
+
+
+# Patterns we refuse to touch without --destructive-ok
+_DEFAULT_DESTRUCTIVE_PATTERNS = [
+    r"/delete[-_]?all\b",
+    r"/wipe\b",
+    r"/purge\b",
+    r"/drop[-_]?(?:db|database|table|all)\b",
+    r"/reset[-_]?(?:all|db|database)\b",
+    r"/destroy[-_]?all\b",
+    r"/admin/(?:teardown|format|nuke)\b",
+    r"/__truncate__\b",
+    r"/factory[-_]?reset\b",
+]
+
+_DEFAULT_MUTATING_METHODS = {"DELETE", "PUT", "PATCH"}
+
+
+@dataclass
+class ScopeConfig:
+    target: str = ""
+    url_allowlist: list[str] = field(default_factory=list)        # regex patterns
+    url_blocklist: list[str] = field(default_factory=list)
+    method_allowlist: list[str] = field(default_factory=lambda: ["GET", "POST", "HEAD", "OPTIONS"])
+    destructive_patterns: list[str] = field(default_factory=lambda: list(_DEFAULT_DESTRUCTIVE_PATTERNS))
+    destructive_ok: bool = False             # --destructive-ok flag
+    max_requests_per_endpoint: int = 30
+    max_requests_total: int = 1500
+    five_xx_streak_threshold: int = 8        # halt scan after this many consecutive 5xx from one host
+    authorization_attestation: str = ""      # free text, written into audit log
+
+    @classmethod
+    def load(cls, path: Optional[Path], destructive_ok: bool = False) -> "ScopeConfig":
+        cfg = cls(destructive_ok=destructive_ok)
+        if path is None:
+            return cfg
+        if not path.exists():
+            return cfg
+        if _yaml is None:
+            print(f"[scope] WARNING: scope file {path} given but PyYAML not installed; using defaults")
+            return cfg
+        data = _yaml.safe_load(path.read_text()) or {}
+        for k, v in data.items():
+            if hasattr(cfg, k):
+                setattr(cfg, k, v)
+        return cfg
+
+
+class ScopeError(Exception):
+    """Raised when a probe attempts an out-of-scope request."""
+    pass
+
+
+class HardKillSignal(Exception):
+    """Raised when scan should halt entirely (5xx flood, lockout, etc)."""
+    pass
+
+
+class ScopeGuard:
+    """Stateful scope enforcer. One per pentest run. Thread-safe."""
+
+    def __init__(self, cfg: ScopeConfig):
+        self.cfg = cfg
+        self._lock = threading.Lock()
+        self._per_endpoint: dict[str, int] = {}
+        self._total = 0
+        self._five_xx_streak = 0
+        self._compiled_allow = [re.compile(p) for p in cfg.url_allowlist]
+        self._compiled_block = [re.compile(p) for p in cfg.url_blocklist]
+        self._compiled_destructive = [re.compile(p, re.IGNORECASE) for p in cfg.destructive_patterns]
+
+    def check_request(self, method: str, path: str) -> tuple[bool, str]:
+        """Returns (allowed, reason). Reason is non-empty when blocked."""
+        method = method.upper()
+        # path normalization for budgeting (strip query, replace numeric ids with {id})
+        norm_path = re.sub(r"/\d+(?=/|$)", "/{id}", path.split("?", 1)[0])
+
+        with self._lock:
+            # 1. hard total budget
+            if self._total >= self.cfg.max_requests_total:
+                return False, f"max_requests_total={self.cfg.max_requests_total} exhausted"
+
+            # 2. per-endpoint budget
+            ep_key = f"{method} {norm_path}"
+            current = self._per_endpoint.get(ep_key, 0)
+            if current >= self.cfg.max_requests_per_endpoint:
+                return False, (f"per-endpoint budget exhausted "
+                               f"({current}/{self.cfg.max_requests_per_endpoint} for {ep_key})")
+
+            # 3. method allowlist (default disallows DELETE/PUT/PATCH unless --destructive-ok)
+            if method not in [m.upper() for m in self.cfg.method_allowlist]:
+                if method in _DEFAULT_MUTATING_METHODS and not self.cfg.destructive_ok:
+                    return False, (f"method {method} blocked by default; "
+                                   f"pass --destructive-ok or add to method_allowlist")
+
+            # 4. destructive path pattern
+            for rx in self._compiled_destructive:
+                if rx.search(path):
+                    if not self.cfg.destructive_ok:
+                        return False, f"destructive path pattern matched: {rx.pattern}"
+
+            # 5. blocklist
+            for rx in self._compiled_block:
+                if rx.search(path):
+                    return False, f"url_blocklist match: {rx.pattern}"
+
+            # 6. allowlist (if set, must match at least one)
+            if self._compiled_allow:
+                if not any(rx.search(path) for rx in self._compiled_allow):
+                    return False, "no url_allowlist pattern matched"
+
+            # OK — count it
+            self._per_endpoint[ep_key] = current + 1
+            self._total += 1
+            return True, ""
+
+    def record_response(self, status: int):
+        with self._lock:
+            if 500 <= status < 600:
+                self._five_xx_streak += 1
+            else:
+                self._five_xx_streak = 0
+            if self._five_xx_streak >= self.cfg.five_xx_streak_threshold:
+                raise HardKillSignal(
+                    f"5xx streak threshold reached "
+                    f"({self._five_xx_streak} consecutive 5xx responses). "
+                    f"Likely WAF block, lockout, or server overload. Halting scan."
+                )
+
+    def stats(self) -> dict:
+        with self._lock:
+            return {
+                "total_requests": self._total,
+                "distinct_endpoints": len(self._per_endpoint),
+                "five_xx_streak": self._five_xx_streak,
+                "per_endpoint": dict(sorted(self._per_endpoint.items(),
+                                            key=lambda x: -x[1])[:20]),
+            }
+
+
+class AuditLog:
+    """JSONL append-only log of every request issued during a scan."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        # Open file with line-buffering so crashes don't lose events
+        self._f = open(self.path, "a", buffering=1)
+        self._count = 0
+
+    def header(self, meta: dict):
+        self._write({"_event": "scan_start", "ts": time.time(), **meta})
+
+    def request(self, identity: str, template_id: str, method: str, url: str,
+                status: int, duration_ms: float, blocked_reason: str = ""):
+        self._write({
+            "_event": "blocked" if blocked_reason else "request",
+            "ts": time.time(), "identity": identity, "template_id": template_id,
+            "method": method.upper(), "url": url, "status": status,
+            "duration_ms": round(duration_ms, 1),
+            "blocked_reason": blocked_reason or None,
+        })
+
+    def finding(self, finding_dict: dict):
+        self._write({"_event": "finding", "ts": time.time(), **finding_dict})
+
+    def footer(self, stats: dict):
+        self._write({"_event": "scan_end", "ts": time.time(), **stats})
+
+    def _write(self, obj: dict):
+        with self._lock:
+            self._f.write(json.dumps(obj, default=str) + "\n")
+            self._count += 1
+
+    def close(self):
+        with self._lock:
+            try:
+                self._f.close()
+            except Exception:
+                pass
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+
+def write_example_scope_file(path: Path):
+    """Emit a fully-commented example scope.yaml for the user to customize."""
+    content = """# cxg pentest scope file
+# All fields optional. Defaults shown.
+
+# Operator's written authorization (free text — copied into audit log header).
+authorization_attestation: "Authorized internal staging test by Shahid (2026-06-02)"
+
+# Method allowlist. Add DELETE/PUT/PATCH only with --destructive-ok or explicit override.
+method_allowlist: [GET, POST, HEAD, OPTIONS]
+
+# URL allowlist (regex). If empty, all paths under --target are in scope.
+# If non-empty, only paths matching at least one pattern are allowed.
+url_allowlist: []
+# Example:
+# url_allowlist:
+#   - "^/api/.*"
+
+# URL blocklist (regex). Always enforced.
+url_blocklist: []
+# Example:
+# url_blocklist:
+#   - "^/api/users/1\\b"   # never touch the root admin account
+
+# Destructive path patterns. These are blocked unless --destructive-ok is set.
+destructive_patterns:
+  - "/delete[-_]?all\\b"
+  - "/wipe\\b"
+  - "/purge\\b"
+  - "/drop[-_]?(?:db|database|table|all)\\b"
+  - "/reset[-_]?(?:all|db|database)\\b"
+
+# Budgets
+max_requests_per_endpoint: 30
+max_requests_total: 1500
+
+# Halt scan after this many consecutive 5xx (likely WAF / lockout / server crash)
+five_xx_streak_threshold: 8
+"""
+    path.write_text(content)

--- a/pentest/session_health.py
+++ b/pentest/session_health.py
@@ -1,0 +1,159 @@
+"""Session health monitor — keeps authenticated contexts alive across long scans.
+
+Between probes, the engine asks SessionHealthMonitor whether each ProbeContext is
+still authenticated. The check uses the LANDING TEST (navigate to target, see if we
+get bounced to a login page) as the primary signal — same logic as pre-flight
+inspection — because it works on every app without needing a configured /me endpoint.
+
+If landing test says dead AND we have creds, we try to re-auth from the in-memory
+creds map. If no creds, we mark dead-permanent. Dead profiles get skipped from
+subsequent template runs.
+"""
+from __future__ import annotations
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+def _looks_like_login_page(final_url: str, html: str) -> bool:
+    """Same heuristic profile_inspect uses — see profile_inspect.py for rationale."""
+    u = (final_url or "").lower()
+    if any(s in u for s in ("/login", "/signin", "/sign-in", "/auth/login",
+                              "/oauth/authorize", "/sso", "/saml",
+                              "auth.ac", "okta.com", "auth0.com", "accounts.google.com",
+                              "/keycloak", "/realms/")):
+        return True
+    h = (html or "")[:65536].lower()
+    login_markers = (
+        '<input type="password"', "<input type='password'", "type=password",
+        'name="password"', "name='password'",
+        "sign in to", "log in to", "please sign in", "please log in",
+        ">login</", ">sign in</",
+    )
+    return sum(1 for m in login_markers if m in h) >= 2
+
+
+@dataclass
+class HealthState:
+    profile_name: str
+    last_check_ts: float = 0.0
+    last_status: int = 0
+    consecutive_failures: int = 0
+    reauth_attempts: int = 0
+    dead: bool = False
+
+
+class SessionHealthMonitor:
+    """One per scan run. Owns per-profile health state and creds for re-auth."""
+
+    def __init__(self, target: str, health_path: str = "/api/me",
+                 creds_map: Optional[dict[str, tuple[str, str, str]]] = None,
+                 login_path: str = "/api/auth/login",
+                 max_reauth_attempts: int = 3):
+        self.target = target.rstrip("/")
+        self.health_path = health_path
+        self.login_path = login_path
+        self.creds_map = creds_map or {}
+        self.max_reauth_attempts = max_reauth_attempts
+        self.states: dict[str, HealthState] = {}
+
+    def state(self, profile_name: str) -> HealthState:
+        if profile_name not in self.states:
+            self.states[profile_name] = HealthState(profile_name=profile_name)
+        return self.states[profile_name]
+
+    async def check(self, ctx) -> tuple[bool, int]:
+        """Return (alive, status). Uses the LANDING TEST as the primary signal:
+        navigate to target, see if the final URL/page looks like a login redirect.
+
+        status is set to 200 on alive, 0 on landing-failed, or the actual HTTP status
+        from the secondary me_path probe if we tried that.
+        """
+        s = self.state(ctx.profile.name)
+        s.last_check_ts = time.time()
+
+        # Landing test (primary): navigate to target, check final URL+content.
+        # We do this on the existing page rather than opening a new context — keeps
+        # state in sync with what subsequent probes see.
+        try:
+            await ctx.page.goto(self.target, wait_until="domcontentloaded", timeout=15000)
+            try:
+                await ctx.page.wait_for_load_state("networkidle", timeout=3000)
+            except Exception:
+                pass
+            landed_url = ctx.page.url
+            try:
+                landed_html = await ctx.page.content()
+            except Exception:
+                landed_html = ""
+        except Exception:
+            s.last_status = 0
+            s.consecutive_failures += 1
+            return False, 0
+
+        if not _looks_like_login_page(landed_url, landed_html):
+            s.last_status = 200
+            s.consecutive_failures = 0
+            return True, 200
+
+        # Bounced to login page → dead
+        s.last_status = 401
+        s.consecutive_failures += 1
+        return False, 401
+
+    async def ensure_alive(self, ctx) -> tuple[bool, str]:
+        """Check + auto-reauth if needed. Returns (alive_now, message)."""
+        s = self.state(ctx.profile.name)
+        if s.dead:
+            return False, f"profile {ctx.profile.name} permanently dead"
+        alive, status = await self.check(ctx)
+        if alive:
+            return True, f"healthy ({status})"
+        # Re-auth attempt
+        creds = self.creds_map.get(ctx.profile.name)
+        if not creds:
+            return False, f"unhealthy (status {status}) and no creds for re-auth"
+        if s.reauth_attempts >= self.max_reauth_attempts:
+            s.dead = True
+            return False, f"reauth budget exhausted ({s.reauth_attempts} attempts)"
+        s.reauth_attempts += 1
+        email, password, label = creds
+        ok, msg = await self._reauth(ctx, email, password)
+        if not ok:
+            return False, f"reauth attempt {s.reauth_attempts} failed: {msg}"
+        # Re-check
+        alive, status = await self.check(ctx)
+        if alive:
+            s.reauth_attempts = 0
+            return True, f"reauth successful ({status})"
+        return False, f"reauth completed but health still {status}"
+
+    async def _reauth(self, ctx, email: str, password: str) -> tuple[bool, str]:
+        """POST creds to login_path inside the existing context. Updates cookies in place."""
+        try:
+            # Need CSRF — ensure we've fetched the index once
+            await ctx.page.goto(self.target, wait_until="domcontentloaded", timeout=10000)
+            csrf = None
+            for c in await ctx.ctx.cookies():
+                if c["name"] == "csrf_token":
+                    csrf = c["value"]
+                    break
+            res = await ctx.page.evaluate(
+                """async ({url, body, csrf}) => {
+                    const h = {'Content-Type':'application/json'};
+                    if (csrf) h['X-CSRF-Token'] = csrf;
+                    const r = await fetch(url, {method:'POST', credentials:'include', headers:h, body: JSON.stringify(body)});
+                    return r.status;
+                }""",
+                {"url": self.target + self.login_path,
+                 "body": {"email": email, "password": password},
+                 "csrf": csrf},
+            )
+            if res in (200, 201, 204):
+                return True, f"login returned {res}"
+            return False, f"login returned {res}"
+        except Exception as e:
+            return False, f"exception: {e}"

--- a/pentest/validator.py
+++ b/pentest/validator.py
@@ -1,0 +1,161 @@
+"""Pre-execution validator for AI-generated JS pentest templates.
+
+Catches templates that would:
+  - silently misbehave (no @id, no @vuln_class, no cxgProbe function)
+  - violate the contract (raw fetch() instead of cxg.fetch — credentials lost)
+  - target destructive routes (regex check on string literals in the source)
+  - exceed declared request budget
+
+Static analysis is intentionally conservative — better to flag a benign template
+than to run a bad one. The runtime ScopeGuard provides the backstop.
+"""
+from __future__ import annotations
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+REQUIRED_META = ["id", "vuln_class"]
+ALLOWED_VULN_CLASSES = {
+    "idor", "csrf", "xss", "ssrf", "command_injection", "session_replay",
+    "credential_stuffing", "rate_limit_bypass", "privilege_escalation",
+    "sensitive_data_exposure", "metrics_info_disclosure", "clickjacking",
+    "content_sniffing", "auth_api",
+}
+
+# Patterns we refuse to allow in a template source (regex over JS source text).
+# These map to literal strings that, if found in fetch URLs, indicate intent to
+# touch destructive endpoints. Conservative — false positives are OK.
+_DESTRUCTIVE_LITERAL_PATTERNS = [
+    r"['\"`][^'\"`]*?/delete[-_]?all[^'\"`]*['\"`]",
+    r"['\"`][^'\"`]*?/wipe[^'\"`]*['\"`]",
+    r"['\"`][^'\"`]*?/purge[^'\"`]*['\"`]",
+    r"['\"`][^'\"`]*?/drop[-_]?(?:db|database|table|all)[^'\"`]*['\"`]",
+    r"['\"`][^'\"`]*?/reset[-_]?(?:all|db|database)[^'\"`]*['\"`]",
+    r"['\"`][^'\"`]*?/factory[-_]?reset[^'\"`]*['\"`]",
+]
+
+# Anti-pattern: raw fetch() bypasses our cxg.fetch wrapper (which auto-adds CSRF
+# and routes through audit log). Allow window.__cxg_fetchAs and cxg.fetch / cxg.fetchAs.
+_RAW_FETCH_PATTERN = re.compile(
+    r"(?<![.\w])fetch\s*\(",
+)
+# But we DO allow patterns like cxg.fetch(...) and window.__cxg_fetchAs(...)
+# By using a negative lookbehind for `.` or word char, we naturally skip the cxg.fetch case.
+
+# Hard upper bound on raw `await ... fetch` or loop iterations (cheap heuristic).
+# We count occurrences of `cxg.fetch(`, `cxg.fetchAs(`, `__cxg_fetchAs(` — if combined with
+# a for/while loop they could explode. Flag if more than this many fetch sites AND a loop.
+_MAX_FETCH_CALLSITES = 12
+
+_FETCH_CALLSITES = re.compile(r"\b(?:cxg\.fetch(?:As)?\b|__cxg_fetchAs\b)")
+_LOOP_PATTERN = re.compile(r"\b(?:for|while)\s*\(")
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    meta: dict = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+_META_RX = re.compile(r"//\s*@(\w+):\s*(.*)")
+
+
+def parse_meta(source: str) -> dict:
+    meta = {}
+    for line in source.splitlines():
+        m = _META_RX.match(line.strip())
+        if m:
+            meta[m.group(1).lower()] = m.group(2).strip()
+    return meta
+
+
+def validate(source: str, destructive_ok: bool = False) -> ValidationResult:
+    errors: list[str] = []
+    warnings: list[str] = []
+    meta = parse_meta(source)
+
+    # 1. Required metadata
+    for k in REQUIRED_META:
+        if k not in meta:
+            errors.append(f"missing required metadata: @{k}")
+
+    if "vuln_class" in meta and meta["vuln_class"] not in ALLOWED_VULN_CLASSES:
+        warnings.append(f"unusual vuln_class '{meta['vuln_class']}' (not in standard set)")
+
+    # 2. Must define cxgProbe
+    if not re.search(r"\basync\s+function\s+cxgProbe\s*\(", source):
+        errors.append("missing required `async function cxgProbe(cxg)` definition")
+
+    # 3. No raw fetch() — must use cxg.fetch or cxg.fetchAs
+    raw_fetch_matches = []
+    for m in _RAW_FETCH_PATTERN.finditer(source):
+        # Check the char immediately before — if it's `.` it's cxg.fetch, allow.
+        start = m.start()
+        if start > 0 and source[start - 1] in ".$_":
+            continue
+        # If the preceding identifier is `window.__cxg_fetchAs` style, allow.
+        # We've already excluded `.fetch(`. So a bare `fetch(` slipped through — flag it.
+        line_start = source.rfind("\n", 0, start) + 1
+        line_end = source.find("\n", start)
+        line = source[line_start:line_end if line_end >= 0 else len(source)]
+        raw_fetch_matches.append((start, line.strip()))
+    if raw_fetch_matches:
+        errors.append(
+            f"raw fetch() call detected ({len(raw_fetch_matches)} site(s)). "
+            f"Templates must use cxg.fetch(path, opts) or cxg.fetchAs(idx, path, opts) — "
+            f"raw fetch() bypasses CSRF injection and the audit log. "
+            f"First offending line: {raw_fetch_matches[0][1][:120]}"
+        )
+
+    # 4. Destructive literals
+    if not destructive_ok:
+        for pat in _DESTRUCTIVE_LITERAL_PATTERNS:
+            m = re.search(pat, source, re.IGNORECASE)
+            if m:
+                errors.append(
+                    f"template contains destructive endpoint literal: {m.group(0)[:80]} — "
+                    f"pass --destructive-ok to allow"
+                )
+
+    # 5. Cheap explosion heuristic: many fetch sites + a loop = potential runaway
+    callsite_count = len(_FETCH_CALLSITES.findall(source))
+    has_loop = bool(_LOOP_PATTERN.search(source))
+    if callsite_count > _MAX_FETCH_CALLSITES and has_loop:
+        warnings.append(
+            f"template has {callsite_count} fetch call sites AND a loop — potential request flood. "
+            f"ScopeGuard budget will halt it, but consider rewriting."
+        )
+
+    # 6. requires_auth_count sanity
+    if "requires_auth_count" in meta:
+        try:
+            n = int(meta["requires_auth_count"])
+            if n < 1 or n > 5:
+                warnings.append(f"requires_auth_count={n} is unusual (expected 1 or 2)")
+        except ValueError:
+            errors.append(f"requires_auth_count must be an int, got: {meta['requires_auth_count']}")
+
+    return ValidationResult(ok=not errors, errors=errors, warnings=warnings, meta=meta)
+
+
+if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        if not p.exists():
+            print(f"missing: {p}")
+            continue
+        r = validate(p.read_text())
+        status = "OK" if r.ok else "REJECT"
+        print(f"{status} {p}")
+        for e in r.errors:
+            print(f"  ✗ {e}")
+        for w in r.warnings:
+            print(f"  ⚠ {w}")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,8 +146,417 @@ pub enum Commands {
     /// MCP (Model Context Protocol) server for AI agent integration
     Mcp(McpCommand),
 
+    /// AI-driven whitebox pentest pipeline (guardlink source code → authenticated browser execution)
+    ///
+    /// Reads `whitebox/findings.sarif` produced by guardlink, ranks threats against an
+    /// operator goal, and asks your local AI CLI (claude / codex / gemini) to write
+    /// JavaScript probe templates that read the target's source to craft code-aware
+    /// payloads. Those templates execute in N parallel authenticated Chromium contexts,
+    /// emitting confirmed/refuted/ambiguous findings to a JSON report plus a JSONL audit
+    /// log of every HTTP request.
+    ///
+    /// Capabilities:
+    ///   • Interactive auth capture for SSO/MFA flows (no need to script logins)
+    ///   • Chained-auth probes (IDOR cross-user) via `--auth-numbers 2+`
+    ///   • Pre-flight identity inspection — landing-test based, no /me-path required
+    ///   • Goal-driven LLM ranking of guardlink hypotheses
+    ///   • Validator-guarded code-generation with hard 240s timeout per AI call
+    ///   • Retry-with-mutation on AMBIGUOUS triage (max N retries, env-bound skip)
+    ///   • Scope enforcement (URL/method allowlist, per-endpoint budget, 5xx hard-kill)
+    ///   • Cookie-jar primitives in templates (HttpOnly-aware via Playwright)
+    ///   • Out-of-band callback support for blind-vuln confirmation (`--oast`)
+    ///   • Per-profile custom headers (WAF bypass, internal-test headers)
+    ///   • Split report: confirmed_findings vs mitigation_verifications vs ambiguous
+    Pentest(PentestCommand),
+
     /// Display version information
     Version,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct PentestCommand {
+    #[command(subcommand)]
+    pub action: PentestAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum PentestAction {
+    /// Install the Python orchestrator into ~/.cert-x-gen/pentest/
+    ///
+    /// One-time setup. Copies the Python orchestrator bundled with the cxg source tree
+    /// to `~/.cert-x-gen/pentest/`, then verifies the required Python deps (playwright,
+    /// anthropic) are installed. Must be run before `cxg pentest auth` or `cxg pentest run`.
+    ///
+    /// Examples:
+    ///     cxg pentest install
+    ///     cxg pentest install --force     # reinstall after pulling new cxg source
+    Install {
+        /// Reinstall even if `~/.cert-x-gen/pentest/` already exists. Use after
+        /// updating the cxg source tree or pulling new Python modules.
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Capture an authenticated browser session as a reusable profile
+    ///
+    /// Spawns a real headed Chromium window. You log in by ANY means — username/password,
+    /// SSO redirect, MFA prompt, hardware key, magic link, OAuth popup. When the app
+    /// dashboard is showing, press ENTER in the terminal (or close the browser) and
+    /// cxg snapshots cookies + localStorage + sessionStorage from every origin the
+    /// browser touched. The profile is saved at `~/.cert-x-gen/auth/<profile>.json`
+    /// plus metadata at `<profile>.meta.json`.
+    ///
+    /// A post-capture landing-test verifies the session works: it re-opens a fresh
+    /// browser context with the saved state, navigates to --target, and checks whether
+    /// the final URL/page looks like a login or the app dashboard.
+    ///
+    /// Use `--auth-numbers N` for chained-auth scenarios (e.g. IDOR testing needs two
+    /// different identities). cxg prompts for a human-readable label for each capture.
+    ///
+    /// Examples:
+    ///     # Single interactive capture
+    ///     cxg pentest auth --target https://app.example.com --profile admin
+    ///
+    ///     # Two identities for chained-auth (e.g. IDOR victim + attacker)
+    ///     cxg pentest auth --target https://app.example.com --profile pentest --auth-numbers 2
+    ///
+    ///     # Scripted login (no browser pop-up)
+    ///     cxg pentest auth --target https://app.example.com --profile bot \
+    ///       --creds 'user@example.com:hunter2' --login-path /api/auth/login
+    ///
+    ///     # Capture a profile that sends a WAF-bypass header on every request
+    ///     cxg pentest auth --target https://app.example.com --profile pentest \
+    ///       --header "x-test-automation:abc123xyz"
+    Auth {
+        /// Target URL where login happens (e.g. https://app.example.com).
+        /// After capture, the landing-test verifier opens this URL with the saved
+        /// cookies; if it doesn't bounce to a login page, the session is alive.
+        #[arg(long)]
+        target: String,
+
+        /// Profile name. If --auth-numbers > 1, this is the PREFIX and final profiles
+        /// are named `<profile>-1`, `<profile>-2`, etc. Use a stable name so subsequent
+        /// `cxg pentest run --auth <profile>` invocations can reload it.
+        #[arg(long)]
+        profile: String,
+
+        /// Number of profiles to capture in sequence. Each capture opens its own
+        /// Chromium window and prompts for a label (e.g. "victim", "attacker", "admin").
+        /// Required ≥2 for chained-auth probes like IDOR cross-user tests.
+        #[arg(long, default_value = "1")]
+        auth_numbers: usize,
+
+        /// Inline credentials `email:password` for scripted login (skips browser pop-up).
+        /// Only works for password-based auth — SSO/MFA flows MUST use interactive capture.
+        #[arg(long)]
+        creds: Option<String>,
+
+        /// File with `profile:email:password[:label]` per line for scripted batch capture.
+        /// Useful for re-auth between scans of password-only test apps.
+        #[arg(long)]
+        creds_file: Option<PathBuf>,
+
+        /// Endpoint path for scripted login POST. Only used with `--creds` or `--creds-file`.
+        /// The captured browser will POST {email, password} as JSON to <target><login-path>.
+        #[arg(long, default_value = "/api/auth/login")]
+        login_path: String,
+
+        /// Human-readable label for the profile (e.g. "admin", "low-priv-user").
+        /// Shown in scan output to make findings readable. Does not affect behavior.
+        #[arg(long)]
+        label: Option<String>,
+
+        /// Optional URL probed after capture as a secondary identity check. The landing
+        /// test is the primary signal regardless. Default: empty (landing test only).
+        /// Pass an empty string to skip the secondary probe entirely.
+        #[arg(long)]
+        verify_url: Option<String>,
+
+        /// Custom HTTP header `NAME:VALUE` sent on every outbound request from this
+        /// profile's browser context — including login, every scan probe, every health
+        /// check. Repeatable for multiple headers. Saved with the profile so future
+        /// `cxg pentest run --auth <profile>` invocations reuse them automatically.
+        ///
+        /// Use case: WAF-bypass tokens granted by infra (e.g. `x-test-automation`),
+        /// internal-test headers, custom forwarding hints.
+        ///
+        /// SECURITY: header values are stored in plaintext under
+        /// `~/.cert-x-gen/auth/<profile>.meta.json`. Treat the file like a credential.
+        /// `chmod 600` if your machine has multiple users. Delete the profile when
+        /// the engagement ends. Header values are sent to EVERY origin the browser
+        /// touches, including IDPs — keep this in mind for SSO flows.
+        #[arg(long = "header", value_name = "NAME:VALUE")]
+        headers: Vec<String>,
+    },
+
+    /// List saved auth profiles under ~/.cert-x-gen/auth/
+    ///
+    /// Shows profile name, label, target URL, and whether extra_headers are present.
+    /// Useful before running `cxg pentest run --auth <name>` to confirm which profile
+    /// you'll be scanning as.
+    AuthList,
+
+    /// Write an example scope.yaml the operator can edit
+    ///
+    /// scope.yaml controls the safety rails for a scan: method allowlist (default
+    /// GET/POST/HEAD/OPTIONS — DELETE/PUT/PATCH require `--destructive-ok`), URL
+    /// allow/blocklist regexes, per-endpoint and total request budgets, 5xx-streak
+    /// hard-kill threshold, and the `authorization_attestation` field that's recorded
+    /// in the audit log header.
+    ///
+    /// Example:
+    ///     cxg pentest scope-init -o my-engagement-scope.yaml
+    ScopeInit {
+        /// Output file path. Default: scope.yaml in the current directory.
+        #[arg(short, long, default_value = "scope.yaml")]
+        output: PathBuf,
+    },
+
+    /// Run the full end-to-end pentest pipeline against a target
+    ///
+    /// Pipeline steps:
+    ///   [1]  Load guardlink hypotheses from `<codebase>/whitebox/findings.sarif`
+    ///   [1b] Inspect captured auth profiles via landing-test
+    ///        (`profile_inspect.inspect_profiles_async`)
+    ///   [2]  LLM-rank hypotheses against --goal + profile coverage; AI generates JS
+    ///        templates that read source via Claude/Codex/Gemini's own Read/Grep tools
+    ///   [3]  Load + statically validate templates (`validator.py`)
+    ///   [4]  Open N parallel authenticated Chromium contexts; inject the cxg JS bridge
+    ///   [5]  Run each template; triage findings (CONFIRMED / REFUTED / AMBIGUOUS);
+    ///        mutate-and-retry on payload-fixable AMBIGUOUS, skip environment-bound
+    ///   [6]  Write `report.json` and `audit.jsonl` to --session-dir
+    ///
+    /// The full set of probes available to templates is documented in
+    /// `pentest/docs/TEMPLATES.md`. The runtime intelligence layer (validator, scope,
+    /// session health, mutation, triage, audit) is in `pentest/docs/ARCHITECTURE.md`.
+    ///
+    /// Examples:
+    ///     # Single-profile read-only scan with default settings
+    ///     cxg pentest run --codebase ./repo --target http://localhost:8000 \
+    ///       --auth admin --ai --ai-provider claude
+    ///
+    ///     # Two identities for IDOR/chained-auth, AI off → built-in probes only
+    ///     cxg pentest run --codebase ./repo --target http://localhost:8000 \
+    ///       --auth victim,attacker
+    ///
+    ///     # Verify mitigations only (skips unmitigated threats so you can confirm
+    ///     # declared defenses hold at runtime). Useful for well-annotated codebases.
+    ///     cxg pentest run --codebase ./repo --target https://staging.app \
+    ///       --auth pentest --ai --ai-provider claude \
+    ///       --mitigation-mode mitigated --max-templates 16
+    ///
+    ///     # OAST-confirmed SSRF testing (definitive blind-vuln confirmation)
+    ///     cxg pentest run --codebase ./repo --target https://staging.app \
+    ///       --auth pentest --ai --ai-provider claude \
+    ///       --oast c4ca4238a0b92.oast.fun \
+    ///       --goal "verify SSRF on /slack/proxy via OAST callback"
+    ///
+    /// Exit codes:
+    ///   0 → no confirmed findings (clean scan)
+    ///   1 → no templates available (guardlink output missing or empty)
+    ///   2 → confirmed findings present
+    ///   3 → scan was hard-killed (5xx streak, scope violation, etc.)
+    Run {
+        /// Source codebase root. MUST contain `whitebox/findings.sarif` produced by
+        /// `guardlink sarif <codebase> -o whitebox/findings.sarif`. The codebase is also
+        /// the working directory of the AI CLI during template generation, so the AI
+        /// can read source via its own Read/Grep tools to craft code-aware payloads.
+        #[arg(long)]
+        codebase: PathBuf,
+
+        /// Running target app URL. Both `http://` and `https://` are supported.
+        /// Multi-tenant note: pass the URL where the SESSION cookies live, not a marketing
+        /// host. The landing test verifies you arrive at a non-login page from this URL.
+        #[arg(long)]
+        target: String,
+
+        /// Comma-separated auth profile names previously captured via `cxg pentest auth`.
+        /// Probes that need multiple identities (IDOR cross-user, session-replay-against-
+        /// victim) require ≥2 profiles. The lowest-privilege identity is auto-selected as
+        /// the actor for privesc-class probes.
+        ///
+        /// Leave empty if you're using --interactive-auth to capture fresh profiles inline.
+        #[arg(long, default_value = "")]
+        auth: String,
+
+        /// Open N headed browser windows for interactive login at scan start, then run
+        /// the pipeline with the resulting fresh profiles. Each capture prompts you for
+        /// a per-identity label. Use this when your captured profiles have expired or
+        /// when you don't want to manage profile lifecycle separately.
+        ///
+        /// Profiles are saved as `<--auth-profile>-1`, `<--auth-profile>-2`, etc.
+        #[arg(long, default_value = "0")]
+        interactive_auth: usize,
+
+        /// Name prefix for `--interactive-auth` captures. The final profile names are
+        /// `<auth_profile>-1`, `<auth_profile>-2`, etc.
+        #[arg(long, default_value = "pentest")]
+        auth_profile: String,
+
+        /// Minimum auth contexts the scan requires. If you pass `--auth a,b` but
+        /// `--auth-numbers 3`, chained-auth templates that need 3 contexts will be
+        /// skipped with a warning. Pure usability check — engine doesn't fabricate
+        /// extra contexts.
+        #[arg(long)]
+        auth_numbers: Option<usize>,
+
+        /// File of `profile:email:password[:label]` lines used to AUTO RE-AUTH a
+        /// dead session mid-scan (the session-health monitor detects death via the
+        /// landing test). Without this, a probe that kills its own session — e.g.
+        /// session_replay's logout — leaves remaining probes unable to run.
+        ///
+        /// Recommended for any scan with `--mutation-retries > 0` or scans with
+        /// SessionReplay / Csrf class templates.
+        #[arg(long)]
+        creds_file: Option<PathBuf>,
+
+        /// Template language. `js` (default): AI generates copy-paste-runnable JS
+        /// templates that drive the cxg JS bridge — recommended for all interactive
+        /// pentests. `py`: Python probe path (legacy) — only built-in probes in
+        /// `pentest/payloads/`, no AI generation.
+        #[arg(long, default_value = "js")]
+        template_lang: String,
+
+        /// Natural-language pentest goal. Used as context for both LLM-based hypothesis
+        /// ranking AND template generation. Be specific about which vuln classes,
+        /// endpoints, or claims you want tested.
+        ///
+        /// Examples:
+        ///   "test for IDOR in records and transactions APIs"
+        ///   "verify each declared @mitigates actually holds at runtime"
+        ///   "find unguarded admin endpoints accessible to non-admin tokens"
+        #[arg(long)]
+        goal: Option<String>,
+
+        /// Reuse JS templates from a previously-generated session directory. Skips the
+        /// AI generation step entirely. Useful for re-running the same templates against
+        /// different targets, or after fixing engine bugs that affected template execution.
+        ///
+        /// Template directories are at `~/.cert-x-gen/templates/session-<timestamp>/`.
+        #[arg(long)]
+        template_dir: Option<PathBuf>,
+
+        /// Maximum number of templates the LLM ranker is allowed to select per scan.
+        /// Each template = one AI generation call (~60-180s with claude/codex). Lower for
+        /// fast feedback loops; higher for engagement-grade coverage.
+        #[arg(long, default_value = "8")]
+        max_templates: usize,
+
+        /// Maximum times the AI is allowed to mutate a template after AMBIGUOUS triage.
+        /// Environment-bound AMBIGUOUS (missing role, missing primitive) skip mutation
+        /// automatically; only payload-fixable ones consume retries.
+        /// 0 disables the loop entirely.
+        #[arg(long, default_value = "2")]
+        mutation_retries: usize,
+
+        /// AI provider. `auto` picks the first available CLI tool (claude > codex > gemini),
+        /// falling back to ANTHROPIC_API_KEY / OPENAI_API_KEY HTTP APIs. Otherwise specify
+        /// explicitly. CLI providers don't need API keys — they use your existing CLI auth.
+        ///
+        /// Options: auto | claude | codex | gemini | anthropic | openai
+        #[arg(long, default_value = "claude")]
+        ai_provider: String,
+
+        /// Enable AI-driven template generation. Without `--ai`, only built-in probes
+        /// from `pentest/payloads/` run. With `--ai`, the orchestrator invokes the
+        /// chosen `--ai-provider` to read the codebase and synthesize code-aware
+        /// templates per guardlink hypothesis.
+        #[arg(long)]
+        ai: bool,
+
+        /// Show Chromium windows during scan instead of running headless. Useful for
+        /// debugging probes, watching auth flows, or when WAF bot-detection is blocking
+        /// headless requests (real Chromium has a stronger fingerprint than headless).
+        #[arg(long)]
+        headed: bool,
+
+        /// Path to scope.yaml. Default: safe permissive defaults (any URL, GET/POST/HEAD/
+        /// OPTIONS, 30 reqs/endpoint, 1500 reqs total, kill on 8-streak 5xx).
+        /// Generate one with `cxg pentest scope-init`.
+        #[arg(long)]
+        scope_file: Option<PathBuf>,
+
+        /// Allow DELETE/PUT/PATCH methods AND paths matching destructive regexes
+        /// (`/wipe`, `/delete-all`, `/factory-reset`, etc.) in scope.yaml.
+        /// Default OFF. Required for templates that test destructive-action authz.
+        ///
+        /// USE WITH CARE on production targets. The engine emits a warning at startup
+        /// and every blocked request is still recorded in the audit log.
+        #[arg(long)]
+        destructive_ok: bool,
+
+        /// Free-text written authorization statement recorded in the audit log header.
+        /// Include engagement ID, operator name, change-management ticket, etc.
+        ///
+        /// Example: "Engagement PT-2026-003, operator J. Doe, ticket CHG-1234"
+        ///
+        /// Strongly recommended for any non-local scan. The audit log header is the
+        /// dispute-ready record of "I had authorization to do this scan."
+        #[arg(long)]
+        attestation: Option<String>,
+
+        /// Session directory where this scan's artifacts (audit.jsonl, report.json,
+        /// any captured screenshots) are written.
+        /// Default: ~/.cert-x-gen/sessions/pentest-<YYYYMMDD-HHMMSS>/
+        #[arg(long)]
+        session_dir: Option<PathBuf>,
+
+        /// JSON report output path. Default: `report.json` under --session-dir.
+        /// The report contains: target, codebase, auth_profiles, goal, scope_stats,
+        /// confirmed_findings, ambiguous, mitigation_verifications, dead_profiles,
+        /// rejected_templates, retried_then_resolved.
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+
+        /// Hypothesis filter by declared-mitigation status from guardlink:
+        ///   `any`         — all HTTP-testable hypotheses (default)
+        ///   `unmitigated` — only threats WITHOUT a declared @mitigates
+        ///                   (find unguarded holes)
+        ///   `mitigated`   — only threats WITH @mitigates declared
+        ///                   (verify defenses actually hold at runtime)
+        #[arg(long, default_value = "any")]
+        mitigation_mode: String,
+
+        /// Optional identity endpoint hit during pre-flight inspection to extract
+        /// role/email/id from a JSON response. Failure here does NOT mark the profile
+        /// dead — the landing test is the source of truth. Override only when you
+        /// want role-tier-based probe selection AND the app has a stable /me endpoint.
+        ///
+        /// Default `/api/me`. Set to empty string to skip the secondary probe.
+        #[arg(long, default_value = "/api/me")]
+        me_path: String,
+
+        /// Hard wall-clock timeout per AI generation call. The whole process tree is
+        /// killed if exceeded. Default 240s.
+        ///
+        /// Claude CLI typically takes 60-170s per template; Codex 90-220s; Gemini 30-180s.
+        /// Bump to 600+ for very large codebases the AI has to grep through.
+        #[arg(long, default_value = "240")]
+        generation_timeout: u64,
+
+        /// Skip the pre-flight session health check entirely. Use when:
+        ///   • Multi-tenant app where the session lives at a subdomain different from --target
+        ///   • App has no stable /me-style endpoint
+        ///   • You know the session is fresh and want to skip the verification roundtrip
+        ///
+        /// Per-template health checks still run during the scan unless you also configure
+        /// scope.yaml to disable them.
+        #[arg(long)]
+        skip_health_check: bool,
+
+        /// Out-of-band callback host (interactsh, Burp Collaborator, etc.). Exposed to
+        /// templates as `cxg.oast.url(label, scheme?)` for definitive blind-vuln
+        /// confirmation. Without this, blind probes (SSRF, blind SQLi, blind XXE,
+        /// blind cmd-injection) must fall back to status-code heuristics and timing,
+        /// which the AI prompt is instructed to mark `confirmed=false`.
+        ///
+        /// Example: `--oast c4ca4238a0b923820dcc.oast.fun`
+        ///
+        /// Start an interactsh-client in another terminal first:
+        ///     interactsh-client  # paste the hostname it prints
+        #[arg(long, value_name = "HOST")]
+        oast: Option<String>,
+    },
 }
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,11 +174,222 @@ async fn run(cli: Cli) -> Result<()> {
                 }
             }
         }
+        Commands::Pentest(cmd) => {
+            run_pentest_command(cmd).await?;
+        }
         Commands::Version => {
             print_version();
         }
     }
 
+    Ok(())
+}
+
+/// Pentest orchestrator install dir — Python sources copied here on first install.
+fn pentest_home() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".cert-x-gen").join("pentest")
+    } else {
+        PathBuf::from(".cert-x-gen/pentest")
+    }
+}
+
+/// Dispatch for `cxg pentest …` — shells out to the Python orchestrator installed under
+/// ~/.cert-x-gen/pentest/. The orchestrator is a Python module that handles auth capture,
+/// codebase ingest, AI generation, browser execution, scope enforcement, and reporting.
+async fn run_pentest_command(cmd: cli::PentestCommand) -> Result<()> {
+    use std::process::Command as SysCommand;
+    let home = pentest_home();
+
+    // Install action — copy bundled Python orchestrator + check deps.
+    if matches!(cmd.action, cli::PentestAction::Install { .. }) {
+        let force = matches!(cmd.action, cli::PentestAction::Install { force: true });
+        return pentest_install(&home, force);
+    }
+
+    // For every other action, the orchestrator must be installed.
+    let orchestrator = home.join("cxg_pentest.py");
+    if !orchestrator.exists() {
+        eprintln!("Pentest orchestrator not installed at {}", orchestrator.display());
+        eprintln!("Run: cxg pentest install");
+        return Err(Error::Config("pentest orchestrator not installed".to_string()));
+    }
+
+    // Build argv for the Python orchestrator.
+    let mut args: Vec<String> = vec![orchestrator.to_string_lossy().to_string()];
+    match cmd.action {
+        cli::PentestAction::Install { .. } => unreachable!(),
+        cli::PentestAction::Auth { target, profile, auth_numbers, creds, creds_file, login_path, label, verify_url, headers } => {
+            args.extend(["auth".into(), "login".into(),
+                "--target".into(), target,
+                "--profile".into(), profile,
+                "--auth-numbers".into(), auth_numbers.to_string(),
+                "--login-path".into(), login_path]);
+            if let Some(c) = creds { args.extend(["--creds".into(), c]); }
+            if let Some(f) = creds_file { args.extend(["--creds-file".into(), f.to_string_lossy().to_string()]); }
+            if let Some(l) = label { args.extend(["--label".into(), l]); }
+            if let Some(v) = verify_url { args.extend(["--verify-url".into(), v]); }
+            for h in headers { args.extend(["--header".into(), h]); }
+        }
+        cli::PentestAction::AuthList => {
+            args.extend(["auth".into(), "list".into()]);
+        }
+        cli::PentestAction::ScopeInit { output } => {
+            args.extend(["scope".into(), "init".into(),
+                "--output".into(), output.to_string_lossy().to_string()]);
+        }
+        cli::PentestAction::Run {
+            codebase, target, auth, interactive_auth, auth_profile, auth_numbers, creds_file,
+            template_lang, goal, template_dir, max_templates, mutation_retries, ai_provider,
+            ai, headed, scope_file, destructive_ok, attestation, session_dir, output,
+            mitigation_mode, me_path, generation_timeout, skip_health_check, oast,
+        } => {
+            args.push("pentest".into());
+            args.extend(["--codebase".into(), codebase.to_string_lossy().to_string()]);
+            args.extend(["--target".into(), target]);
+            args.extend(["--auth".into(), auth]);
+            args.extend(["--interactive-auth".into(), interactive_auth.to_string()]);
+            args.extend(["--auth-profile".into(), auth_profile]);
+            if let Some(n) = auth_numbers { args.extend(["--auth-numbers".into(), n.to_string()]); }
+            if let Some(f) = creds_file { args.extend(["--creds-file".into(), f.to_string_lossy().to_string()]); }
+            args.extend(["--template-lang".into(), template_lang]);
+            if let Some(g) = goal { args.extend(["--goal".into(), g]); }
+            if let Some(d) = template_dir { args.extend(["--template-dir".into(), d.to_string_lossy().to_string()]); }
+            args.extend(["--max-templates".into(), max_templates.to_string()]);
+            args.extend(["--mutation-retries".into(), mutation_retries.to_string()]);
+            args.extend(["--ai-provider".into(), ai_provider]);
+            if ai { args.push("--ai".into()); }
+            if headed { args.push("--headed".into()); }
+            if let Some(s) = scope_file { args.extend(["--scope-file".into(), s.to_string_lossy().to_string()]); }
+            if destructive_ok { args.push("--destructive-ok".into()); }
+            if let Some(a) = attestation { args.extend(["--attestation".into(), a]); }
+            if let Some(s) = session_dir { args.extend(["--session-dir".into(), s.to_string_lossy().to_string()]); }
+            if let Some(o) = output { args.extend(["--output".into(), o.to_string_lossy().to_string()]); }
+            args.extend(["--mitigation-mode".into(), mitigation_mode]);
+            args.extend(["--me-path".into(), me_path]);
+            args.extend(["--generation-timeout".into(), generation_timeout.to_string()]);
+            if skip_health_check { args.push("--skip-health-check".into()); }
+            if let Some(h) = oast { args.extend(["--oast".into(), h]); }
+        }
+    }
+
+    let python = which_python()?;
+    let status = SysCommand::new(&python).args(&args).status()
+        .map_err(|e| Error::Config(format!("failed to spawn python orchestrator: {}", e)))?;
+    if !status.success() {
+        // Bubble the non-zero exit code up — Python uses 2 for "findings found", 3 for hard-kill
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+
+/// Find a usable python3 binary. Tries CXG_PYTHON env var first.
+fn which_python() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("CXG_PYTHON") {
+        return Ok(PathBuf::from(p));
+    }
+    for candidate in &["python3", "python"] {
+        if let Ok(out) = std::process::Command::new("which").arg(candidate).output() {
+            if out.status.success() {
+                let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Ok(PathBuf::from(path));
+                }
+            }
+        }
+    }
+    Err(Error::Config("python3 not found on PATH (set CXG_PYTHON env var to override)".into()))
+}
+
+/// Install the pentest orchestrator: copy bundled Python sources to ~/.cert-x-gen/pentest/
+/// and verify deps (playwright, anthropic).
+fn pentest_install(home: &Path, force: bool) -> Result<()> {
+    use std::process::Command as SysCommand;
+
+    if home.exists() && !force {
+        println!("pentest orchestrator already installed at {}", home.display());
+        println!("  use `cxg pentest install --force` to reinstall");
+    } else {
+        if home.exists() {
+            std::fs::remove_dir_all(home).ok();
+        }
+        std::fs::create_dir_all(home).map_err(|e| Error::Config(format!("mkdir failed: {}", e)))?;
+
+        // The Python orchestrator lives in the cxg source tree at pentest/.
+        // For development, we copy from the source dir; for shipped binaries, we'd
+        // bundle these via include_dir!. For now, find the source dir relative to the
+        // running binary OR via CXG_SOURCE env var.
+        let src_dir = find_pentest_source()?;
+        copy_dir_recursive(&src_dir, home)?;
+        println!("installed pentest orchestrator → {}", home.display());
+    }
+
+    // Dep check
+    let python = which_python()?;
+    println!("checking Python deps…");
+    let check = SysCommand::new(&python)
+        .args(["-c", "import playwright, anthropic; print('OK')"])
+        .output();
+    match check {
+        Ok(o) if o.status.success() => println!("  ✓ playwright + anthropic installed"),
+        _ => {
+            println!("  ⚠ missing Python deps. Install with:");
+            println!("    pip3 install --break-system-packages playwright anthropic");
+            println!("    python3 -m playwright install chromium");
+        }
+    }
+    Ok(())
+}
+
+fn find_pentest_source() -> Result<PathBuf> {
+    if let Ok(s) = std::env::var("CXG_SOURCE") {
+        let p = PathBuf::from(s).join("pentest");
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    // 1) sibling to current_exe (release install layout)
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            for rel in &["pentest", "../pentest", "../share/cert-x-gen/pentest"] {
+                let p = parent.join(rel);
+                if p.join("cxg_pentest.py").exists() {
+                    return Ok(p);
+                }
+            }
+        }
+    }
+    // 2) source tree (development): cwd/pentest or ./pentest from cargo's manifest dir
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd_p = cwd.join("pentest");
+    if cwd_p.join("cxg_pentest.py").exists() {
+        return Ok(cwd_p);
+    }
+    Err(Error::Config(
+        "could not locate pentest source dir. Set CXG_SOURCE=<cxg-repo> to override.".into(),
+    ))
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).map_err(|e| Error::Config(format!("mkdir {}: {}", dst.display(), e)))?;
+    for entry in std::fs::read_dir(src).map_err(|e| Error::Config(format!("readdir {}: {}", src.display(), e)))? {
+        let entry = entry.map_err(|e| Error::Config(format!("dirent: {}", e)))?;
+        let ft = entry.file_type().map_err(|e| Error::Config(format!("filetype: {}", e)))?;
+        let name = entry.file_name();
+        // Skip pycache / hidden / temp output
+        let name_s = name.to_string_lossy();
+        if name_s.starts_with("__pycache__") || name_s.starts_with(".") || name_s == "report.json" {
+            continue;
+        }
+        let src_p = entry.path();
+        let dst_p = dst.join(&name);
+        if ft.is_dir() {
+            copy_dir_recursive(&src_p, &dst_p)?;
+        } else {
+            std::fs::copy(&src_p, &dst_p).map_err(|e| Error::Config(format!("copy {}→{}: {}",
+                src_p.display(), dst_p.display(), e)))?;
+        }
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use cert_x_gen::{
     utils,
 };
 use clap::Parser;
+use include_dir::{include_dir, Dir};
 use std::sync::Arc;
 use std::{
     collections::HashSet,
@@ -184,6 +185,12 @@ async fn run(cli: Cli) -> Result<()> {
 
     Ok(())
 }
+
+/// Pentest orchestrator Python sources, embedded into the binary at compile time.
+/// This lets a shipped `cxg` self-install the orchestrator on any machine without
+/// needing the source tree on disk. A development source tree (CXG_SOURCE or a
+/// `pentest/` dir next to the repo) still takes precedence when present.
+static PENTEST_ASSETS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/pentest");
 
 /// Pentest orchestrator install dir — Python sources copied here on first install.
 fn pentest_home() -> PathBuf {
@@ -408,13 +415,27 @@ fn pentest_install(home: &Path, force: bool) -> Result<()> {
         }
         std::fs::create_dir_all(home).map_err(|e| Error::Config(format!("mkdir failed: {}", e)))?;
 
-        // The Python orchestrator lives in the cxg source tree at pentest/.
-        // For development, we copy from the source dir; for shipped binaries, we'd
-        // bundle these via include_dir!. For now, find the source dir relative to the
-        // running binary OR via CXG_SOURCE env var.
-        let src_dir = find_pentest_source()?;
-        copy_dir_recursive(&src_dir, home)?;
-        println!("installed pentest orchestrator → {}", home.display());
+        // Prefer an on-disk source tree when one is available (development, or an
+        // explicit CXG_SOURCE override) so contributors can iterate on the Python
+        // without rebuilding the binary. Otherwise extract the copy embedded into
+        // the binary at compile time — this is the path every shipped install takes.
+        match find_pentest_source() {
+            Ok(src_dir) => {
+                copy_dir_recursive(&src_dir, home)?;
+                println!(
+                    "installed pentest orchestrator → {} (from {})",
+                    home.display(),
+                    src_dir.display()
+                );
+            }
+            Err(_) => {
+                extract_embedded_pentest(home)?;
+                println!(
+                    "installed pentest orchestrator → {} (embedded)",
+                    home.display()
+                );
+            }
+        }
     }
 
     // Dep check
@@ -495,6 +516,56 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Extract the pentest orchestrator embedded in the binary (via include_dir!) into
+/// `dst`. Used by shipped installs where no source tree is present on disk.
+fn extract_embedded_pentest(dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)
+        .map_err(|e| Error::Config(format!("mkdir {}: {}", dst.display(), e)))?;
+    extract_embedded_dir(&PENTEST_ASSETS, dst)
+}
+
+/// Recursively write an embedded directory to disk, mirroring copy_dir_recursive's
+/// exclusions so __pycache__, hidden files, *.pyc, and stale report.json never land
+/// in the install dir. Embedded file paths are relative to the include_dir! root, so
+/// each is joined onto `dst_root` directly.
+fn extract_embedded_dir(dir: &Dir, dst_root: &Path) -> Result<()> {
+    for entry in dir.entries() {
+        match entry {
+            include_dir::DirEntry::Dir(d) => {
+                if embedded_should_skip(d.path()) {
+                    continue;
+                }
+                extract_embedded_dir(d, dst_root)?;
+            }
+            include_dir::DirEntry::File(f) => {
+                let rel = f.path();
+                if embedded_should_skip(rel) {
+                    continue;
+                }
+                let dst_p = dst_root.join(rel);
+                if let Some(parent) = dst_p.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| Error::Config(format!("mkdir {}: {}", parent.display(), e)))?;
+                }
+                std::fs::write(&dst_p, f.contents())
+                    .map_err(|e| Error::Config(format!("write {}: {}", dst_p.display(), e)))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// True if any component of an embedded path should be excluded from extraction.
+fn embedded_should_skip(path: &Path) -> bool {
+    path.components().any(|c| {
+        let s = c.as_os_str().to_string_lossy();
+        s.starts_with("__pycache__")
+            || s.starts_with('.')
+            || s == "report.json"
+            || s.ends_with(".pyc")
+    })
 }
 
 /// Handle auto-update logic based on CLI flags

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,39 +210,96 @@ async fn run_pentest_command(cmd: cli::PentestCommand) -> Result<()> {
     // For every other action, the orchestrator must be installed.
     let orchestrator = home.join("cxg_pentest.py");
     if !orchestrator.exists() {
-        eprintln!("Pentest orchestrator not installed at {}", orchestrator.display());
+        eprintln!(
+            "Pentest orchestrator not installed at {}",
+            orchestrator.display()
+        );
         eprintln!("Run: cxg pentest install");
-        return Err(Error::Config("pentest orchestrator not installed".to_string()));
+        return Err(Error::Config(
+            "pentest orchestrator not installed".to_string(),
+        ));
     }
 
     // Build argv for the Python orchestrator.
     let mut args: Vec<String> = vec![orchestrator.to_string_lossy().to_string()];
     match cmd.action {
         cli::PentestAction::Install { .. } => unreachable!(),
-        cli::PentestAction::Auth { target, profile, auth_numbers, creds, creds_file, login_path, label, verify_url, headers } => {
-            args.extend(["auth".into(), "login".into(),
-                "--target".into(), target,
-                "--profile".into(), profile,
-                "--auth-numbers".into(), auth_numbers.to_string(),
-                "--login-path".into(), login_path]);
-            if let Some(c) = creds { args.extend(["--creds".into(), c]); }
-            if let Some(f) = creds_file { args.extend(["--creds-file".into(), f.to_string_lossy().to_string()]); }
-            if let Some(l) = label { args.extend(["--label".into(), l]); }
-            if let Some(v) = verify_url { args.extend(["--verify-url".into(), v]); }
-            for h in headers { args.extend(["--header".into(), h]); }
+        cli::PentestAction::Auth {
+            target,
+            profile,
+            auth_numbers,
+            creds,
+            creds_file,
+            login_path,
+            label,
+            verify_url,
+            headers,
+        } => {
+            args.extend([
+                "auth".into(),
+                "login".into(),
+                "--target".into(),
+                target,
+                "--profile".into(),
+                profile,
+                "--auth-numbers".into(),
+                auth_numbers.to_string(),
+                "--login-path".into(),
+                login_path,
+            ]);
+            if let Some(c) = creds {
+                args.extend(["--creds".into(), c]);
+            }
+            if let Some(f) = creds_file {
+                args.extend(["--creds-file".into(), f.to_string_lossy().to_string()]);
+            }
+            if let Some(l) = label {
+                args.extend(["--label".into(), l]);
+            }
+            if let Some(v) = verify_url {
+                args.extend(["--verify-url".into(), v]);
+            }
+            for h in headers {
+                args.extend(["--header".into(), h]);
+            }
         }
         cli::PentestAction::AuthList => {
             args.extend(["auth".into(), "list".into()]);
         }
         cli::PentestAction::ScopeInit { output } => {
-            args.extend(["scope".into(), "init".into(),
-                "--output".into(), output.to_string_lossy().to_string()]);
+            args.extend([
+                "scope".into(),
+                "init".into(),
+                "--output".into(),
+                output.to_string_lossy().to_string(),
+            ]);
         }
         cli::PentestAction::Run {
-            codebase, target, auth, interactive_auth, auth_profile, auth_numbers, creds_file,
-            template_lang, goal, template_dir, max_templates, mutation_retries, ai_provider,
-            ai, headed, scope_file, destructive_ok, attestation, session_dir, output,
-            mitigation_mode, me_path, generation_timeout, skip_health_check, oast,
+            codebase,
+            target,
+            auth,
+            interactive_auth,
+            auth_profile,
+            auth_numbers,
+            creds_file,
+            template_lang,
+            goal,
+            template_dir,
+            max_templates,
+            mutation_retries,
+            ai_provider,
+            ai,
+            headed,
+            scope_file,
+            destructive_ok,
+            attestation,
+            session_dir,
+            output,
+            mitigation_mode,
+            me_path,
+            generation_timeout,
+            skip_health_check,
+            oast,
         } => {
             args.push("pentest".into());
             args.extend(["--codebase".into(), codebase.to_string_lossy().to_string()]);
@@ -250,31 +307,62 @@ async fn run_pentest_command(cmd: cli::PentestCommand) -> Result<()> {
             args.extend(["--auth".into(), auth]);
             args.extend(["--interactive-auth".into(), interactive_auth.to_string()]);
             args.extend(["--auth-profile".into(), auth_profile]);
-            if let Some(n) = auth_numbers { args.extend(["--auth-numbers".into(), n.to_string()]); }
-            if let Some(f) = creds_file { args.extend(["--creds-file".into(), f.to_string_lossy().to_string()]); }
+            if let Some(n) = auth_numbers {
+                args.extend(["--auth-numbers".into(), n.to_string()]);
+            }
+            if let Some(f) = creds_file {
+                args.extend(["--creds-file".into(), f.to_string_lossy().to_string()]);
+            }
             args.extend(["--template-lang".into(), template_lang]);
-            if let Some(g) = goal { args.extend(["--goal".into(), g]); }
-            if let Some(d) = template_dir { args.extend(["--template-dir".into(), d.to_string_lossy().to_string()]); }
+            if let Some(g) = goal {
+                args.extend(["--goal".into(), g]);
+            }
+            if let Some(d) = template_dir {
+                args.extend(["--template-dir".into(), d.to_string_lossy().to_string()]);
+            }
             args.extend(["--max-templates".into(), max_templates.to_string()]);
             args.extend(["--mutation-retries".into(), mutation_retries.to_string()]);
             args.extend(["--ai-provider".into(), ai_provider]);
-            if ai { args.push("--ai".into()); }
-            if headed { args.push("--headed".into()); }
-            if let Some(s) = scope_file { args.extend(["--scope-file".into(), s.to_string_lossy().to_string()]); }
-            if destructive_ok { args.push("--destructive-ok".into()); }
-            if let Some(a) = attestation { args.extend(["--attestation".into(), a]); }
-            if let Some(s) = session_dir { args.extend(["--session-dir".into(), s.to_string_lossy().to_string()]); }
-            if let Some(o) = output { args.extend(["--output".into(), o.to_string_lossy().to_string()]); }
+            if ai {
+                args.push("--ai".into());
+            }
+            if headed {
+                args.push("--headed".into());
+            }
+            if let Some(s) = scope_file {
+                args.extend(["--scope-file".into(), s.to_string_lossy().to_string()]);
+            }
+            if destructive_ok {
+                args.push("--destructive-ok".into());
+            }
+            if let Some(a) = attestation {
+                args.extend(["--attestation".into(), a]);
+            }
+            if let Some(s) = session_dir {
+                args.extend(["--session-dir".into(), s.to_string_lossy().to_string()]);
+            }
+            if let Some(o) = output {
+                args.extend(["--output".into(), o.to_string_lossy().to_string()]);
+            }
             args.extend(["--mitigation-mode".into(), mitigation_mode]);
             args.extend(["--me-path".into(), me_path]);
-            args.extend(["--generation-timeout".into(), generation_timeout.to_string()]);
-            if skip_health_check { args.push("--skip-health-check".into()); }
-            if let Some(h) = oast { args.extend(["--oast".into(), h]); }
+            args.extend([
+                "--generation-timeout".into(),
+                generation_timeout.to_string(),
+            ]);
+            if skip_health_check {
+                args.push("--skip-health-check".into());
+            }
+            if let Some(h) = oast {
+                args.extend(["--oast".into(), h]);
+            }
         }
     }
 
     let python = which_python()?;
-    let status = SysCommand::new(&python).args(&args).status()
+    let status = SysCommand::new(&python)
+        .args(&args)
+        .status()
         .map_err(|e| Error::Config(format!("failed to spawn python orchestrator: {}", e)))?;
     if !status.success() {
         // Bubble the non-zero exit code up — Python uses 2 for "findings found", 3 for hard-kill
@@ -298,7 +386,9 @@ fn which_python() -> Result<PathBuf> {
             }
         }
     }
-    Err(Error::Config("python3 not found on PATH (set CXG_PYTHON env var to override)".into()))
+    Err(Error::Config(
+        "python3 not found on PATH (set CXG_PYTHON env var to override)".into(),
+    ))
 }
 
 /// Install the pentest orchestrator: copy bundled Python sources to ~/.cert-x-gen/pentest/
@@ -307,7 +397,10 @@ fn pentest_install(home: &Path, force: bool) -> Result<()> {
     use std::process::Command as SysCommand;
 
     if home.exists() && !force {
-        println!("pentest orchestrator already installed at {}", home.display());
+        println!(
+            "pentest orchestrator already installed at {}",
+            home.display()
+        );
         println!("  use `cxg pentest install --force` to reinstall");
     } else {
         if home.exists() {
@@ -371,10 +464,15 @@ fn find_pentest_source() -> Result<PathBuf> {
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    std::fs::create_dir_all(dst).map_err(|e| Error::Config(format!("mkdir {}: {}", dst.display(), e)))?;
-    for entry in std::fs::read_dir(src).map_err(|e| Error::Config(format!("readdir {}: {}", src.display(), e)))? {
+    std::fs::create_dir_all(dst)
+        .map_err(|e| Error::Config(format!("mkdir {}: {}", dst.display(), e)))?;
+    for entry in std::fs::read_dir(src)
+        .map_err(|e| Error::Config(format!("readdir {}: {}", src.display(), e)))?
+    {
         let entry = entry.map_err(|e| Error::Config(format!("dirent: {}", e)))?;
-        let ft = entry.file_type().map_err(|e| Error::Config(format!("filetype: {}", e)))?;
+        let ft = entry
+            .file_type()
+            .map_err(|e| Error::Config(format!("filetype: {}", e)))?;
         let name = entry.file_name();
         // Skip pycache / hidden / temp output
         let name_s = name.to_string_lossy();
@@ -386,8 +484,14 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         if ft.is_dir() {
             copy_dir_recursive(&src_p, &dst_p)?;
         } else {
-            std::fs::copy(&src_p, &dst_p).map_err(|e| Error::Config(format!("copy {}→{}: {}",
-                src_p.display(), dst_p.display(), e)))?;
+            std::fs::copy(&src_p, &dst_p).map_err(|e| {
+                Error::Config(format!(
+                    "copy {}→{}: {}",
+                    src_p.display(),
+                    dst_p.display(),
+                    e
+                ))
+            })?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

Adds a new `cxg pentest` subcommand that turns a guardlink-annotated codebase plus captured authenticated browser sessions into runtime-confirmed security findings. It bridges whitebox source understanding with authenticated blackbox exploitation:

- Reads `whitebox/findings.sarif` produced by guardlink and LLM-ranks threats against a natural-language operator goal.
- Asks a local AI CLI (Claude / Codex / Gemini) to write JS probe templates that read the target's source to craft code-aware payloads.
- Executes templates in N parallel authenticated Chromium contexts with scope enforcement, session-health monitoring, mutation-retry triage, and a full JSONL audit log.
- Classifies each finding deterministically as CONFIRMED / REFUTED (mitigation holds) / AMBIGUOUS.

## What's in this PR

- `src/cli.rs` — `Pentest` subcommand surface (`run` / `auth` / `auth-list` / `scope-init` / `install`).
- `src/main.rs` — dispatch + installer that copies the bundled Python orchestrator to `~/.cert-x-gen/pentest/`.
- `pentest/` — Python orchestrator, built-in payloads, and operator docs (`README.md`, `docs/ARCHITECTURE.md`, `docs/OPERATOR_GUIDE.md`, `docs/TEMPLATES.md`, `docs/TROUBLESHOOTING.md`).

27 files, ~7.9k insertions.

## How to install / try

```bash
cargo install --path .        # build the cxg binary with the new subcommand
cxg pentest install           # copy the Python orchestrator + dep check
pip3 install --break-system-packages playwright anthropic
python3 -m playwright install chromium
cxg pentest --help
```

## Notes for reviewer

- The Rust binary is a thin dispatcher; the pipeline logic lives in the `pentest/` Python tree.
- `__pycache__/` and `report.json` are gitignored and excluded from both the commit and the installer copy.
- Build verified locally via `cargo install --path .` (compiles clean; pre-existing missing-docs warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)