### PR TITLE
fix(test): isolate AIManager provider tests from on-disk config (fixes ubuntu CI failure)

### DIFF
--- a/src/ai/manager.rs
+++ b/src/ai/manager.rs
@@ -629,7 +629,13 @@ mod tests {
 
     #[test]
     fn test_list_providers() {
-        let manager = AIManager::new().unwrap();
+        // Use an explicit in-memory default config rather than AIManager::new(),
+        // which calls AIConfig::load() and reads (or creates) the on-disk config at
+        // config_path(). On a runner with a pre-existing/empty config file that read
+        // yields an empty providers map, so the assertions below would fail for
+        // environmental reasons unrelated to this code. with_config() keeps the test
+        // deterministic and free of filesystem side effects.
+        let manager = AIManager::with_config(AIConfig::default()).unwrap();
         let providers = manager.list_providers();
 
         assert!(!providers.is_empty());
@@ -638,7 +644,9 @@ mod tests {
 
     #[test]
     fn test_prompt_builder_integration() {
-        let manager = AIManager::new().unwrap();
+        // with_config avoids the AIConfig::load() disk read/write that new() performs;
+        // this test only exercises the prompt builder, which is config-independent.
+        let manager = AIManager::with_config(AIConfig::default()).unwrap();
 
         // Verify prompt builder is accessible
         let builder = manager.prompt_builder();
@@ -665,7 +673,9 @@ mod tests {
 
     #[test]
     fn test_prompt_builder_skeletons() {
-        let manager = AIManager::new().unwrap();
+        // with_config avoids the AIConfig::load() disk read/write that new() performs;
+        // this test only exercises the prompt builder, which is config-independent.
+        let manager = AIManager::with_config(AIConfig::default()).unwrap();
         let builder = manager.prompt_builder();
 
         // Verify all supported languages have skeletons except YAML


### PR DESCRIPTION
## What

Switches three `AIManager` unit tests from `AIManager::new()` to `AIManager::with_config(AIConfig::default())` so they no longer depend on on-disk config state.

## Why — the v1.2.0 CI failure

`CI / Test (ubuntu-latest)` failed on `main` (`fa6b85a`) with:

```
thread 'ai::manager::tests::test_list_providers' panicked at src/ai/manager.rs:635:9:
assertion failed: !providers.is_empty()
test result: FAILED. 209 passed; 1 failed
```

It passed on both macOS runners and on local dev — an environment-dependent flake, not a regression from any recent PR.

**Root cause:** `AIManager::new()` → `AIConfig::load()` reads `~/.cert-x-gen/ai-config.yaml`, creating a default (which includes `ollama`) only if the file is **absent**. A runner whose HOME already held a config with an empty `providers:` map returns an empty provider list, so `assert!(!providers.is_empty())` panics. macOS runners and local machines had no such file, so `load()` wrote and returned the default and the assertion held — which is why it stayed invisible until a reused ubuntu runner with dirtier state hit it. `load()` also *writes* to disk, giving these unit tests a filesystem side effect and a shared-path race under parallel `cargo test`.

## Fix

`with_config()` (already `pub`) builds the manager from an explicit in-memory config — deterministic, no disk read/write:

- `test_list_providers` — the failing test; asserts on providers, so it must run against a known config.
- `test_prompt_builder_integration`, `test_prompt_builder_skeletons` — only exercise the (config-independent) prompt builder; moved off `new()` to drop the same latent filesystem dependency.
- `test_create_manager` — **left on `new()`**, since it deliberately tests that constructor.

No production code changed — tests only.

## Verification

Reproduced the exact CI condition locally by seeding an empty-providers config under an overridden HOME:

- **Before** (new()-based): `test_list_providers` fails with the empty providers map — matches CI.
- **After** (with_config): all three pass under the same poisoned config.

Full suite on the branch:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-features` — pass
- `cargo clippy --all-features -- -W clippy::all` — pass
- `cargo test --all-features` — **210 passed, 0 failed**

## Follow-up (not in this PR)

`AIConfig::load()` writing during construction makes it unsuitable for any test that builds a manager. Longer term, either a read-only load variant or a test-only config-path override would let the remaining `new()`-based tests (and the ollama async ones) run hermetically. Out of scope for unblocking the release.
