### PR TITLE
feat(pentest): carry guardlink's threat_id through to report.json

### DIFF
--- a/pentest/ai_generator.py
+++ b/pentest/ai_generator.py
@@ -353,6 +353,9 @@ def make_probe_class(vuln_class: str, source: str, requires_auth_count: int = 1)
                     description=f.get("description", ""),
                     evidence=f.get("evidence", {}) or {},
                     payload=f.get("payload"),
+                    # Carry guardlink's stable id from the originating hypothesis; absent-safe for a
+                    # hypothesis that is None or predates threat ids.
+                    threat_id=getattr(hypothesis, "threat_id", None),
                 ))
             except Exception:
                 continue

--- a/pentest/browser_engine.py
+++ b/pentest/browser_engine.py
@@ -39,6 +39,10 @@ class Finding:
     evidence: dict = field(default_factory=dict)
     payload: Optional[str] = None
     hypothesis_id: Optional[str] = None
+    # guardlink's stable threat id, carried from the originating hypothesis so siete can correlate
+    # this finding to its exposure by an exact lookup. None for AI/mutation-synthesised probes with
+    # no originating guardlink hypothesis. Serialised into report.json via to_dict().
+    threat_id: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/pentest/guardlink.py
+++ b/pentest/guardlink.py
@@ -50,7 +50,7 @@ class Hypothesis:
     """A pentest target derived from guardlink data."""
     id: str
     vuln_class: str           # e.g. "idor", "csrf", "xss", "session_replay", "credential_stuffing"
-    threat: str               # guardlink threat id, e.g. "#idor"
+    threat: str               # guardlink threat REF, e.g. "#idor" (a category, not a stable id)
     asset: str                # guardlink asset, e.g. "#users-api"
     http_method: Optional[str]
     http_path: Optional[str]  # may contain {var} placeholders
@@ -66,6 +66,10 @@ class Hypothesis:
     playwright_required: bool = False
     # @comment annotations near the route handler — captures intent ("by design")
     nearby_comments: list[str] = field(default_factory=list)
+    # guardlink's stable, opaque threat id ("gl-<hash>") for the exposure this hypothesis came
+    # from — read verbatim from the SARIF result, never computed here. None when the SARIF predates
+    # threat ids or the result is not a guardlink exposure. cxg carries it; it never mints one.
+    threat_id: Optional[str] = None
     raw: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
@@ -221,18 +225,24 @@ def parse_sarif(sarif_path: Path) -> list[Hypothesis]:
             cg = props.get("codegraph_reachability", {}) or {}
             taint = props.get("taint_path", {}) or {}
 
-            threat_id = (
+            threat_ref = (
                 props.get("guardlink_threat")
                 or props.get("threat")        # upstream schema
                 or ""
             )
+            # guardlink's stable per-exposure id (docs/prd/threat-id-design.md §5). Prefer the plain
+            # property; fall back to the SARIF-native partialFingerprints slot. Absent on old
+            # guardlink, parse-error, dangling-ref, and non-guardlink results — carry None, never
+            # fabricate. Kept verbatim: cxg is not an authority for this id, only a carrier.
+            pf = r.get("partialFingerprints", {}) or {}
+            gl_threat_id = props.get("threatId") or pf.get("guardlink/threatId") or None
             asset = (
                 props.get("guardlink_asset")
                 or props.get("asset")          # upstream schema
                 or ""
             )
             vuln_class = _normalize_vuln_class(
-                rlm.get("vuln_class") or threat_id or rule_id
+                rlm.get("vuln_class") or threat_ref or rule_id
             )
 
             sev_raw = (
@@ -273,7 +283,8 @@ def parse_sarif(sarif_path: Path) -> list[Hypothesis]:
             hypo = Hypothesis(
                 id=f"gl-{i}-{vuln_class}",
                 vuln_class=vuln_class,
-                threat=threat_id or "",
+                threat=threat_ref or "",
+                threat_id=gl_threat_id,
                 asset=asset,
                 http_method=cg.get("http_method"),
                 http_path=cg.get("http_path"),

--- a/pentest/js_engine.py
+++ b/pentest/js_engine.py
@@ -70,6 +70,13 @@ class JsTemplate:
     def severity(self) -> str:
         return self.meta.get("severity", "medium")
 
+    @property
+    def threat_id(self) -> Optional[str]:
+        """guardlink's stable threat id, carried in the `// @threat_id:` header the generator wrote
+        for the originating hypothesis. None for AI/mutation-synthesised templates that have no
+        such header. Read verbatim; the id is opaque to cxg."""
+        return self.meta.get("threat_id")
+
 
 def parse_template(path: Path) -> JsTemplate:
     src = path.read_text()
@@ -431,6 +438,7 @@ class JsEngine:
             evidence=f.get("evidence", {}) or {},
             payload=str(f.get("payload")) if f.get("payload") is not None else None,
             hypothesis_id=tpl.id,
+            threat_id=tpl.threat_id,
         )
 
     async def _run_single_template(self, runner_page, tpl: JsTemplate,

--- a/pentest/js_generator.py
+++ b/pentest/js_generator.py
@@ -226,6 +226,18 @@ def _claude_cli_generate(codebase: Path, system: str, user: str, timeout_s: int 
     return _cli_generate(codebase, system, user, provider="claude", timeout_s=timeout_s)
 
 
+def _inject_threat_id_header(js: str, threat_id: Optional[str]) -> str:
+    """Prepend a `// @threat_id: <id>` meta line so guardlink's stable id rides on the template.
+
+    Deterministic on purpose — it does NOT rely on the model emitting the header, which would be
+    unreliable. The engine parses meta from every `// @key:` line regardless of position, and the
+    header is the durable carrier that also survives siete's replay from a saved --template-dir.
+    No-op when the hypothesis has no id, or a header is already present (idempotent)."""
+    if not threat_id or "@threat_id:" in js:
+        return js
+    return f"// @threat_id: {threat_id}\n{js}"
+
+
 def generate_js_template(codebase: Path, session_dir: Path, hypothesis, goal: str,
                          provider: str = "claude", timeout_s: int = 240) -> Optional[Path]:
     """Generate a JS template for one hypothesis. Returns Path to the saved .js file.
@@ -284,6 +296,7 @@ def generate_js_template(codebase: Path, session_dir: Path, hypothesis, goal: st
     if not js:
         print(f"  ✗ {hypothesis.vuln_class}: no JS block in {provider} output ({len(raw)} chars, {elapsed:.1f}s)")
         return None
+    js = _inject_threat_id_header(js, getattr(hypothesis, "threat_id", None))
     out_path.write_text(js)
     print(f"  ✓ {hypothesis.vuln_class} → {out_path.name} ({len(js)} chars, {elapsed:.1f}s)")
     return out_path

--- a/pentest/tests/test_threat_id.py
+++ b/pentest/tests/test_threat_id.py
@@ -1,0 +1,183 @@
+"""Carry guardlink's stable threat_id through the cxg pentest pipeline.
+
+docs/prd/threat-id-design.md §5 (cxg section): guardlink mints a stable, opaque `gl-<hash>` id per
+exposure; cxg reads it off the SARIF result, carries it through the hypothesis and the template onto
+each Finding, and emits it per finding in report.json — the artifact siete reads. cxg is only a
+carrier: it never mints or recomputes the id, and it must survive the id being absent (old guardlink,
+non-guardlink results, AI/mutation-synthesised probes) or shared across several results.
+
+Run: python3 -m unittest discover -s pentest/tests   (pentest/ on sys.path; no third-party deps).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# The pentest modules use bare imports (`from auth import ...`), so the package dir must be on the
+# path — exactly as the orchestrator runs them.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import guardlink  # noqa: E402
+from browser_engine import Finding  # noqa: E402
+from js_engine import JsEngine, JsTemplate, parse_template  # noqa: E402
+from js_generator import _inject_threat_id_header  # noqa: E402
+
+
+def _sarif(results: list[dict]) -> dict:
+    return {"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "GuardLink"}}, "results": results}]}
+
+
+def _exposure_result(threat_id=None, *, use_fingerprint=False, asset="#ws-proxy", threat="#idor",
+                     file="api/ws/attach.go", line=42, rule="guardlink/unmitigated-critical") -> dict:
+    r: dict = {
+        "ruleId": rule,
+        "message": {"text": f"{asset} is exposed to {threat.lstrip('#')}"},
+        "locations": [{"physicalLocation": {"artifactLocation": {"uri": file},
+                                             "region": {"startLine": line}}}],
+        "properties": {"severity": "high", "asset": asset, "threat": threat},
+    }
+    if threat_id is not None:
+        if use_fingerprint:
+            r["partialFingerprints"] = {"guardlink/threatId": threat_id}
+        else:
+            r["properties"]["threatId"] = threat_id
+    return r
+
+
+def _write_sarif(tmp: Path, results: list[dict]) -> Path:
+    p = tmp / "findings.sarif"
+    p.write_text(json.dumps(_sarif(results)))
+    return p
+
+
+class ParseSarifReadsThreatId(unittest.TestCase):
+    def setUp(self):
+        self._dir = Path(__file__).resolve().parent / "_tmp"
+        self._dir.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        for p in self._dir.glob("*"):
+            p.unlink()
+
+    def test_reads_properties_threat_id(self):
+        path = _write_sarif(self._dir, [_exposure_result("gl-a1b2c3d4e5f6")])
+        [h] = guardlink.parse_sarif(path)
+        self.assertEqual(h.threat_id, "gl-a1b2c3d4e5f6")
+
+    def test_falls_back_to_partial_fingerprints_when_properties_absent(self):
+        # properties carries no threatId; the SARIF-native slot does.
+        path = _write_sarif(self._dir, [_exposure_result("gl-fallback0001", use_fingerprint=True)])
+        [h] = guardlink.parse_sarif(path)
+        self.assertEqual(h.threat_id, "gl-fallback0001")
+
+    def test_none_when_neither_present(self):
+        path = _write_sarif(self._dir, [_exposure_result(None)])
+        [h] = guardlink.parse_sarif(path)
+        self.assertIsNone(h.threat_id)
+
+    def test_never_fabricates_for_a_result_without_an_id(self):
+        # Even a fully-formed exposure with no threatId stays None — cxg mints nothing.
+        path = _write_sarif(self._dir, [_exposure_result(None, asset="#a", threat="#t", file="x.go")])
+        [h] = guardlink.parse_sarif(path)
+        self.assertIsNone(h.threat_id)
+
+    def test_two_results_sharing_one_threat_id_both_parse_neither_dropped(self):
+        # guardlink bases the id on (asset, threat, file), so an @exposes and its @confirmed — or two
+        # weaknesses at the same place — legitimately share it. cxg must keep BOTH hypotheses.
+        shared = "gl-deadbeef0000"
+        path = _write_sarif(self._dir, [
+            _exposure_result(shared, rule="guardlink/unmitigated-critical"),
+            _exposure_result(shared, rule="guardlink/confirmed-exploitable"),
+        ])
+        hyps = guardlink.parse_sarif(path)
+        self.assertEqual(len(hyps), 2)
+        self.assertEqual([h.threat_id for h in hyps], [shared, shared])
+
+    def test_property_wins_over_fingerprint_when_both_present(self):
+        r = _exposure_result("gl-fromprops001")
+        r["partialFingerprints"] = {"guardlink/threatId": "gl-fromfinger99"}
+        path = _write_sarif(self._dir, [r])
+        [h] = guardlink.parse_sarif(path)
+        self.assertEqual(h.threat_id, "gl-fromprops001")
+
+
+class TemplateHeaderCarriesThreatId(unittest.TestCase):
+    def test_injects_header_deterministically(self):
+        js = "// @id: probe-1\nasync function cxgProbe(cxg) { return []; }\n"
+        out = _inject_threat_id_header(js, "gl-abc123abc123")
+        self.assertIn("// @threat_id: gl-abc123abc123", out)
+
+    def test_injection_is_idempotent_and_absent_safe(self):
+        js = "// @id: probe-1\nx();\n"
+        self.assertEqual(_inject_threat_id_header(js, None), js)          # no id -> unchanged
+        once = _inject_threat_id_header(js, "gl-1")
+        self.assertEqual(_inject_threat_id_header(once, "gl-1"), once)     # already present -> no dup
+
+    def test_parse_template_reads_the_header(self):
+        d = Path(__file__).resolve().parent / "_tmp"
+        d.mkdir(exist_ok=True)
+        p = d / "probe.js"
+        p.write_text(_inject_threat_id_header("// @id: probe-1\n// @vuln_class: idor\nx();\n", "gl-xyz789xyz789"))
+        try:
+            tpl = parse_template(p)
+            self.assertEqual(tpl.threat_id, "gl-xyz789xyz789")
+        finally:
+            p.unlink()
+
+    def test_template_without_header_has_none(self):
+        tpl = JsTemplate(path=Path("x.js"), source="x();", meta={"id": "probe-1", "vuln_class": "idor"})
+        self.assertIsNone(tpl.threat_id)
+
+
+class FindingInheritsThreatId(unittest.TestCase):
+    def _engine(self) -> JsEngine:
+        # _finding_from_dict only touches self.target, so skip the browser-heavy __init__.
+        eng = object.__new__(JsEngine)
+        eng.target = "http://lab:9054"
+        return eng
+
+    def test_finding_inherits_the_templates_threat_id(self):
+        tpl = JsTemplate(path=Path("p.js"), source="",
+                         meta={"id": "probe-1", "vuln_class": "idor", "threat_id": "gl-share111111"})
+        finding = self._engine()._finding_from_dict(
+            {"confirmed": True, "endpoint": "GET /x", "description": "d"}, tpl)
+        self.assertEqual(finding.threat_id, "gl-share111111")
+
+    def test_finding_threat_id_is_none_for_a_template_without_one(self):
+        tpl = JsTemplate(path=Path("p.js"), source="", meta={"id": "ai-probe", "vuln_class": "idor"})
+        finding = self._engine()._finding_from_dict({"confirmed": False, "endpoint": ""}, tpl)
+        self.assertIsNone(finding.threat_id)
+
+
+class ReportJsonRoundTrip(unittest.TestCase):
+    def _report(self, findings: list[Finding]) -> str:
+        # Mirrors cxg_pentest.py's report emission for the fields under test.
+        return json.dumps({"confirmed_findings": [f.to_dict() for f in findings]},
+                          indent=2, default=str)
+
+    def test_present_and_absent_both_round_trip(self):
+        with_id = Finding(id="f1", vuln_class="idor", severity="high", confirmed=True,
+                          target="http://lab", endpoint="GET /x", description="d",
+                          hypothesis_id="probe-1", threat_id="gl-abc123abc123")
+        without = Finding(id="f2", vuln_class="xss", severity="low", confirmed=True,
+                          target="http://lab", endpoint="GET /y", description="d")  # AI-synthesised
+        doc = json.loads(self._report([with_id, without]))
+        a, b = doc["confirmed_findings"]
+        self.assertEqual(a["threat_id"], "gl-abc123abc123")
+        self.assertIsNone(b["threat_id"])              # present as null, not fabricated
+        self.assertIn("threat_id", b)                   # the key is always emitted
+
+    def test_shared_id_survives_to_report(self):
+        # Two findings from two results that shared one threat_id both carry it into report.json.
+        shared = "gl-deadbeef0000"
+        fs = [Finding(id=f"f{i}", vuln_class="idor", severity="high", confirmed=True,
+                      target="http://lab", endpoint="GET /x", description="d", threat_id=shared)
+              for i in range(2)]
+        doc = json.loads(self._report(fs))
+        self.assertEqual([f["threat_id"] for f in doc["confirmed_findings"]], [shared, shared])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Description

Carries guardlink's stable, opaque threat_id (gl-<hash>) through the cxg pentest pipeline so it lands on every finding in report.json — the artifact siete correlates against. Per docs/prd/threat-id-design.md §5, cxg is only a carrier: it reads the id off each SARIF result and threads it through unchanged, never minting, recomputing, or fabricating one.

- Read (guardlink.py): parse_sarif reads properties.threatId, falling back to partialFingerprints["guardlink/threatId"], into a new Hypothesis.threat_id: Optional[str]. None for old-guardlink / parse-error / dangling-ref / non-guardlink results.
- Not unique: guardlink bases the id on (asset, threat, file), so an @exposes and its @confirmed — or two weaknesses at the same place — legitimately share it. parse_sarif appends one hypothesis per result and keys nothing on the id, so no collision is dropped; resolving the fan-out is siete's job.
- Carry: the id rides the template's // @threat_id: meta header, injected deterministically at generation (js_generator.py) rather than via the model, so it survives the disk round-trip including siete's replay from a saved --template-dir. JsTemplate.threat_id reads it; JsEngine._finding_from_dict threads it onto the Finding; the in-memory AI-probe path (ai_generator.py) carries it from the hypothesis. Synthesised probes with no originating hypothesis → absent.
- Emit: Finding gains threat_id (browser_engine.py); to_dict() serialises it, so each finding in report.json carries "threat_id": "gl-..." when known, null otherwise.

Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] New template
- [ ] Documentation update

Related Issues

Part of the cross-repo threat-ID work (guardlink mints → cxg carries → siete correlates), per docs/prd/threat-id-design.md §5. (No tracking issue number on hand — fill in if one exists.)

Testing

- Python (pentest/tests/test_threat_id.py, stdlib unittest — pytest isn't installed in this env): python3 -m unittest discover -s pentest/tests → 14 passed. Covers: properties.threatId read; partialFingerprints fallback; property-wins-when-both; neither → None (never fabricated); two results sharing one id both parse (neither dropped); template header inject/idempotent/absent-safe + round-trip via parse_template; a finding inherits the id; report.json round-trips present and absent cases.
- End-to-end sanity: exercised parse → template header carry → _finding_from_dict → report.json emission, confirming a confirmed finding shows "threat_id": "gl-7ce279ce25ec", an AI-synthesised finding shows "threat_id": null (key always present), and a shared id survives on both findings.
- Rust untouched/green: cargo build clean; cargo test → 210 unit + 15 doc-tests passed, 0 failed.

Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (no doc changes; the @threat_id template header and the new report.json field could warrant a note in pentest/docs/TEMPLATES.md if the team wants it)
- [x] My changes generate no new warnings (cargo build clean; py_compile clean on all touched modules)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally