### PR TITLE
feat: bridge AI provider — run cxg template-gen through siete's editor host-model

### DIFF
--- a/pentest/ai_generator.py
+++ b/pentest/ai_generator.py
@@ -170,7 +170,46 @@ class OpenAiApiProvider(_Provider):
         return resp.choices[0].message.content or ""
 
 
+class BridgeProvider(_Provider):
+    """siete's host-model bridge: the editor's own configured model, over a loopback endpoint.
+
+    Lets the Bugb plugin drive cxg template generation with the editor's model (e.g. VS Code's
+    language model) instead of requiring a separate coding-agent CLI on PATH. Wire format matches
+    siete's HttpBridgeProvider: POST {"prompt","tag","cwd"} with a Bearer token to
+    $SIETE_BRIDGE_URL, answered 200 with {"completion": str} (or a text/plain body taken verbatim).
+    """
+    name = "bridge"
+
+    def available(self) -> tuple[bool, str]:
+        if not os.environ.get("SIETE_BRIDGE_URL"):
+            return False, "SIETE_BRIDGE_URL not set (no editor bridge)"
+        return True, "siete host-model bridge (editor's configured model)"
+
+    def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
+        from urllib.request import Request, urlopen
+        url = os.environ["SIETE_BRIDGE_URL"]
+        token = os.environ.get("SIETE_BRIDGE_TOKEN")
+        prompt = f"{system}\n\n---\n\n{user}"
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        body = json.dumps({"prompt": prompt, "tag": "cxg", "cwd": os.getcwd()}).encode("utf-8")
+        req = Request(url, data=body, headers=headers, method="POST")
+        with urlopen(req, timeout=900) as resp:
+            content_type = resp.headers.get("Content-Type") or ""
+            raw = resp.read().decode("utf-8", errors="replace")
+        if raw.lstrip().startswith("{") or "application/json" in content_type:
+            try:
+                completion = json.loads(raw).get("completion")
+                if completion:
+                    return completion
+            except (ValueError, AttributeError):
+                pass
+        return raw
+
+
 _PROVIDER_REGISTRY = {
+    "bridge":        BridgeProvider,
     "claude":        ClaudeCliProvider,
     "codex":         CodexCliProvider,
     "gemini":        GeminiCliProvider,
@@ -180,9 +219,10 @@ _PROVIDER_REGISTRY = {
     "openai-api":    OpenAiApiProvider,
 }
 
-# Preference order when --ai-provider=auto: CLI tools first (no key juggling),
-# API providers as fallback.
-_AUTO_ORDER = ["claude", "codex", "gemini", "anthropic-api", "openai-api"]
+# Preference order when --ai-provider=auto: the editor's host-model bridge first when it's present
+# (its availability gates on $SIETE_BRIDGE_URL, so it is skipped when absent), then CLI tools (no
+# key juggling), then API providers as fallback.
+_AUTO_ORDER = ["bridge", "claude", "codex", "gemini", "anthropic-api", "openai-api"]
 
 
 def pick_provider(name: str = "auto") -> tuple[Optional[_Provider], str]:


### PR DESCRIPTION
## What
Adds a `BridgeProvider` to the pentest AI generator so cxg's template generation can run through **siete's editor host-model bridge** — the editor's own configured model (e.g. VS Code's language model) — instead of requiring a separate coding-agent CLI (`claude`/`codex`/`gemini`) on PATH.

## Why
When Bugb drives a verify run from the editor, siete's own prompts already route through the editor model over a loopback bridge; cxg's template generation didn't — it always spawned its own CLI agent. This closes that gap: a plugin user with no coding-agent CLI installed can still run cxg, using their editor's model.

## How
`BridgeProvider.generate()` POSTs to `$SIETE_BRIDGE_URL` with the Bearer token, matching siete's `HttpBridgeProvider` wire format exactly:
- request: `POST {"prompt","tag":"cxg","cwd"}` + `Authorization: Bearer $SIETE_BRIDGE_TOKEN`
- response: `200 {"completion": str}`, or a `text/plain` body verbatim

Registered in `_PROVIDER_REGISTRY`; first in `_AUTO_ORDER` but gated by `available()` on `$SIETE_BRIDGE_URL`, so `auto` picks it only when the bridge is present and otherwise falls through to the CLI tools.

## Cross-repo dependency
Pairs with a **siete** PR (accept `--ai-provider bridge`; inject it on the plugin's host-model path only). **Merge together** — neither is useful alone.

## Testing
- ✅ Provider resolves correctly: unavailable without `$SIETE_BRIDGE_URL`, available with it; registered; first in auto order.
- ⏳ Needs a live plugin verify against an HTTP target with a host model — confirm cxg's template gen flows through the editor model (bridge receives `tag:"cxg"` POSTs).

## Scope
One file: `pentest/ai_generator.py`. (An unrelated in-tree `README.md` install-docs edit was deliberately left out.)