### PR TITLE
fix(deps): update openssl to 0.10.81 to clear 8 security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,15 +2921,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2968,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## What

Lockfile-only update of `openssl` **0.10.73 → 0.10.81** (and `openssl-sys` 0.9.109 → 0.9.117).

`Cargo.toml` already declares `openssl = { version = "0.10", features = ["vendored"] }`, so 0.10.81 is semver-compatible and **no manifest change is required**. The diff is 9 lines of `Cargo.lock`.

## Why

This clears **8 open Dependabot advisories — 5 of the repo's 7 highs**:

| Severity | Advisory | Summary |
|---|---|---|
| high | GHSA-xp3w-r5p5-63rr | UB in `X509Ref::ocsp_responders` for non-UTF-8 OCSP URLs |
| high | GHSA-pqf5-4pqq-29f5 | `Deriver::derive` / `PkeyCtxRef::derive` overflow short buffers |
| high | GHSA-8c75-8mhr-p7r9 | Incorrect bounds assertion in AES key wrap |
| high | GHSA-hppc-g8h3-xhp3 | Unchecked callback length in PSK/cookie trampolines leaks adjacent memory |
| high | GHSA-ghm9-cr32-g9qj | `MdCtxRef::digest_final()` writes past caller buffer |
| medium | GHSA-phqj-4mhp-q6mq | OOB write in `cipher_update_inplace` for AES-KW-PAD |
| medium | GHSA-xv59-967r-8726 | Heap buffer overflow on AES key-wrap-with-padding |
| low | GHSA-xmgf-hq76-4vx2 | OOB read in PEM password callback on oversized length |

All eight are patched at 0.10.80 or below.

`openssl` is a **direct dependency built vendored**, so it is statically compiled into every released `cxg` binary — these are not transitive or dev-only.

## Verification

Run locally on `2e431be` + this change, mirroring the CI job commands:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-features` — pass
- `cargo clippy --all-features -- -W clippy::all` — pass
- `cargo test --all-features` — **210 passed, 0 failed**, 6 ignored; 15 doc-tests passed

macOS only locally; CI covers ubuntu-latest.
