### PR TITLE
fix(deps): update prometheus to 0.14 to clear protobuf recursion advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -3196,7 +3196,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3221,9 +3221,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "psl-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ uuid = { version = "1.6", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Metrics
-prometheus = "0.13"
+prometheus = "0.14"
 metrics = "0.21"
 metrics-exporter-prometheus = "0.13"
 


### PR DESCRIPTION
## What

`prometheus` **0.13 → 0.14**, which moves the transitive `protobuf` **2.28.0 → 3.7.2**.

## Why

Clears **GHSA-2gh3-rmm4-6rq5** (medium) — uncontrolled recursion in `protobuf` 2.x parsing crafted input. Fixed in the 3.x line.

`protobuf` reached the tree solely via `prometheus 0.13.4`. `metrics-exporter-prometheus` does not pull it, so this one bump covers it.

## Notes

- prometheus API in use (`TextEncoder`, `Encoder`, `HistogramOpts::new`, `Error`) is core and unchanged across 0.13 → 0.14 — no source changes.
- protobuf **remains in the tree** (now 3.7.2). prometheus 0.14 makes protobuf optional but still enables it by default for protobuf-format export. It could be dropped entirely with `default-features = false`, but that removes protobuf-format metrics export — a behavioural change out of scope for a security bump. 3.7.2 is patched, so the advisory clears regardless.

## Verification

Local, on `a48878c` + this change:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-features` — pass
- `cargo clippy --all-features -- -W clippy::all` — pass
- `cargo test --all-features` — **210 passed, 0 failed**, 6 ignored; 15 doc-tests passed
- `cargo build --release` — pass
