### PR TITLE
fix(deps): update git2 to 0.20.4 to clear GHSA-j39j-6gw9-jw6h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,9 +1602,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.18.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
@@ -2440,9 +2440,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.2+1.7.2"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ crossbeam = "0.8"
 walkdir = "2.4"
 
 # Template management
-git2 = "0.18"
+git2 = "0.20"
 
 # OpenSSL (vendored for cross-compilation)
 openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
## What

`git2` **0.18 → 0.20.4** (manifest + lockfile). Bundled `libgit2-sys` moves 1.7.2 → 1.9.6.

## Why

Clears **GHSA-j39j-6gw9-jw6h** (low) — potential UB dereferencing a `Buf` in git2. `git2` is a direct dependency used for template-repo management (`src/template/git.rs`, `src/template/auto_update.rs`).

## API compatibility

The git2 surface in use is small and unchanged across 0.18 → 0.20:

- `Repository::open`
- `build::RepoBuilder::new`
- `Cred::default`, `Cred::ssh_key_from_agent`
- `Error::from_str`

No source changes required.

## Supersedes #3

Dependabot's #3 proposes the same bump but its branch is **36 commits behind** current `main` — it predates the openssl, bytes and reqwest/rustls consolidation. Its green CI is from 2026-02 against that old base. This redoes the bump against current `main` with a fresh run. **#3 should be closed once this merges.**

## Verification

Local, on `df54f17` + this change:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-features` — pass
- `cargo clippy --all-features -- -W clippy::all` — pass
- `cargo test --all-features` — **210 passed, 0 failed**, 6 ignored; 15 doc-tests passed
- `cargo build --release` — pass (libgit2-sys 1.9.6 vendored build clean)

macOS only locally; the ubuntu and intel-macos Build jobs in CI exercise the other libgit2-sys targets.
