### PR TITLE
rename: SIETE_BRIDGE_* -> BUGB_BRIDGE_* (cxg bridge provider)

### DIFF
--- a/pentest/ai_generator.py
+++ b/pentest/ai_generator.py
@@ -171,24 +171,24 @@ class OpenAiApiProvider(_Provider):
 
 
 class BridgeProvider(_Provider):
-    """siete's host-model bridge: the editor's own configured model, over a loopback endpoint.
+    """bugb's host-model bridge: the editor's own configured model, over a loopback endpoint.
 
     Lets the Bugb plugin drive cxg template generation with the editor's model (e.g. VS Code's
     language model) instead of requiring a separate coding-agent CLI on PATH. Wire format matches
-    siete's HttpBridgeProvider: POST {"prompt","tag","cwd"} with a Bearer token to
-    $SIETE_BRIDGE_URL, answered 200 with {"completion": str} (or a text/plain body taken verbatim).
+    bugb's HttpBridgeProvider: POST {"prompt","tag","cwd"} with a Bearer token to
+    $BUGB_BRIDGE_URL, answered 200 with {"completion": str} (or a text/plain body taken verbatim).
     """
     name = "bridge"
 
     def available(self) -> tuple[bool, str]:
-        if not os.environ.get("SIETE_BRIDGE_URL"):
-            return False, "SIETE_BRIDGE_URL not set (no editor bridge)"
-        return True, "siete host-model bridge (editor's configured model)"
+        if not os.environ.get("BUGB_BRIDGE_URL"):
+            return False, "BUGB_BRIDGE_URL not set (no editor bridge)"
+        return True, "bugb host-model bridge (editor's configured model)"
 
     def generate(self, system: str, user: str, max_tokens: int = 1500) -> str:
         from urllib.request import Request, urlopen
-        url = os.environ["SIETE_BRIDGE_URL"]
-        token = os.environ.get("SIETE_BRIDGE_TOKEN")
+        url = os.environ["BUGB_BRIDGE_URL"]
+        token = os.environ.get("BUGB_BRIDGE_TOKEN")
         prompt = f"{system}\n\n---\n\n{user}"
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
         if token:
@@ -220,7 +220,7 @@ _PROVIDER_REGISTRY = {
 }
 
 # Preference order when --ai-provider=auto: the editor's host-model bridge first when it's present
-# (its availability gates on $SIETE_BRIDGE_URL, so it is skipped when absent), then CLI tools (no
+# (its availability gates on $BUGB_BRIDGE_URL, so it is skipped when absent), then CLI tools (no
 # key juggling), then API providers as fallback.
 _AUTO_ORDER = ["bridge", "claude", "codex", "gemini", "anthropic-api", "openai-api"]
 


### PR DESCRIPTION
## What
cxg's `BridgeProvider` now reads **`BUGB_BRIDGE_URL`/`BUGB_BRIDGE_TOKEN`** (was `SIETE_BRIDGE_*`), and its docstring/reason strings name the engine `bugb`.

## Why
Last leg of the de-siete rename. These env vars are the shared bridge contract — the plugin *sets* them, the engine and cxg *read* them — so they were held back from the engine's de-siete pass and must move atomically across all three sides.

## ⚠ Atomic — merge with the siete PR
Pairs with **siete PR (rename/bridge-env)**. **Merge together.** Until both land, the plugin sets `BUGB_BRIDGE_*` while cxg still reads `SIETE_BRIDGE_*`, so cxg's editor-model path won't find the env and falls back to a CLI agent. Clean break — no `SIETE_` fallback.

## Testing
✅ Provider resolves on `BUGB_BRIDGE_URL`; the old `SIETE_BRIDGE_URL` no longer satisfies it (verified clean break). One file: `pentest/ai_generator.py` (README left untouched).