### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "cert-x-gen"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cert-x-gen"
-version = "1.1.1"
+# @g.comment -- "release 1.2.0: ships the self-update command (#12) and AI pentest pipeline (#10)"
+version = "1.2.0"
 edition = "2021"
 authors = ["CERT-X-GEN Core Team"]
 description = "Advanced Multi-Language Security Scanning Engine"


### PR DESCRIPTION
Bumps `Cargo.toml`/`Cargo.lock` from 1.1.1 → **1.2.0**.

Since the `v1.1.1` tag (March 25), two features merged to `main` but were never released, because the version was never bumped and no tag was pushed:

- **#12** — `cxg update` top-level self-update command
- **#10** — AI-driven whitebox pentest pipeline

Minor bump (not patch) since these are new features.

## After merge
Push the `v1.2.0` tag to trigger the release workflow (binaries, GHCR, crates.io, Homebrew tap). ⚠️ Merge homebrew-cxg#1 and add the ruleset bypass actors **first**, or the tap update will fail again exactly as it did for 1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)