### PR TITLE
fix(pentest): SPA session-health false-negative + operator identity metadata

### DIFF
--- a/pentest/auth.py
+++ b/pentest/auth.py
@@ -20,6 +20,25 @@ from typing import Optional
 
 AUTH_DIR = Path.home() / ".cert-x-gen" / "auth"
 
+# @g.comment -- "Operator-facing privilege bands mapped onto the same 0-100 scale profile_inspect.ROLE_TIER uses, so an explicit --tier slots cleanly next to auto-derived role tiers (admin=100, analyst=60, user=20)."
+TIER_ALIASES = {"high": 90, "medium": 50, "med": 50, "low": 10, "none": 0, "guest": 5}
+
+
+# @g.comment -- "Parse the operator-supplied privilege tier: an int 0-100 or a high/medium/low alias; None (unset/blank) means 'auto-derive from the app role at inspection time'."
+def parse_tier(raw) -> Optional[int]:
+    if raw is None:
+        return None
+    s = str(raw).strip().lower()
+    if not s:
+        return None
+    if s in TIER_ALIASES:
+        return TIER_ALIASES[s]
+    try:
+        v = int(s)
+    except ValueError:
+        raise ValueError(f"invalid tier '{raw}': use an integer 0-100 or high/medium/low")
+    return max(0, min(100, v))
+
 
 @dataclass
 class AuthProfile:
@@ -28,6 +47,11 @@ class AuthProfile:
     storage_state_path: str
     label: Optional[str] = None  # human-readable: "admin", "analyst", "user"
     extra_headers: dict = field(default_factory=dict)  # WAF bypass header, etc.
+    # @g.comment -- "Operator-supplied identity metadata fed to the AI ranker/generator: tier sets explicit privilege rank (overrides the role heuristic), persona is a semantic role hint, cohort groups same-permission peers for horizontal IDOR/cross-tenant tests, tags carry free-form context."
+    tier: Optional[int] = None       # explicit privilege rank 0-100; None = auto-derive from role
+    persona: Optional[str] = None    # semantic role hint, e.g. "billing-analyst"
+    cohort: Optional[str] = None     # peer group, e.g. "analyst-team-a" — marks same-priv different-user pairs
+    tags: dict = field(default_factory=dict)  # free-form k=v context
 
     @property
     def storage_state(self) -> dict:
@@ -39,16 +63,21 @@ def profile_path(name: str) -> Path:
 
 
 def save_profile(name: str, target: str, storage_state: dict, label: Optional[str] = None,
-                 extra_headers: Optional[dict] = None) -> AuthProfile:
+                 extra_headers: Optional[dict] = None, tier: Optional[int] = None,
+                 persona: Optional[str] = None, cohort: Optional[str] = None,
+                 tags: Optional[dict] = None) -> AuthProfile:
     AUTH_DIR.mkdir(parents=True, exist_ok=True)
     state_path = profile_path(name)
     state_path.write_text(json.dumps(storage_state, indent=2))
     meta_path = AUTH_DIR / f"{name}.meta.json"
+    # @g.comment -- "Persist the operator identity metadata alongside the session so `cxg pentest run` reloads tier/persona/cohort/tags without re-prompting."
     meta = {"name": name, "target": target, "label": label,
-            "extra_headers": extra_headers or {}}
+            "extra_headers": extra_headers or {},
+            "tier": tier, "persona": persona, "cohort": cohort, "tags": tags or {}}
     meta_path.write_text(json.dumps(meta, indent=2))
     return AuthProfile(name=name, target=target, storage_state_path=str(state_path),
-                         label=label, extra_headers=extra_headers or {})
+                         label=label, extra_headers=extra_headers or {},
+                         tier=tier, persona=persona, cohort=cohort, tags=tags or {})
 
 
 def load_profile(name: str) -> AuthProfile:
@@ -63,6 +92,10 @@ def load_profile(name: str) -> AuthProfile:
         storage_state_path=str(state_path),
         label=meta.get("label"),
         extra_headers=meta.get("extra_headers") or {},
+        tier=meta.get("tier"),
+        persona=meta.get("persona"),
+        cohort=meta.get("cohort"),
+        tags=meta.get("tags") or {},
     )
 
 
@@ -82,7 +115,9 @@ def list_profiles() -> list[AuthProfile]:
 
 def capture_interactive(target: str, profile_name: str, label: Optional[str] = None,
                         verify_url: Optional[str] = None,
-                        extra_headers: Optional[dict] = None) -> AuthProfile:
+                        extra_headers: Optional[dict] = None,
+                        tier: Optional[int] = None, persona: Optional[str] = None,
+                        cohort: Optional[str] = None, tags: Optional[dict] = None) -> AuthProfile:
     """Open headed Chromium, let the operator log in (SSO / MFA / magic link / OAuth popup all work),
     save the storage_state. Two ways to signal completion:
 
@@ -187,7 +222,8 @@ def capture_interactive(target: str, profile_name: str, label: Optional[str] = N
               file=sys.stderr)
 
     prof = save_profile(profile_name, target, state, label=label,
-                          extra_headers=extra_headers)
+                          extra_headers=extra_headers, tier=tier, persona=persona,
+                          cohort=cohort, tags=tags)
 
     # Post-capture verification — same landing-page test the scan-time inspector uses.
     # If verify_url is set, we ALSO hit it as a bonus check (without overriding the
@@ -294,9 +330,17 @@ def _verify_captured_session(target: str, verify_url: Optional[str], state: dict
 
 def capture_interactive_multi(target: str, profile_prefix: str, n: int,
                               verify_url: Optional[str] = None,
-                              extra_headers: Optional[dict] = None) -> list[AuthProfile]:
-    """Open N headed Chromium windows in sequence. Before each, prompt the operator for a
-    human-readable label (e.g. "attacker", "victim"). Saves as <prefix>-1, <prefix>-2, ...
+                              extra_headers: Optional[dict] = None,
+                              default_tier: Optional[int] = None,
+                              default_persona: Optional[str] = None,
+                              default_cohort: Optional[str] = None,
+                              tags: Optional[dict] = None) -> list[AuthProfile]:
+    """Open N headed Chromium windows in sequence. Before each, prompt the operator for the
+    identity metadata (label, privilege tier, persona, cohort). Saves as <prefix>-1, ...
+
+    Per-identity prompts make multi-capture the place to encode privilege structure: e.g.
+    capture 1 = admin (tier high), 2/3 = two analysts sharing cohort "analyst-team", 4 = a
+    low-priv user. Flag values (--tier/--persona/--cohort) pre-fill the prompts as defaults.
 
     Same login mechanism as capture_interactive — any auth method works (SSO, MFA, OAuth, etc.)."""
     profiles: list[AuthProfile] = []
@@ -305,14 +349,33 @@ def capture_interactive_multi(target: str, profile_prefix: str, n: int,
         print(f"\n══════════════════════════════════════════════════════════════════")
         print(f"  Auth capture {i}/{n}")
         print(f"══════════════════════════════════════════════════════════════════")
+        # @g.comment -- "Prompt per identity so an N-capture run can encode a full privilege ladder; each field falls back to the flag default (or auto) on blank input."
         try:
             label = input(f"  Label for this identity (e.g. attacker / victim / admin) [{name}]: ").strip()
         except EOFError:
             label = ""
         if not label:
             label = name
+        tier = default_tier
+        tier_default_hint = str(default_tier) if default_tier is not None else "auto from role"
+        try:
+            tier_raw = input(f"  Privilege tier — int 0-100 or high/medium/low [{tier_default_hint}]: ").strip()
+            if tier_raw:
+                tier = parse_tier(tier_raw)
+        except (EOFError, ValueError) as e:
+            if isinstance(e, ValueError):
+                print(f"    ⚠ {e}; using default ({tier_default_hint})", file=sys.stderr)
+        try:
+            persona = input(f"  Persona / semantic role hint [{default_persona or '-'}]: ").strip() or default_persona
+        except EOFError:
+            persona = default_persona
+        try:
+            cohort = input(f"  Cohort (group same-permission peers for horizontal tests) [{default_cohort or '-'}]: ").strip() or default_cohort
+        except EOFError:
+            cohort = default_cohort
         prof = capture_interactive(target, name, label=label, verify_url=verify_url,
-                                     extra_headers=extra_headers)
+                                     extra_headers=extra_headers, tier=tier,
+                                     persona=persona, cohort=cohort, tags=tags)
         profiles.append(prof)
     print(f"\n  ✓ captured {len(profiles)} auth profiles")
     return profiles
@@ -320,7 +383,9 @@ def capture_interactive_multi(target: str, profile_prefix: str, n: int,
 
 def capture_scripted(target: str, profile_name: str, email: str, password: str,
                      login_path: str = "/api/auth/login", label: Optional[str] = None,
-                     extra_headers: Optional[dict] = None) -> AuthProfile:
+                     extra_headers: Optional[dict] = None, tier: Optional[int] = None,
+                     persona: Optional[str] = None, cohort: Optional[str] = None,
+                     tags: Optional[dict] = None) -> AuthProfile:
     """Headless login flow: navigate, POST creds via the page's fetch (so cookies stick), save state.
 
     We use the page's fetch() instead of a raw HTTP client so cookies are stored in the browser
@@ -358,7 +423,8 @@ def capture_scripted(target: str, profile_name: str, email: str, password: str,
             raise RuntimeError(f"scripted login failed for {email}: status={result.get('status')} body={result.get('data')}")
         state = ctx.storage_state()
         browser.close()
-    return save_profile(profile_name, target, state, label=label)
+    return save_profile(profile_name, target, state, label=label, extra_headers=extra_headers,
+                        tier=tier, persona=persona, cohort=cohort, tags=tags)
 
 
 def main(argv: list[str]) -> int:
@@ -382,6 +448,22 @@ def main(argv: list[str]) -> int:
     p_login.add_argument("--label", default=None,
                          help="Human-readable label (e.g. 'admin', 'low-priv-user'). Shown in scan "
                               "output to make findings readable.")
+    p_login.add_argument("--tier", default=None,
+                         help="Explicit privilege rank: an integer 0-100 or an alias high/medium/low "
+                              "(=90/50/10). Overrides the role-based heuristic and feeds the AI ranker "
+                              "so it picks the right identity per probe (lowest tier for privesc, etc.). "
+                              "Omit to auto-derive from the app's role. In multi-capture this pre-fills "
+                              "the per-identity prompt.")
+    p_login.add_argument("--persona", default=None,
+                         help="Semantic role hint (e.g. 'billing-analyst') passed to the AI as extra "
+                              "context — useful when the app's /me endpoint has no clear role field.")
+    p_login.add_argument("--cohort", default=None,
+                         help="Peer group name (e.g. 'analyst-team-a'). Give two SAME-permission, "
+                              "DIFFERENT-user sessions the same cohort so the AI knows they are peers "
+                              "and can target horizontal IDOR / cross-tenant access between them.")
+    p_login.add_argument("--tag", action="append", default=[], metavar="NAME=VALUE",
+                         help="Free-form k=v context attached to the profile and shown to the AI. "
+                              "Repeatable.")
     p_login.add_argument("--creds", default=None,
                          help="Inline credentials email:password for scripted login (skips browser "
                               "pop-up). Only works for password-based auth — SSO/MFA flows MUST use "
@@ -410,7 +492,13 @@ def main(argv: list[str]) -> int:
     args = ap.parse_args(argv)
     if args.cmd == "list":
         for prof in list_profiles():
-            print(f"  {prof.name:20s} label={prof.label or '-':10s} target={prof.target}")
+            tier_s = str(prof.tier) if prof.tier is not None else "auto"
+            extra = f" tier={tier_s}"
+            if prof.cohort:
+                extra += f" cohort={prof.cohort}"
+            if prof.persona:
+                extra += f" persona={prof.persona}"
+            print(f"  {prof.name:20s} label={prof.label or '-':12s}{extra:24s} target={prof.target}")
         return 0
 
     if args.cmd == "login":
@@ -430,6 +518,20 @@ def main(argv: list[str]) -> int:
         elif args.creds:
             email, pw = args.creds.split(":", 1)
             creds_list.append((email, pw, args.label))
+
+        # @g.comment -- "Resolve operator identity metadata once, up front: parse the tier alias/int and the repeatable --tag NAME=VALUE pairs, then thread them into every capture path."
+        try:
+            tier_default = parse_tier(args.tier)
+        except ValueError as e:
+            print(f"  ✗ {e}", file=sys.stderr)
+            return 2
+        tags: dict = {}
+        for t in getattr(args, "tag", []) or []:
+            if "=" not in t:
+                print(f"  ⚠ ignoring malformed --tag '{t}' (expected NAME=VALUE)", file=sys.stderr)
+                continue
+            k, _, v = t.partition("=")
+            tags[k.strip()] = v.strip()
 
         # Resolve verify_url: None → default to <target>/api/me; "" → skip verification
         vurl = args.verify_url
@@ -454,21 +556,26 @@ def main(argv: list[str]) -> int:
                   f"{list(extra_headers)}", file=sys.stderr)
 
         if not creds_list and n > 1:
-            # Interactive multi-capture with per-profile label prompt
+            # Interactive multi-capture with per-profile metadata prompts
             capture_interactive_multi(args.target, args.profile, n,
-                                       verify_url=vurl_resolved, extra_headers=extra_headers)
+                                       verify_url=vurl_resolved, extra_headers=extra_headers,
+                                       default_tier=tier_default, default_persona=args.persona,
+                                       default_cohort=args.cohort, tags=tags)
             return 0
         for i in range(n):
             name = args.profile if n == 1 else f"{args.profile}-{i+1}"
             if creds_list:
                 email, pw, lbl = creds_list[i % len(creds_list)]
                 prof = capture_scripted(args.target, name, email, pw, args.login_path,
-                                          label=lbl or args.label, extra_headers=extra_headers)
+                                          label=lbl or args.label, extra_headers=extra_headers,
+                                          tier=tier_default, persona=args.persona,
+                                          cohort=args.cohort, tags=tags)
                 print(f"[auth] saved {prof.name} (scripted, {email})")
             else:
                 prof = capture_interactive(args.target, name, label=args.label,
                                              verify_url=vurl_resolved,
-                                             extra_headers=extra_headers)
+                                             extra_headers=extra_headers, tier=tier_default,
+                                             persona=args.persona, cohort=args.cohort, tags=tags)
                 print(f"[auth] saved {prof.name} (interactive)")
         return 0
     return 1

--- a/pentest/cxg_pentest.py
+++ b/pentest/cxg_pentest.py
@@ -142,7 +142,13 @@ async def run_pentest(args) -> int:
                 parts = line.split(":")
                 if len(parts) >= 3:
                     creds_map[parts[0]] = (parts[1], parts[2], parts[3] if len(parts) > 3 else parts[0])
-        health = SessionHealthMonitor(args.target, creds_map=creds_map)
+        # @g.comment -- "When --skip-health-check is set, disable the runtime SessionHealthMonitor entirely; otherwise the per-template landing-test re-check re-kills profiles the operator forced alive in pre-flight. The engine guards every health call with `if self.health is not None`, so None safely skips runtime checks."
+        # @g.comment -- "Pass --me-path through as the monitor's health_path so its authenticated API probe hits the operator-specified endpoint instead of the hardcoded /api/me default."
+        if getattr(args, "skip_health_check", False):
+            health = None
+        else:
+            health = SessionHealthMonitor(args.target, creds_map=creds_map,
+                                          health_path=args.me_path)
 
         # 1b. PRE-FLIGHT: inspect captured auth profiles so the ranker knows what
         # identities we have to attack with (and warns if we're missing critical tiers).

--- a/pentest/docs/OPERATOR_GUIDE.md
+++ b/pentest/docs/OPERATOR_GUIDE.md
@@ -119,7 +119,8 @@ The generated scope.yaml has inline comments for every option. Read them.
 cxg pentest auth \
   --target https://staging.app.example.com \
   --profile pentest-admin \
-  --label admin
+  --label admin \
+  --tier high
 ```
 
 A headed Chromium window opens. You log in by **any means** — SSO redirect
@@ -138,21 +139,61 @@ Expected output:
 ✓ session verified — landed at https://staging.app.example.com/dashboard (no login redirect)
 ```
 
-### Two identities for IDOR / horizontal privesc
+### Identity metadata — give the AI privilege context
+
+Beyond `--label` (display only), you can attach **privilege structure** to a
+profile. This metadata is saved with the session and fed to the AI ranker and
+template generator, so it picks the right identity per probe instead of
+defaulting to the first one:
+
+| Flag | Meaning |
+|------|---------|
+| `--tier` | Explicit privilege rank: integer **0–100**, or alias **high/medium/low** (= 90/50/10). Overrides the role-based heuristic. Omit to auto-derive from the app's role. |
+| `--persona` | Semantic role hint (e.g. `billing-analyst`) — useful when the app's `/api/me` exposes no clear role field. |
+| `--cohort` | Peer group name. Two **same-permission, different-user** sessions sharing a cohort are treated as peers, so the AI targets horizontal IDOR / cross-tenant access between them. |
+| `--tag NAME=VALUE` | Free-form context (repeatable), e.g. `--tag tenant=acme`. |
+
+**Why tier matters:** privilege-escalation and RBAC probes run as the
+**lowest-tier** identity — testing "can an admin do admin things" proves
+nothing. Without a real low-privilege session, those probes are unfalsifiable
+and get deprioritized. Pinning `--tier low` on a genuine least-privilege login
+is the single highest-value thing you can do for privesc coverage.
+
+`--tier` overrides the auto-derived role tier; everything is **backward
+compatible** — profiles captured without these flags simply auto-derive tier
+from their role, exactly as before.
+
+### Multiple identities — capturing a privilege ladder
 
 ```bash
 cxg pentest auth \
   --target https://staging.app.example.com \
-  --profile pentest --auth-numbers 2
+  --profile pentest --auth-numbers 4
 ```
 
-cxg opens two Chromium windows in sequence. For each, it prompts you for
-a label (e.g. "victim", "attacker"). Profiles save as `pentest-1`,
-`pentest-2`. Reference both in the scan: `--auth pentest-1,pentest-2`.
+cxg opens four Chromium windows in sequence. Before each, it prompts you
+**per identity** for label, tier, persona, and cohort (any flags you passed
+pre-fill the defaults). Profiles save as `pentest-1` … `pentest-4`. Reference
+them in the scan: `--auth pentest-1,pentest-2,pentest-3,pentest-4`.
 
-For chained-auth probes like cross-user IDOR, the smart-runner-selection
-logic auto-picks the lowest-tier identity as the actor — so label them
-accurately if you want predictable behavior.
+A good ladder for IDOR / horizontal-privesc / RBAC coverage:
+
+```
+capture 1 → label admin,     tier high
+capture 2 → label analyst-a, tier medium, cohort analyst-team
+capture 3 → label analyst-b, tier medium, cohort analyst-team
+capture 4 → label user,      tier low
+```
+
+That gives you a high tier (verify admin-only allowed paths), a true low tier
+(make vertical privesc falsifiable), and an **analyst peer-cohort** — two
+distinct users at the same permission level so the AI can have one create a
+resource and the other attempt to read it (horizontal IDOR / cross-tenant). A
+peer reaching another peer's data is a finding.
+
+The smart-runner-selection logic auto-picks the lowest-tier identity as the
+actor for chained-auth probes, and each identity's `cxg.fetchAs(idx)` context
+index is now shown to the generator so templates target the right tier.
 
 ### Multi-tenant apps where SSO scopes cookies to a different subdomain
 
@@ -190,7 +231,8 @@ cxg pentest auth \
   --login-path /api/auth/login
 ```
 
-Useful for local dev environments and CI. Won't work for SSO.
+Useful for local dev environments and CI. Won't work for SSO. The identity
+metadata flags (`--tier`, `--persona`, `--cohort`, `--tag`) apply here too.
 
 ## Phase 4 — Pre-flight checks
 
@@ -202,7 +244,8 @@ Before running a long scan, validate everything is set up correctly.
 cxg pentest auth-list
 ```
 
-Confirm each profile shows up with the expected `target` and `label`.
+Confirm each profile shows up with the expected `target`, `label`, and — when
+set — `tier`, `cohort`, and `persona` (tier shows `auto` when not pinned).
 
 ### Dry-run pre-flight inspection
 
@@ -233,14 +276,20 @@ asyncio.run(main())
 Expected output for a healthy setup:
 
 ```
-· pentest-admin label=admin role=admin
+· pentest-admin label=admin role=admin tier=90* cohort=… 
     · landed at https://staging.app.example.com/dashboard (no login redirect)
-· pentest-user label=user role=user
+· pentest-user label=user role=user tier=10*
     · landed at https://staging.app.example.com/dashboard (no login redirect)
 ```
 
+A `*` after `tier` means it was operator-set via `--tier` (otherwise it was
+derived from the role). When two live profiles share a cohort, the inspection
+notes call it out as a testable peer group for horizontal IDOR.
+
 If you see `DEAD: status=...` or `landed at <login URL>`, the session
-expired. Re-capture before scanning.
+expired. Re-capture before scanning. (Note: a session whose app renders a
+login-like SPA shell is no longer false-flagged dead — the inspector confirms
+with an authenticated `--me-path` probe before giving up.)
 
 ## Phase 5 — Run the scan
 

--- a/pentest/js_generator.py
+++ b/pentest/js_generator.py
@@ -326,20 +326,40 @@ def _format_profile_context(profile_infos: list) -> str:
     """Build the profile context block injected into the ranking prompt."""
     if not profile_infos:
         return "Captured identities: (none — running on bare guardlink data)"
-    lines = ["Captured identities:"]
-    for info in profile_infos:
+    lines = ["Captured identities (index = cxg.fetchAs(idx) context):"]
+    # @g.comment -- "Surface the operator identity metadata (label, persona, explicit tier, cohort, tags) to the AI ranker/generator, with a stable 0-based index so generated templates can fetchAs the right tier instead of defaulting to context 0."
+    cohorts: dict = {}
+    for idx, info in enumerate(profile_infos):
         if not info.alive:
-            lines.append(f"  - {info.profile_name} (DEAD: status={info.me_status})")
+            lines.append(f"  [{idx}] {info.profile_name} (DEAD: status={info.me_status})")
             continue
-        bits = [info.profile_name]
+        bits = [f"[{idx}] {info.profile_name}"]
+        if getattr(info, "label", None) and info.label != info.profile_name:
+            bits.append(f"label={info.label}")
+        if getattr(info, "persona", None):
+            bits.append(f"persona={info.persona}")
         if info.role:
             bits.append(f"role={info.role}")
         if info.email:
             bits.append(f"({info.email})")
-        if info.tier:
-            bits.append(f"tier={info.tier}")
-        lines.append(f"  - {' '.join(bits)}")
-    # Coverage warnings
+        tier = getattr(info, "tier", 0)
+        explicit = getattr(info, "tier_explicit", False)
+        bits.append(f"tier={tier}{' (operator-set)' if explicit else ' (role-derived)'}")
+        if getattr(info, "cohort", None):
+            bits.append(f"cohort={info.cohort}")
+            cohorts.setdefault(info.cohort, []).append(f"[{idx}] {info.profile_name}")
+        if getattr(info, "tags", None):
+            bits.append("tags=" + ",".join(f"{k}={v}" for k, v in info.tags.items()))
+        lines.append("  - " + " ".join(bits))
+    # Peer-cohort guidance: same-permission different-user pairs enable horizontal tests.
+    for c, members in cohorts.items():
+        if len(members) >= 2:
+            lines.append(f"  ↔ cohort '{c}' = peers {', '.join(members)} — SAME permissions, "
+                         "DIFFERENT users: use one to create/own a resource, the other to attempt "
+                         "horizontal access (IDOR / cross-tenant). A peer reaching another's data is a finding.")
+    # Tier guidance + coverage warnings
+    lines.append("  → For privilege-escalation / RBAC probes, run as the LOWEST-tier identity "
+                 "(via cxg.fetchAs of its index) and treat reaching a higher-tier resource as the finding.")
     has_low = any(getattr(i, "tier", 0) <= 30 and i.alive for i in profile_infos)
     has_high = any(getattr(i, "tier", 0) > 70 and i.alive for i in profile_infos)
     if not has_low:

--- a/pentest/mutator.py
+++ b/pentest/mutator.py
@@ -212,11 +212,14 @@ def classify(finding: dict) -> TriageVerdict:
 
 
 def _signature(template_id: str, finding: dict) -> str:
+    # @g.comment -- "evidence may arrive as a dict or as a plain string depending on the AI verdict shape; only index it when it is a dict so the mutation-retry path cannot crash with AttributeError on str.get"
+    evidence = finding.get("evidence")
+    evidence_status = evidence.get("status") if isinstance(evidence, dict) else None
     payload = json.dumps({
         "tpl": template_id,
         "vuln_class": finding.get("vuln_class"),
         "endpoint": finding.get("endpoint"),
-        "evidence_status": (finding.get("evidence") or {}).get("status"),
+        "evidence_status": evidence_status,
         "description_head": (finding.get("description") or "")[:80],
     }, sort_keys=True)
     return hashlib.sha256(payload.encode()).hexdigest()[:12]

--- a/pentest/profile_inspect.py
+++ b/pentest/profile_inspect.py
@@ -161,6 +161,11 @@ async def _inspect_one(p, profile: AuthProfile, target: str,
 
         if 200 <= info.me_status < 300 and isinstance(body, dict):
             # me_path worked — extract identity details
+            # @g.comment -- "A 2xx from the authenticated me_path probe is proof of a live session, so override a login-page false-positive from the landing test (SPAs embed login markup in the authenticated dashboard, tripping the heuristic)"
+            if not info.alive:
+                info.alive = True
+                info.notes.append(f"{me_path} returned {info.me_status}; overriding "
+                                  "login-page landing heuristic (session is authenticated)")
             info.user_id = body.get("id") or body.get("user_id") or body.get("uid")
             info.email = body.get("email") or body.get("username") or body.get("user_email")
             info.role = (body.get("role") or body.get("user_role")

--- a/pentest/profile_inspect.py
+++ b/pentest/profile_inspect.py
@@ -46,6 +46,11 @@ class ProfileInfo:
     permissions: dict = field(default_factory=dict)
     raw_me: dict = field(default_factory=dict)
     notes: list[str] = field(default_factory=list)
+    # @g.comment -- "Operator-supplied identity metadata carried from the saved AuthProfile so the ranker/generator can see it; tier_explicit records whether the tier came from --tier (trusted) vs the role heuristic."
+    persona: Optional[str] = None
+    cohort: Optional[str] = None
+    tags: dict = field(default_factory=dict)
+    tier_explicit: bool = False
 
     def short(self) -> str:
         if not self.alive:
@@ -55,6 +60,11 @@ class ProfileInfo:
             bits.append(f"label={self.label}")
         if self.role:
             bits.append(f"role={self.role}")
+        if self.persona:
+            bits.append(f"persona={self.persona}")
+        bits.append(f"tier={self.tier}{'*' if self.tier_explicit else ''}")
+        if self.cohort:
+            bits.append(f"cohort={self.cohort}")
         if self.email:
             bits.append(f"email={self.email}")
         if self.user_id is not None:
@@ -99,8 +109,14 @@ async def _inspect_one(p, profile: AuthProfile, target: str,
     The landing test mirrors what the captured session does in real use, so it's the
     most reliable single signal.
     """
+    # @g.comment -- "Seed ProfileInfo with operator metadata from the saved profile; an explicit --tier is trusted over the role heuristic so the ranker uses operator intent."
+    operator_tier = getattr(profile, "tier", None)
     info = ProfileInfo(profile_name=profile.name, label=profile.label, target=target,
-                        alive=False)
+                        alive=False, persona=getattr(profile, "persona", None),
+                        cohort=getattr(profile, "cohort", None),
+                        tags=getattr(profile, "tags", None) or {},
+                        tier_explicit=operator_tier is not None,
+                        tier=operator_tier if operator_tier is not None else 0)
     try:
         browser = await p.chromium.launch(headless=True)
         ctx_kwargs = {"storage_state": profile.storage_state}
@@ -171,7 +187,8 @@ async def _inspect_one(p, profile: AuthProfile, target: str,
             info.role = (body.get("role") or body.get("user_role")
                          or (body.get("user") or {}).get("role")
                          or body.get("group"))
-            if isinstance(info.role, str):
+            # @g.comment -- "Only fall back to the role heuristic when the operator did not pin a tier via --tier; an explicit tier wins."
+            if isinstance(info.role, str) and not info.tier_explicit:
                 info.tier = ROLE_TIER.get(info.role.lower(), 30)
             perms: dict = {}
             for k, v in body.items():
@@ -187,8 +204,9 @@ async def _inspect_one(p, profile: AuthProfile, target: str,
             info.notes.append(f"{me_path} returned {info.me_status} but landing test "
                               "says session is alive; identity details unknown")
             # Without role info, we can't tier; default to mid (30) so privesc probes
-            # still consider this profile usable.
-            info.tier = 30
+            # still consider this profile usable — unless the operator pinned a tier.
+            if not info.tier_explicit:
+                info.tier = 30
         elif info.me_status in (401, 403):
             info.notes.append(f"{me_path} returned {info.me_status}")
 
@@ -225,6 +243,12 @@ def coverage_summary(infos: list[ProfileInfo]) -> dict:
     has_low = any(i.tier <= 30 for i in alive)
     has_mid = any(30 < i.tier <= 70 for i in alive)
     has_high = any(i.tier > 70 for i in alive)
+    # @g.comment -- "Group alive identities by operator cohort so we can flag when a cohort has >=2 peers (horizontal IDOR / cross-tenant is testable) and feed that into the coverage notes."
+    cohorts: dict[str, list[str]] = {}
+    for i in alive:
+        if i.cohort:
+            cohorts.setdefault(i.cohort, []).append(i.profile_name)
+    peer_cohorts = {c: members for c, members in cohorts.items() if len(members) >= 2}
     notes: list[str] = []
     if not has_low and (has_mid or has_high):
         notes.append("no low-privilege identity captured — IDOR / RBAC-bypass / "
@@ -235,6 +259,9 @@ def coverage_summary(infos: list[ProfileInfo]) -> dict:
     if len(alive) < 2:
         notes.append("only one live identity — chained-auth probes (IDOR cross-user, "
                      "session-replay-against-victim) need >=2 profiles")
+    for c, members in peer_cohorts.items():
+        notes.append(f"cohort '{c}' has {len(members)} live peers ({', '.join(members)}) — "
+                     "horizontal IDOR / cross-tenant access between them is testable")
     return {
         "live_count": len(alive),
         "total_count": len(infos),
@@ -243,5 +270,6 @@ def coverage_summary(infos: list[ProfileInfo]) -> dict:
         "has_low_priv": has_low,
         "has_mid_priv": has_mid,
         "has_high_priv": has_high,
+        "peer_cohorts": peer_cohorts,
         "notes": notes,
     }

--- a/pentest/session_health.py
+++ b/pentest/session_health.py
@@ -99,7 +99,28 @@ class SessionHealthMonitor:
             s.consecutive_failures = 0
             return True, 200
 
-        # Bounced to login page → dead
+        # Landing test thinks this is a login page — but SPAs render their login
+        # component (password field, "sign in" text) into the DOM even when
+        # authenticated, so the heuristic false-positives on logged-in dashboards.
+        # Before declaring dead, confirm with an authenticated API probe: if health_path
+        # returns 2xx with the saved cookies, the session is genuinely alive.
+        # @g.comment -- "Authenticated API probe overrides the login-page heuristic so SPA dashboards (which embed login markup) are not false-flagged dead, which previously skipped every probe in the run"
+        try:
+            api_status = await ctx.page.evaluate(
+                """async (path) => {
+                    try { const r = await fetch(path, {credentials:'include'}); return r.status; }
+                    catch (e) { return 0; }
+                }""",
+                self.health_path,
+            )
+        except Exception:
+            api_status = 0
+        if isinstance(api_status, int) and 200 <= api_status < 300:
+            s.last_status = api_status
+            s.consecutive_failures = 0
+            return True, api_status
+
+        # Bounced to login page AND the API probe did not confirm a live session → dead
         s.last_status = 401
         s.consecutive_failures += 1
         return False, 401

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,6 +307,30 @@ pub enum PentestAction {
         /// touches, including IDPs — keep this in mind for SSO flows.
         #[arg(long = "header", value_name = "NAME:VALUE")]
         headers: Vec<String>,
+
+        /// Explicit privilege rank for this identity: an integer 0-100 or an alias
+        /// high/medium/low (= 90/50/10). Overrides the role-based heuristic and is fed to
+        /// the AI ranker so it selects the right identity per probe (lowest tier for
+        /// privesc, etc.). Omit to auto-derive from the app's role. In multi-capture
+        /// (--auth-numbers > 1) this pre-fills the per-identity prompt.
+        #[arg(long)]
+        tier: Option<String>,
+
+        /// Semantic role hint (e.g. "billing-analyst") passed to the AI as extra context —
+        /// useful when the app's /me endpoint exposes no clear role field.
+        #[arg(long)]
+        persona: Option<String>,
+
+        /// Peer-group name (e.g. "analyst-team-a"). Give two SAME-permission, DIFFERENT-user
+        /// sessions the same cohort so the AI treats them as peers and targets horizontal
+        /// IDOR / cross-tenant access between them.
+        #[arg(long)]
+        cohort: Option<String>,
+
+        /// Free-form `NAME=VALUE` context attached to the profile and shown to the AI.
+        /// Repeatable.
+        #[arg(long = "tag", value_name = "NAME=VALUE")]
+        tags: Vec<String>,
     },
 
     /// List saved auth profiles under ~/.cert-x-gen/auth/

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,6 +328,10 @@ async fn run_pentest_command(cmd: cli::PentestCommand) -> Result<()> {
             label,
             verify_url,
             headers,
+            tier,
+            persona,
+            cohort,
+            tags,
         } => {
             args.extend([
                 "auth".into(),
@@ -355,6 +359,19 @@ async fn run_pentest_command(cmd: cli::PentestCommand) -> Result<()> {
             }
             for h in headers {
                 args.extend(["--header".into(), h]);
+            }
+            // @g.comment -- "Forward the operator identity-metadata flags to the Python orchestrator so tier/persona/cohort/tags reach the auth capture and are persisted with the profile"
+            if let Some(t) = tier {
+                args.extend(["--tier".into(), t]);
+            }
+            if let Some(p) = persona {
+                args.extend(["--persona".into(), p]);
+            }
+            if let Some(c) = cohort {
+                args.extend(["--cohort".into(), c]);
+            }
+            for t in tags {
+                args.extend(["--tag".into(), t]);
             }
         }
         cli::PentestAction::AuthList => {


### PR DESCRIPTION
## Summary

Follow-up work on the AI pentest pipeline (#10), recovered from an unmerged branch. Two related changes to the pentest orchestrator:

1. **Fix: SPA dashboards false-flagged as dead sessions** (correctness — the important one)
2. **Feature: operator-supplied identity metadata** (`--tier/--persona/--cohort/--tag`)

Branch was based off a commit inside #10; cherry-picked cleanly onto current `main`, no conflicts.

## 1. SPA session-health fix

**Problem:** `SessionHealthMonitor._looks_like_login_page` flags any page with ≥2 login markers (password field + "sign in" text) as a login page. Authenticated single-page-app dashboards render their login component into the DOM even when logged in, so a **live session reads as bounced-to-login → profile declared dead → every probe in the run is skipped.** The scan completes having tested nothing.

**Fix:** before declaring a profile dead on the heuristic, confirm with an authenticated API probe to `health_path`; a 2xx with the saved cookies proves the session is alive. Same override applied in pre-flight inspection (`profile_inspect.py`, via `me_path`).

Two related fixes in the same commit:
- `--skip-health-check` now actually disables the runtime `SessionHealthMonitor`. Previously it only forced the pre-flight verdict, and the per-template re-check re-killed the profile anyway.
- `mutator.py`: guard `_signature` against a string-typed `evidence` field — previously crashed the mutation-retry path with `AttributeError: 'str' object has no attribute 'get'`.

**Effect on detection:** runs against SPA targets go from "0 probes executed, 0 findings" to actually running. This is a detection-effectiveness fix, not a throughput change — it adds one API probe, so it's marginally more work per session, but the run does its job instead of silently no-oping.

## 2. Operator identity metadata

New per-identity metadata captured at `cxg pentest auth`, persisted to `<profile>.meta.json`, fed to the AI ranker/generator:

- `--tier` — explicit privilege rank 0-100 (or high/medium/low = 90/50/10). Overrides the role-string heuristic; omit to auto-derive.
- `--persona` — semantic role hint for apps with no clear `/me` role field.
- `--cohort` — peer group; two same-permission different-user sessions sharing a cohort are flagged as peers so the AI targets horizontal IDOR / cross-tenant.
- `--tag NAME=VALUE` — free-form context, repeatable.

Plumbed Rust (`cli.rs`/`main.rs`) → Python orchestrator. **Backward-compatible:** existing profiles load with `tier=None` (auto-derive). Motivation: weak privesc coverage when tier was inferred only from the app's role string.

## Verification

Local, cherry-picked onto `5fe007c`:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-features` — pass
- `cargo clippy --all-features -- -W clippy::all` — pass
- `cargo test --all-features` — **210 passed, 0 failed**
- `cargo build --release` — pass (the release build embeds `pentest/` via `include_dir!`, so this compiles the changed orchestrator into the binary)
- `python3 -m py_compile` — all 6 changed pentest files pass
