### PR TITLE
fix(deps): update bytes to 1.12.1 to clear integer overflow advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,9 +377,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION
## What

Lockfile-only update of `bytes` **1.10.1 → 1.12.1**. Two-line `Cargo.lock` diff.

## Why

Clears **GHSA-434x-w66g-qw3r** (medium) — integer overflow in `BytesMut::reserve`. Patched at 1.11.1; this goes to the current 1.12.1.

## Supersedes #2

Dependabot's #2 proposes the same fix (→ 1.11.1) but its CI run is from 2026-02, against a base predating the #10, #11, #12 and #13 merges. Its `Test` jobs failed on both platforms while Check, Clippy, Format and all three Build jobs passed — an implausible failure mode for a `bytes` patch bump, and the logs are now past GitHub's 90-day retention (HTTP 410), so the cause can't be recovered.

Rather than merge on unverifiable months-old CI, this redoes the update against current `main` with a fresh run. **#2 should be closed once this merges.**

## Verification

Local, on `5569455` + this change, mirroring the CI job commands:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-features` — pass
- `cargo clippy --all-features -- -W clippy::all` — pass
- `cargo test --all-features` — **210 passed, 0 failed**, 6 ignored; 15 doc-tests passed

macOS only locally; CI covers ubuntu-latest.
