### PR TITLE
Track B: saved-session auth for CI (import/inject, health gate, --auth-dir)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
           node-version: '20'
       - run: python -m pip install --upgrade pip
       - run: pip install -r pentest/requirements.txt
+      # Track B's `auth verify` liveness tests drive a real headless Chromium;
+      # the pip package ships no browser binary. Install it (with OS deps) so
+      # those tests run against the same substrate a real `auth verify --ci` does.
+      - run: python -m playwright install --with-deps chromium
       - run: python -m pytest -v
         working-directory: pentest
 

--- a/pentest/auth.py
+++ b/pentest/auth.py
@@ -22,11 +22,13 @@ app instances (one --user-data-dir each) and lets the operator log into each by 
 """
 from __future__ import annotations
 import base64
+import hashlib
 import json
 import os
 import re
 import sys
 from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -218,6 +220,70 @@ def assert_auth_dir_not_world_readable(auth_dir: Path) -> None:
             f"auth dir {auth_dir} is world-accessible (mode {oct(mode & 0o777)}); a saved "
             f"session is a credential. Run `chmod 700 {auth_dir}` and retry, or run without "
             f"CI mode to override.")
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+# @g.comment -- "Earliest FUTURE cookie expiry in a storage_state, as the session's derivable expiry — the point the replayed session most likely stops authenticating. Session cookies carry expires == -1 (Playwright's sentinel) and are skipped; if every cookie is a session cookie the expiry is genuinely not derivable and this returns None rather than inventing one."
+def _earliest_cookie_expiry(state: dict) -> Optional[str]:
+    exps = [c.get("expires") for c in state.get("cookies", [])
+            if isinstance(c.get("expires"), (int, float)) and c["expires"] > 0]
+    if not exps:
+        return None
+    return _iso(min(exps))
+
+
+# @g.comment -- "A provenance record for one saved session, for the run manifest: a content hash plus derivable capture/expiry times, so a CI run's report shows WHICH session it used and whether it was fresh — an auditable 'this run was authenticated as X'. The fingerprint is sha256 over the CANONICAL (sorted, compact) state so the same session hashes identically across a re-serialising import round-trip, and it is a one-way hash — it identifies a session without ever carrying a cookie or token value into the artifact. A desktop identity has no serialisable state to hash, so its fingerprint is None and the user_data_dir is recorded instead."
+def session_fingerprint(profile: AuthProfile) -> dict:
+    out: dict = {"name": profile.name, "kind": profile.kind}
+    if profile.kind != "storage_state" or not profile.storage_state_path:
+        out["fingerprint"] = None
+        out["user_data_dir"] = profile.user_data_dir
+        return out
+    p = Path(profile.storage_state_path)
+    state = json.loads(p.read_text())
+    canon = json.dumps(state, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    out["fingerprint"] = "sha256:" + hashlib.sha256(canon).hexdigest()
+    out["cookies"] = len(state.get("cookies", []))
+    try:
+        out["captured_at"] = _iso(p.stat().st_mtime)
+    except OSError:
+        out["captured_at"] = None
+    out["expires_at"] = _earliest_cookie_expiry(state)
+    return out
+
+
+# @g.comment -- "Landing-page liveness check for one saved WEB session, reusing profile_inspect's inspector verbatim — the same navigate-to-target-and-see-if-we-bounce-to-login test scan-time pre-flight uses, so `auth verify` and a run agree on alive/dead. Returns 0 alive, non-zero dead, so a pipeline can gate on the exit code before spending a whole run. A desktop identity has no browser landing test (its session lives in the app's user-data dir); it is reported as such and returns 0, matching profile_inspect's own 'no verdict from pre-flight, checked at scan time' placeholder rather than claiming a false death. Prints only status/URL — never a cookie value."
+def verify_profile(name: str, target: Optional[str] = None,
+                   me_path: str = "/api/me") -> int:
+    try:
+        prof = load_profile(name)
+    except Exception as e:
+        print(f"  ✗ auth profile '{name}' could not be loaded: {e}", file=sys.stderr)
+        return 2
+    if prof.kind != "storage_state":
+        print(f"  ⓘ '{name}' is a desktop identity (kind={prof.kind}); its session lives in "
+              f"{prof.user_data_dir!r} and cannot be verified out-of-band. Liveness is "
+              f"checked at scan time by the Electron substrate.", file=sys.stderr)
+        return 0
+    tgt = target or prof.target
+    if not tgt:
+        print(f"  ✗ no target to verify '{name}' against — the profile has no saved target; "
+              f"pass --target.", file=sys.stderr)
+        return 2
+    from profile_inspect import inspect_profiles
+    info = inspect_profiles([name], tgt, me_path=me_path)[0]
+    if info.alive:
+        print(f"  ✓ session for '{name}' is ALIVE against {tgt}", file=sys.stderr)
+        for n in info.notes:
+            print(f"      · {n}", file=sys.stderr)
+        return 0
+    print(f"  ✗ session for {name} expired — re-capture and re-import", file=sys.stderr)
+    for n in info.notes:
+        print(f"      · {n}", file=sys.stderr)
+    return 1
 
 
 # @g.comment -- "Persists one identity's metadata, and — only for kind == storage_state — its Playwright storage_state JSON; kind/user_data_dir are trailing keyword args so every pre-existing positional caller (capture_interactive, capture_scripted) is untouched, and a desktop caller passes storage_state=None plus kind='user_data_dir' instead of a dict there isn't one of."
@@ -765,6 +831,20 @@ def build_parser():
                           help="Non-interactive CI mode: refuse a world-accessible --auth-dir "
                                "rather than write a credential a fellow user could read.")
 
+    # @g.comment -- "Out-of-band liveness gate for a saved session: exit 0 alive / non-zero dead, reusing the same landing-page test scan-time pre-flight uses. A pipeline runs this before spending a whole run, and re-captures when it fails."
+    p_verify = sub.add_parser(
+        "verify",
+        help="Check a saved web session is still alive (exit 0 alive / non-zero dead)")
+    p_verify.add_argument("--profile", required=True, help="Profile name to verify.")
+    p_verify.add_argument("--target", default=None,
+                          help="Override the profile's saved target for the landing test.")
+    p_verify.add_argument("--me-path", default="/api/me",
+                          help="Secondary identity endpoint probed for role/email; the landing "
+                               "test is the source of truth. Default /api/me.")
+    p_verify.add_argument("--auth-dir", default=None,
+                          help="Read the profile from this auth directory instead of "
+                               "~/.cert-x-gen/auth.")
+
     p_list = sub.add_parser("list", help="List saved auth profiles under ~/.cert-x-gen/auth/")
     return ap
 
@@ -803,6 +883,9 @@ def main(argv: list[str]) -> int:
         print(f"[auth] imported {prof.name} "
               f"(storage_state, {len(state.get('cookies', []))} cookies)")
         return 0
+
+    if args.cmd == "verify":
+        return verify_profile(args.profile, target=args.target, me_path=args.me_path)
 
     if args.cmd == "list":
         for prof in list_profiles():

--- a/pentest/auth.py
+++ b/pentest/auth.py
@@ -21,8 +21,10 @@ app instances (one --user-data-dir each) and lets the operator log into each by 
 (scripted), naming them <profile>-1, <profile>-2, ...
 """
 from __future__ import annotations
+import base64
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
@@ -32,6 +34,30 @@ AUTH_DIR = Path.home() / ".cert-x-gen" / "auth"
 
 # @g.comment -- "Operator-facing privilege bands mapped onto the same 0-100 scale profile_inspect.ROLE_TIER uses, so an explicit --tier slots cleanly next to auto-derived role tiers (admin=100, analyst=60, user=20)."
 TIER_ALIASES = {"high": 90, "medium": 50, "med": 50, "low": 10, "none": 0, "guest": 5}
+
+
+# @g.comment -- "Parse the repeatable --tag NAME=VALUE pairs into a dict, warning on (and skipping) a malformed one rather than aborting. Extracted so `login` and `import` share one spelling of the same operator metadata surface."
+def parse_tags(raw_tags) -> dict:
+    tags: dict = {}
+    for t in raw_tags or []:
+        if "=" not in t:
+            print(f"  ⚠ ignoring malformed --tag '{t}' (expected NAME=VALUE)", file=sys.stderr)
+            continue
+        k, _, v = t.partition("=")
+        tags[k.strip()] = v.strip()
+    return tags
+
+
+# @g.comment -- "Parse the repeatable --header NAME:VALUE pairs into a dict. Values are NEVER echoed here — a header is frequently a WAF/bypass token, a credential — so the caller prints keys only, exactly as the capture path does."
+def parse_headers(raw_headers) -> dict:
+    headers: dict = {}
+    for h in raw_headers or []:
+        if ":" not in h:
+            print(f"  ⚠ ignoring malformed --header '{h}' (expected NAME:VALUE)", file=sys.stderr)
+            continue
+        name, _, val = h.partition(":")
+        headers[name.strip()] = val.strip()
+    return headers
 
 
 # @g.comment -- "Parse the operator-supplied privilege tier: an int 0-100 or a high/medium/low alias; None (unset/blank) means 'auto-derive from the app role at inspection time'."
@@ -79,6 +105,119 @@ class AuthProfile:
 
 def profile_path(name: str) -> Path:
     return AUTH_DIR / f"{name}.json"
+
+
+def meta_path(name: str) -> Path:
+    return AUTH_DIR / f"{name}.meta.json"
+
+
+# @g.comment -- "Redirects the whole module at a different auth directory for one process — a CI pipeline restores a bundle of profiles into its own dir and points the run at it via --auth-dir. Every profile function (save_profile, load_profile, list_profiles, profile_path) reads AUTH_DIR at CALL time, and profile_inspect/js_engine/browser_engine all reach the store only through load_profile, so reassigning this module global is the single lever that moves all of them. A freshly-created dir is made 0700 (a saved session is a credential); a pre-existing dir is left exactly as the operator restored it, so the CI world-readable guard can still judge it rather than being silently papered over."
+def set_auth_dir(path) -> None:
+    global AUTH_DIR
+    AUTH_DIR = Path(path)
+    ensure_auth_dir()
+
+
+# @g.comment -- "Creates the auth store 0700 when it does not exist yet, so cxg never materialises a credential directory a fellow user can read. Does NOT touch the mode of a dir that already exists — that is the operator's to set, and silently widening or narrowing it would hide exactly the misconfiguration the CI guard exists to catch."
+def ensure_auth_dir() -> None:
+    if not AUTH_DIR.exists():
+        AUTH_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(AUTH_DIR, 0o700)
+        except OSError:
+            pass
+
+
+# @g.comment -- "chmod 600 a written profile file. A storage_state is live cookies/tokens; on a multi-user host the default umask (commonly 0644) would leave it group/world-readable. Best-effort: a filesystem that cannot represent Unix modes (a mounted share, Windows) must not fail the import over it."
+def _chmod_600(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+# @g.comment -- "Maps a profile name onto its single-profile env-var convention, CXG_AUTH_STATE_<NAME>: uppercased with every non-alphanumeric folded to underscore, so 'pentest-alice' -> CXG_AUTH_STATE_PENTEST_ALICE lands on a valid shell identifier a CI secret can be exported as."
+def env_var_for(name: str) -> str:
+    return "CXG_AUTH_STATE_" + re.sub(r"[^A-Z0-9]", "_", name.upper())
+
+
+# @g.comment -- "Resolves the supplied storage_state into a dict without ever echoing its contents. Source precedence: an explicit --storage-state path, '-' for stdin (a CI secret pipes straight in, never touching disk in plaintext beyond the profile dir), or — when omitted — the base64 CXG_AUTH_STATE_<NAME> env var for the single-profile case. Every failure is a ValueError with a redacted message: a malformed secret must never be dumped to a log to explain why it was malformed."
+def load_storage_state_from_source(source: Optional[str], name: str) -> dict:
+    if source == "-":
+        raw = sys.stdin.read()
+    elif source:
+        raw = Path(source).read_text()
+    else:
+        env = env_var_for(name)
+        b64 = os.environ.get(env)
+        if not b64:
+            raise ValueError(
+                f"no storage state supplied: pass --storage-state <path|-> or set {env} "
+                f"(base64-encoded Playwright storage_state)")
+        try:
+            raw = base64.b64decode(b64).decode("utf-8")
+        except Exception as e:
+            raise ValueError(f"{env} is not valid base64-encoded UTF-8: {type(e).__name__}")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"storage state is not valid JSON: {e}")
+
+
+# @g.comment -- "Writes a profile from an already-obtained storage_state — no browser — reusing save_profile verbatim so the on-disk shape is byte-for-byte what a capture produces and a run cannot tell an imported profile from a captured one. The two written files are then chmod 600'd (a saved session is a credential) and a REDACTED summary is printed: counts and header KEYS only, never a cookie/token value, exactly as extra_headers already does on the capture path. Validates the state is a Playwright storage_state (has cookies or origins) before persisting, so a stray JSON object cannot masquerade as a session that would then silently authenticate as nobody."
+def import_profile(name: str, target: str, storage_state: dict, *,
+                   label: Optional[str] = None, extra_headers: Optional[dict] = None,
+                   tier: Optional[int] = None, persona: Optional[str] = None,
+                   cohort: Optional[str] = None, tags: Optional[dict] = None,
+                   verbose: bool = True) -> AuthProfile:
+    if not isinstance(storage_state, dict):
+        raise ValueError("storage state must be a JSON object (a Playwright storage_state)")
+    cookies = storage_state.get("cookies")
+    origins = storage_state.get("origins")
+    if cookies is None and origins is None:
+        raise ValueError(
+            "supplied state does not look like a Playwright storage_state "
+            "(no 'cookies' or 'origins' key)")
+    ensure_auth_dir()
+    prof = save_profile(name, target, storage_state, label=label,
+                        extra_headers=extra_headers, tier=tier, persona=persona,
+                        cohort=cohort, tags=tags)
+    _chmod_600(profile_path(name))
+    _chmod_600(meta_path(name))
+    if verbose:
+        cks = cookies or []
+        ors = origins or []
+        # Redacted: counts and domain COUNT only — never a cookie name or value.
+        print(f"  ✓ imported {len(cks)} cookies across "
+              f"{len({c.get('domain', '?') for c in cks})} domains, "
+              f"{sum(len(o.get('localStorage', [])) for o in ors)} localStorage items, "
+              f"{sum(len(o.get('sessionStorage', [])) for o in ors)} sessionStorage items",
+              file=sys.stderr)
+        if extra_headers:
+            # Print header KEYS, never their values — they may be WAF/bypass tokens.
+            print(f"  ✓ {len(extra_headers)} extra header(s) saved: {list(extra_headers)}",
+                  file=sys.stderr)
+    return prof
+
+
+# @g.comment -- "True when the run is in non-interactive CI mode: either the explicit --ci flag, or the CXG_CI env var set truthy so a pipeline that cannot easily add the flag still opts in. Deliberately NOT the generic `CI` env var (set by every CI provider) — that would silently flip a developer's local run whose shell happened to inherit CI=true into hard-fail mode; opting into the dead-session hard-fail has to be a decision, not an accident."
+def is_ci(flag: bool = False) -> bool:
+    if flag:
+        return True
+    return os.environ.get("CXG_CI", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+# @g.comment -- "Refuses an auth store other users can reach, in CI mode. A storage_state is a credential; a world-accessible bundle dir on a shared runner leaks every session in it. Raises rather than warns, because CI mode's whole contract is fail-loud: the operator restores the bundle, so chmod 700 is theirs to do. A missing dir is not a violation (nothing to leak yet); a dir with any other-user bit set is."
+def assert_auth_dir_not_world_readable(auth_dir: Path) -> None:
+    try:
+        mode = auth_dir.stat().st_mode
+    except FileNotFoundError:
+        return
+    if mode & 0o007:
+        raise PermissionError(
+            f"auth dir {auth_dir} is world-accessible (mode {oct(mode & 0o777)}); a saved "
+            f"session is a credential. Run `chmod 700 {auth_dir}` and retry, or run without "
+            f"CI mode to override.")
 
 
 # @g.comment -- "Persists one identity's metadata, and — only for kind == storage_state — its Playwright storage_state JSON; kind/user_data_dir are trailing keyword args so every pre-existing positional caller (capture_interactive, capture_scripted) is untouched, and a desktop caller passes storage_state=None plus kind='user_data_dir' instead of a dict there isn't one of."
@@ -589,6 +728,43 @@ def build_parser():
     p_login.add_argument("--app-binary", default="",
                          help="Path to a built desktop app. Alternative to --app-cmd.")
 
+    # @g.comment -- "Non-interactive import: write a profile from a supplied Playwright storage_state with NO browser, reusing save_profile so the result is indistinguishable from a capture. This is the CI-replay primitive — a human captures a session once (SSO/MFA and all), exports the storage_state, and every pipeline run injects it here without a display or a human."
+    p_import = sub.add_parser(
+        "import",
+        help="Import a saved Playwright storage_state as a profile (no browser)")
+    p_import.add_argument("--profile", required=True,
+                          help="Profile name. A subsequent `cxg pentest run --auth <profile>` "
+                               "loads it exactly like a captured one.")
+    p_import.add_argument("--target", required=True,
+                          help="Target URL this session authenticates against. Recorded in the "
+                               "profile and used by `auth verify` / run pre-flight as the "
+                               "landing-test URL.")
+    p_import.add_argument("--storage-state", default=None, metavar="PATH|-",
+                          help="Path to a Playwright storage_state JSON, or '-' to read it from "
+                               "stdin (a CI secret pipes straight in). Omit to materialise it "
+                               "from the base64 env var CXG_AUTH_STATE_<NAME> instead.")
+    p_import.add_argument("--label", default=None,
+                          help="Human-readable label (e.g. 'admin'), shown in scan output.")
+    p_import.add_argument("--tier", default=None,
+                          help="Explicit privilege rank: int 0-100 or high/medium/low. Same "
+                               "meaning as on capture.")
+    p_import.add_argument("--persona", default=None, help="Semantic role hint passed to the AI.")
+    p_import.add_argument("--cohort", default=None,
+                          help="Peer group name for horizontal IDOR / cross-tenant tests.")
+    p_import.add_argument("--tag", action="append", default=[], metavar="NAME=VALUE",
+                          help="Free-form k=v context attached to the profile. Repeatable.")
+    p_import.add_argument("--header", action="append", default=[], metavar="NAME:VALUE",
+                          help="Custom HTTP header sent on every request from this profile "
+                               "(e.g. a WAF-bypass token). Repeatable. Stored as a credential; "
+                               "values are never echoed.")
+    p_import.add_argument("--auth-dir", default=None,
+                          help="Write into this auth directory instead of ~/.cert-x-gen/auth. "
+                               "A pipeline restores a bundle of profiles into one dir and points "
+                               "the run at it with the same flag.")
+    p_import.add_argument("--ci", action="store_true",
+                          help="Non-interactive CI mode: refuse a world-accessible --auth-dir "
+                               "rather than write a credential a fellow user could read.")
+
     p_list = sub.add_parser("list", help="List saved auth profiles under ~/.cert-x-gen/auth/")
     return ap
 
@@ -597,6 +773,37 @@ def main(argv: list[str]) -> int:
     ap = build_parser()
 
     args = ap.parse_args(argv)
+
+    # @g.comment -- "Redirect the whole module at --auth-dir before anything reads the store, so import writes into (and verify reads from) the bundle dir a pipeline restored, not ~/.cert-x-gen/auth."
+    if getattr(args, "auth_dir", None):
+        set_auth_dir(args.auth_dir)
+
+    if args.cmd == "import":
+        if is_ci(getattr(args, "ci", False)):
+            try:
+                assert_auth_dir_not_world_readable(AUTH_DIR)
+            except PermissionError as e:
+                print(f"  ✗ {e}", file=sys.stderr)
+                return 2
+        try:
+            tier = parse_tier(args.tier)
+        except ValueError as e:
+            print(f"  ✗ {e}", file=sys.stderr)
+            return 2
+        tags = parse_tags(args.tag)
+        extra_headers = parse_headers(args.header)
+        try:
+            state = load_storage_state_from_source(args.storage_state, args.profile)
+            prof = import_profile(args.profile, args.target, state, label=args.label,
+                                  extra_headers=extra_headers, tier=tier,
+                                  persona=args.persona, cohort=args.cohort, tags=tags)
+        except (ValueError, OSError) as e:
+            print(f"  ✗ {e}", file=sys.stderr)
+            return 2
+        print(f"[auth] imported {prof.name} "
+              f"(storage_state, {len(state.get('cookies', []))} cookies)")
+        return 0
+
     if args.cmd == "list":
         for prof in list_profiles():
             tier_s = str(prof.tier) if prof.tier is not None else "auto"

--- a/pentest/cxg_pentest.py
+++ b/pentest/cxg_pentest.py
@@ -440,11 +440,14 @@ def print_review_only(review_only: list) -> None:
 # @g.comment -- "Carries the empty finding lists explicitly rather than omitting them. A consumer that reads report['confirmed_findings'] must not have to branch on which of two report shapes it got; an absent key raises where an empty list correctly says 'no findings, and see status/caveats for why'. `status` is the one key the full report does not have, and it is what tells a reader these empties mean 'nothing ran' rather than 'everything ran and found nothing'."
 # @g.comment -- "substrate_info is None because the substrate is not built until after this point, which build_report_caveats already treats as its conservative 'nothing is known to be seeded' default — correct here, since no instance was opened at all."
 def build_no_templates_report(args, codebase, session_root, tpl_dir, sarif,
-                              hyps, config_hyps, review_only) -> dict:
+                              hyps, config_hyps, review_only,
+                              auth_provenance=None) -> dict:
     return {
         "target": args.target,
         "codebase": str(codebase),
         "auth_profiles": args.auth,
+        # @g.comment -- "Present with the same shape the full report uses so a consumer reading report['auth_provenance'] never has to branch on which report shape it got. Defaults to [] for the callers (and tests) that build a no-templates report without having run pre-flight."
+        "auth_provenance": auth_provenance or [],
         "goal": args.goal,
         "template_dir": str(tpl_dir),
         "session_dir": str(session_root),
@@ -492,6 +495,27 @@ def host_seeded_dirs(surfaces: list) -> frozenset[Path]:
         Path(s.extra["user_data_dir"]) for s in surfaces
         if s.extra.get("seeded") and "user_data_dir" in s.extra
     )
+
+
+# @g.comment -- "The CI hard-fail decision as a pure predicate: the names of profiles pre-flight found dead, but ONLY in CI mode — out of CI mode it always returns [] so the current warn-and-continue behaviour is byte-identical. Extracted from run_pentest so the load-bearing 'never probe unauthenticated in CI' rule can be pinned by a direct test rather than only through the whole async pipeline. --skip-health-check force-marks profiles alive upstream, so a deliberately-skipped session never reaches this list."
+def ci_dead_sessions(profile_infos: list, ci_mode: bool) -> list[str]:
+    if not ci_mode:
+        return []
+    return [i.profile_name for i in profile_infos if not i.alive]
+
+
+# @g.comment -- "Builds the run manifest's session-provenance list: one record per profile pairing auth.session_fingerprint (a content hash + derivable capture/expiry, never a cookie value) with `fresh`, taken from whether pre-flight found the session alive. A profile that cannot be loaded or hashed degrades to a null-fingerprint record with the error rather than aborting the report — provenance is an audit aid, not a gate. Kept beside auth_profiles (the NAMES) rather than replacing it, because siete reads auth_profiles as a list of strings and folding fingerprints into it would break that parse."
+def build_auth_provenance(profile_names: list[str], profile_infos: list) -> list[dict]:
+    alive = {i.profile_name: i.alive for i in profile_infos}
+    out: list[dict] = []
+    for name in profile_names:
+        try:
+            fp = auth.session_fingerprint(load_profile(name))
+        except Exception as e:
+            fp = {"name": name, "kind": None, "fingerprint": None, "error": str(e)}
+        fp["fresh"] = bool(alive.get(name, False))
+        out.append(fp)
+    return out
 
 
 # @g.comment -- "Reports every captured identity whose kind does not match the selected substrate, as plain operator-readable messages. This closes the one mismatch NONE of the storage_state guards can catch: ElectronSubstrate never reads storage_state at all, so handing it web identities raises nothing — it launches N fresh, LOGGED-OUT app instances while the report names the identities the operator captured, and every probe then refutes real findings against an unauthenticated app while the run looks clean. The reverse direction (a desktop identity on the web substrate) IS caught by WebSubstrate.open, but only after AI template generation has already run, so it is reported here too."
@@ -675,6 +699,22 @@ async def run_pentest(args) -> int:
                       "coverage": cov})
         print()
 
+        # @g.comment -- "Provenance: a per-profile session fingerprint (content hash + derivable capture/expiry) plus whether pre-flight found it fresh. Computed here, once, off the same profile_infos the ranker uses, so the manifest — which siete already reads and pushes to the dashboard — shows WHICH session a CI run used and whether it was alive. Carried in a NEW field (auth_provenance), leaving auth_profiles as the list of NAMES every existing consumer (siete's RepoRef, the replay index) reads, so no downstream parse breaks."
+        auth_provenance = build_auth_provenance(args.auth, profile_infos)
+
+        # @g.comment -- "The load-bearing CI safety property: in --ci / CXG_CI mode a dead session is a HARD FAIL, not today's warn-and-continue. A pipeline must never silently probe UNAUTHENTICATED — that refutes real findings, the same failure the storage_state desktop guard exists to prevent one layer up. Placed after pre-flight (so alive/dead is known) and after --skip-health-check has had its say (which force-marks profiles alive, and is the documented escape hatch), but BEFORE template generation so a dead session costs no AI calls. Exit 5 is distinct from 2 (findings), 3 (truncated) and 4 (usage) so CI can tell 'the session expired' apart from every other outcome."
+        dead = ci_dead_sessions(profile_infos, auth.is_ci(getattr(args, "ci", False)))
+        if dead:
+            for name in dead:
+                print(f"✗ session for {name} expired — re-capture and re-import",
+                      file=sys.stderr)
+            print("   CI mode: refusing to probe unauthenticated. Re-capture the "
+                  "session locally and re-import it with `cxg pentest auth import`.",
+                  file=sys.stderr)
+            audit.footer({"status": "dead_session_ci_hardfail", "dead_profiles": dead})
+            audit.close()
+            return 5
+
         # 2. Generate (or reuse cached) JS templates
         if args.template_dir:
             tpl_dir = Path(args.template_dir)
@@ -703,7 +743,8 @@ async def run_pentest(args) -> int:
                 no_tpl_path = args.output or (session_root / "report.json")
                 Path(no_tpl_path).write_text(json.dumps(
                     build_no_templates_report(args, cb, session_root, tpl_dir, sarif,
-                                              hyps, config_hyps, review_only),
+                                              hyps, config_hyps, review_only,
+                                              auth_provenance=auth_provenance),
                     indent=2, default=str))
                 print(f"report → {no_tpl_path}")
             audit.footer({"status": "no_templates"})
@@ -856,6 +897,8 @@ async def run_pentest(args) -> int:
         report = {
             "target": args.target, "codebase": str(cb),
             "auth_profiles": args.auth, "goal": args.goal,
+            # @g.comment -- "Session provenance rides beside auth_profiles (the names), not inside it: each entry carries a content fingerprint + capture/expiry + whether the session was fresh this run, so the dashboard shows which session a CI run used. auth_profiles stays a list of strings so siete's existing parse is untouched."
+            "auth_provenance": auth_provenance,
             "template_dir": str(tpl_dir),
             "session_dir": str(session_root),
             "audit_log": str(session_root / "audit.jsonl"),
@@ -1175,10 +1218,12 @@ def build_parser():
                        help="Load auth profiles from this directory instead of "
                             "~/.cert-x-gen/auth. Use to point a run at a restored bundle "
                             "of profiles (paired with `cxg pentest auth import --auth-dir`).")
-    # @g.comment -- "Selects non-interactive CI behaviour. In B1 this refuses a world-accessible --auth-dir rather than trusting it (a saved session is a credential); B2 adds the dead-session hard-fail on top of the same flag. Also settable via CXG_CI=1 for pipelines that cannot add the flag."
+    # @g.comment -- "Selects non-interactive CI behaviour: a dead session becomes a HARD FAIL (exit 5) instead of today's warn-and-continue, so a pipeline never silently probes UNAUTHENTICATED and refutes real findings; and a world-accessible --auth-dir is refused rather than trusted. Without it the current warn behaviour is unchanged. Also settable via CXG_CI=1 for pipelines that cannot add the flag."
     p_run.add_argument("--ci", action="store_true",
-                       help="Non-interactive CI mode: a world-accessible --auth-dir is "
-                            "refused rather than trusted. Also enabled by CXG_CI=1.")
+                       help="Non-interactive CI mode: a dead/expired session is a hard "
+                            "failure (exit 5, 'session for <name> expired — re-capture and "
+                            "re-import') instead of a warning, and a world-accessible "
+                            "--auth-dir is refused. Also enabled by CXG_CI=1.")
     return ap
 
 

--- a/pentest/cxg_pentest.py
+++ b/pentest/cxg_pentest.py
@@ -22,6 +22,7 @@ from guardlink import load as load_guardlink
 from browser_engine import BrowserEngine, group_hypotheses
 from payloads import ALL_PROBES
 from ai_generator import generate_probe_source, make_probe_class, pick_provider
+import auth
 from auth import (capture_scripted, capture_interactive_multi, capture_desktop_multi,
                   load_profile)
 from js_generator import generate_all as generate_js_all
@@ -1169,6 +1170,15 @@ def build_parser():
     p_run.add_argument("--host-scan-path", default="",
                        help="Additionally scan this installation directory for data at "
                             "rest. By default only cxg-created user-data dirs are read.")
+    # @g.comment -- "Point the run at a restored bundle of profiles instead of ~/.cert-x-gen/auth. A pipeline caches/decrypts a directory of <name>.json + <name>.meta.json and passes it here; auth.set_auth_dir redirects load_profile, profile_inspect and the engine at it, all through the one module global they already read."
+    p_run.add_argument("--auth-dir", default=None,
+                       help="Load auth profiles from this directory instead of "
+                            "~/.cert-x-gen/auth. Use to point a run at a restored bundle "
+                            "of profiles (paired with `cxg pentest auth import --auth-dir`).")
+    # @g.comment -- "Selects non-interactive CI behaviour. In B1 this refuses a world-accessible --auth-dir rather than trusting it (a saved session is a credential); B2 adds the dead-session hard-fail on top of the same flag. Also settable via CXG_CI=1 for pipelines that cannot add the flag."
+    p_run.add_argument("--ci", action="store_true",
+                       help="Non-interactive CI mode: a world-accessible --auth-dir is "
+                            "refused rather than trusted. Also enabled by CXG_CI=1.")
     return ap
 
 
@@ -1188,6 +1198,17 @@ def main():
         return 1
 
     if args.cmd == "pentest":
+        # @g.comment -- "Redirect the profile store at --auth-dir before anything loads a profile, so a restored bundle is what pre-flight, the engine and check_profile_kinds all read. Every consumer reaches the store only through auth.load_profile, which reads AUTH_DIR at call time, so this one reassignment moves all of them."
+        if getattr(args, "auth_dir", None):
+            auth.set_auth_dir(args.auth_dir)
+        # @g.comment -- "In CI mode, refuse a world-accessible auth store before the run touches any credential in it. Exit 4 (usage), not 2 — 2 already means 'confirmed findings present' and CI keys on it, so a misconfiguration must never read as vulnerabilities found."
+        if auth.is_ci(getattr(args, "ci", False)):
+            try:
+                auth.assert_auth_dir_not_world_readable(auth.AUTH_DIR)
+            except PermissionError as e:
+                print(f"✗ {e}", file=sys.stderr)
+                return 4
+
         # @g.comment -- "Reject a desktop run with no way to launch the app before anything expensive happens. ElectronSubstrate's constructor raises the same error, but it is only reached after pre-flight inspection and AI template generation — minutes of work and, with --interactive-auth, an operator already prompted to log in. The Rust CLI enforces this too; this check covers direct invocation of the orchestrator and keeps the two from drifting silently."
         # @g.comment -- "Exit 4, not 2: 2 already means 'confirmed findings present' and is what CI keys on, so reusing it for a usage error would report vulnerabilities that were never looked for."
         if args.target_type == "electron" and not args.app_cmd and not args.app_binary:

--- a/pentest/tests/test_auth_import.py
+++ b/pentest/tests/test_auth_import.py
@@ -1,0 +1,186 @@
+"""Tests for STORY B1 — non-interactive session import / injection.
+
+A captured session is just a Playwright storage_state file; the blocker for CI is that
+the only capture that survives SSO/MFA needs a human at a browser. `auth import` writes a
+profile from a supplied storage_state with NO browser, reusing save_profile so the result
+is byte-for-byte what a capture produces — a run cannot tell an imported profile from a
+captured one. These tests pin: byte-faithful import from a file, from stdin and from the
+CXG_AUTH_STATE_<NAME> env convention; that a run loads an imported profile exactly like a
+captured one; that --auth-dir redirects the whole store; that no cookie VALUE ever appears
+in import output; and that the written files are 0600.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import stat
+
+import pytest
+
+import auth
+
+
+# A minimal but realistic storage_state: one auth cookie (a secret value we must never
+# echo) plus one origin with localStorage. This is the exact shape a capture produces.
+SECRET_COOKIE_VALUE = "sess_SUPERSECRET_do_not_log_me"
+SAMPLE_STATE = {
+    "cookies": [
+        {"name": "session", "value": SECRET_COOKIE_VALUE, "domain": "app.example.com",
+         "path": "/", "expires": 4102444800.0, "httpOnly": True, "secure": True,
+         "sameSite": "Lax"},
+    ],
+    "origins": [
+        {"origin": "https://app.example.com",
+         "localStorage": [{"name": "token", "value": "ANOTHER_SECRET"}]},
+    ],
+}
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+# @g.comment -- "Import from a file writes BOTH files, and the storage_state JSON round-trips byte-faithfully at the value level: json.loads of what was written equals the supplied dict. save_profile re-serialises with indent=2, so 'byte-faithful' is the content equality a run actually depends on, not literal input bytes."
+def test_import_from_file_writes_byte_faithful_profile(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps(SAMPLE_STATE))
+
+    state = auth.load_storage_state_from_source(str(state_file), "admin")
+    prof = auth.import_profile("admin", "https://app.example.com", state, label="admin")
+
+    assert prof.name == "admin"
+    written = json.loads((tmp_path / "admin.json").read_text())
+    assert written == SAMPLE_STATE  # byte-faithful content round-trip
+    meta = json.loads((tmp_path / "admin.meta.json").read_text())
+    assert meta["target"] == "https://app.example.com"
+    assert meta["label"] == "admin"
+    assert meta["kind"] == "storage_state"
+
+
+# @g.comment -- "'-' reads the state from stdin, so a CI secret pipes straight in and never touches disk in plaintext beyond the profile dir. Same byte-faithful round-trip as the file path."
+def test_import_from_stdin(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(SAMPLE_STATE)))
+
+    state = auth.load_storage_state_from_source("-", "bob")
+    auth.import_profile("bob", "https://app.example.com", state)
+
+    assert json.loads((tmp_path / "bob.json").read_text()) == SAMPLE_STATE
+
+
+# @g.comment -- "The single-profile env convention: with no --storage-state, import materialises CXG_AUTH_STATE_<NAME> (base64 storage_state). The name maps to a valid shell identifier ('pentest-alice' -> CXG_AUTH_STATE_PENTEST_ALICE)."
+def test_import_from_env_base64(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    b64 = base64.b64encode(json.dumps(SAMPLE_STATE).encode()).decode()
+    monkeypatch.setenv("CXG_AUTH_STATE_PENTEST_ALICE", b64)
+
+    assert auth.env_var_for("pentest-alice") == "CXG_AUTH_STATE_PENTEST_ALICE"
+    state = auth.load_storage_state_from_source(None, "pentest-alice")
+    auth.import_profile("pentest-alice", "https://app.example.com", state)
+
+    assert json.loads((tmp_path / "pentest-alice.json").read_text()) == SAMPLE_STATE
+
+
+# @g.comment -- "A run loads an imported profile INDISTINGUISHABLY from a captured one: load_profile returns the same AuthProfile shape and .storage_state yields the exact dict, which is all the engine/pre-flight ever read. This is the whole point of reusing save_profile."
+def test_run_loads_imported_profile_like_a_captured_one(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    auth.import_profile("admin", "https://app.example.com", SAMPLE_STATE,
+                        label="admin", tier=90, persona="ops", cohort="team-a")
+
+    loaded = auth.load_profile("admin")
+    assert loaded.kind == "storage_state"
+    assert loaded.target == "https://app.example.com"
+    assert loaded.tier == 90
+    assert loaded.persona == "ops"
+    assert loaded.cohort == "team-a"
+    assert loaded.storage_state == SAMPLE_STATE
+
+
+# @g.comment -- "--auth-dir redirects the WHOLE store: set_auth_dir reassigns the one module global every profile function reads at call time, so import writes there and load_profile reads back from there. This is the bundle-restore path a pipeline uses."
+def test_auth_dir_redirects_the_store(tmp_path, monkeypatch):
+    # Start from the real default, then redirect — proves the redirection, not a fixture.
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path / "default")
+    bundle = tmp_path / "bundle"
+    auth.set_auth_dir(bundle)
+    auth.import_profile("admin", "https://app.example.com", SAMPLE_STATE)
+
+    assert (bundle / "admin.json").exists()
+    assert not (tmp_path / "default" / "admin.json").exists()
+    assert auth.load_profile("admin").storage_state == SAMPLE_STATE
+
+
+# @g.comment -- "The secret is never echoed on the import path. Capture the redacted summary and assert neither the cookie value nor the localStorage value appears in it — only counts and domain COUNT do, exactly as extra_headers already does for WAF tokens."
+def test_import_never_echoes_a_cookie_value(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    auth.import_profile("admin", "https://app.example.com", SAMPLE_STATE,
+                        extra_headers={"x-waf-bypass": "WAF_TOKEN_SECRET"}, verbose=True)
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert SECRET_COOKIE_VALUE not in combined
+    assert "ANOTHER_SECRET" not in combined
+    assert "WAF_TOKEN_SECRET" not in combined
+    # ...but the header KEY is fine to surface.
+    assert "x-waf-bypass" in combined
+    assert "1 cookies" in combined
+
+
+# @g.comment -- "Both written files are 0600 — a saved session is a credential and must not be group/world-readable on a shared host."
+def test_imported_files_are_0600(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    auth.import_profile("admin", "https://app.example.com", SAMPLE_STATE)
+    assert _mode(tmp_path / "admin.json") == 0o600
+    assert _mode(tmp_path / "admin.meta.json") == 0o600
+
+
+# @g.comment -- "A stray JSON object that is not a storage_state is refused before it is persisted, so it cannot masquerade as a session that would then silently authenticate as nobody."
+def test_import_rejects_non_storage_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    with pytest.raises(ValueError, match="storage_state"):
+        auth.import_profile("x", "https://app.example.com", {"unrelated": "json"})
+    assert not (tmp_path / "x.json").exists()
+
+
+# @g.comment -- "A missing env var yields a redacted, actionable error naming the exact variable — never a dump of whatever was there."
+def test_missing_env_source_is_a_clear_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    monkeypatch.delenv("CXG_AUTH_STATE_GHOST", raising=False)
+    with pytest.raises(ValueError, match="CXG_AUTH_STATE_GHOST"):
+        auth.load_storage_state_from_source(None, "ghost")
+
+
+# @g.comment -- "The CI world-readable guard refuses an auth dir other users can reach, and leaves a private one alone. This is the redaction/permission half of B1."
+def test_world_readable_auth_dir_refused_in_ci(tmp_path):
+    os.chmod(tmp_path, 0o755)  # world-readable
+    with pytest.raises(PermissionError, match="world-accessible"):
+        auth.assert_auth_dir_not_world_readable(tmp_path)
+    os.chmod(tmp_path, 0o700)  # private
+    auth.assert_auth_dir_not_world_readable(tmp_path)  # no raise
+
+
+# @g.comment -- "--ci is one selector; CXG_CI=1 is the other, for pipelines that cannot add the flag. The generic CI env var is deliberately NOT honoured, so a developer whose shell inherited CI=true is not silently flipped into hard-fail mode."
+def test_is_ci_flag_and_env(monkeypatch):
+    monkeypatch.delenv("CXG_CI", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    assert auth.is_ci(True) is True
+    assert auth.is_ci(False) is False
+    monkeypatch.setenv("CXG_CI", "1")
+    assert auth.is_ci(False) is True
+    monkeypatch.setenv("CXG_CI", "0")
+    assert auth.is_ci(False) is False
+    monkeypatch.setenv("CI", "true")  # generic CI must NOT flip it
+    assert auth.is_ci(False) is False
+
+
+# @g.comment -- "End-to-end through auth.main (the argv surface the Rust CLI forwards): `auth import --profile ... --storage-state <file>` writes a 0600 byte-faithful profile and exits 0."
+def test_auth_main_import_end_to_end(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    state_file = tmp_path / "s.json"
+    state_file.write_text(json.dumps(SAMPLE_STATE))
+    rc = auth.main(["import", "--profile", "admin", "--target",
+                    "https://app.example.com", "--storage-state", str(state_file)])
+    assert rc == 0
+    assert json.loads((tmp_path / "admin.json").read_text()) == SAMPLE_STATE
+    assert _mode(tmp_path / "admin.json") == 0o600

--- a/pentest/tests/test_auth_provenance.py
+++ b/pentest/tests/test_auth_provenance.py
@@ -1,0 +1,119 @@
+"""Tests for STORY B2 — CI hard-fail gate + session provenance in the manifest.
+
+Two properties: (1) in CI mode a dead session is a HARD FAIL, so a pipeline never silently
+probes UNAUTHENTICATED and refutes real findings; (2) the run manifest records a per-profile
+session fingerprint (content hash + derivable capture/expiry + freshness) so the dashboard
+shows WHICH session a CI run used and whether it was fresh — without ever carrying a cookie
+value into the artifact.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import auth
+import cxg_pentest
+
+
+@dataclass
+class _Info:
+    profile_name: str
+    alive: bool
+
+
+# @g.comment -- "In CI mode, every dead profile is returned so the run can hard-fail on it; a live one is not. This is the load-bearing 'never probe unauthenticated in CI' decision, pinned directly."
+def test_ci_dead_sessions_reports_dead_in_ci_mode():
+    infos = [_Info("alice", True), _Info("bob", False)]
+    assert cxg_pentest.ci_dead_sessions(infos, ci_mode=True) == ["bob"]
+
+
+# @g.comment -- "OUT of CI mode the list is always empty, so warn-and-continue behaviour is byte-identical to before — a dead session does not hard-fail a non-CI run."
+def test_ci_dead_sessions_empty_outside_ci_mode():
+    infos = [_Info("alice", True), _Info("bob", False)]
+    assert cxg_pentest.ci_dead_sessions(infos, ci_mode=False) == []
+
+
+# @g.comment -- "The fingerprint is a one-way sha256 over the canonical state — stable across a re-serialising import round-trip, and never carrying a cookie value. Derivable timing (captured_at from mtime, expires_at from the earliest future cookie expiry) rides alongside."
+def test_session_fingerprint_shape_and_no_secret(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    state = {
+        "cookies": [{"name": "session", "value": "SECRET_VALUE",
+                     "domain": "app.example.com", "expires": 4102444800.0}],
+        "origins": [],
+    }
+    auth.import_profile("admin", "https://app.example.com", state)
+    fp = auth.session_fingerprint(auth.load_profile("admin"))
+
+    assert fp["name"] == "admin"
+    assert fp["kind"] == "storage_state"
+    assert fp["fingerprint"].startswith("sha256:")
+    assert fp["cookies"] == 1
+    assert fp["captured_at"] is not None
+    assert fp["expires_at"].startswith("2100")  # 4102444800 == 2100-01-01
+    assert "SECRET_VALUE" not in json.dumps(fp)
+
+
+# @g.comment -- "The fingerprint is content-addressed: the same session imported twice (even re-serialised) hashes identically, and a different session hashes differently. That is what makes it a reproducible 'this run used session X' identifier on the dashboard."
+def test_fingerprint_is_content_stable(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    state_a = {"cookies": [{"name": "s", "value": "A", "domain": "x"}], "origins": []}
+    state_b = {"cookies": [{"name": "s", "value": "B", "domain": "x"}], "origins": []}
+    auth.import_profile("a1", "https://x", state_a)
+    auth.import_profile("a2", "https://x", state_a)  # same content, second import
+    auth.import_profile("b1", "https://x", state_b)
+    fa1 = auth.session_fingerprint(auth.load_profile("a1"))["fingerprint"]
+    fa2 = auth.session_fingerprint(auth.load_profile("a2"))["fingerprint"]
+    fb1 = auth.session_fingerprint(auth.load_profile("b1"))["fingerprint"]
+    assert fa1 == fa2
+    assert fa1 != fb1
+
+
+# @g.comment -- "A session with only session-cookies (expires == -1) has no derivable expiry — the record says None rather than inventing one."
+def test_expiry_none_when_only_session_cookies(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    state = {"cookies": [{"name": "s", "value": "x", "domain": "x", "expires": -1}],
+             "origins": []}
+    auth.import_profile("s1", "https://x", state)
+    fp = auth.session_fingerprint(auth.load_profile("s1"))
+    assert fp["expires_at"] is None
+
+
+# @g.comment -- "build_auth_provenance pairs each profile's fingerprint with whether pre-flight found it fresh, keyed by name — this is exactly what lands in the manifest beside auth_profiles."
+def test_build_auth_provenance_marks_freshness(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    state = {"cookies": [{"name": "s", "value": "x", "domain": "x"}], "origins": []}
+    auth.import_profile("alice", "https://x", state)
+    auth.import_profile("bob", "https://x", state)
+    infos = [_Info("alice", True), _Info("bob", False)]
+
+    prov = cxg_pentest.build_auth_provenance(["alice", "bob"], infos)
+    by_name = {p["name"]: p for p in prov}
+    assert by_name["alice"]["fresh"] is True
+    assert by_name["bob"]["fresh"] is False
+    assert all(p["fingerprint"].startswith("sha256:") for p in prov)
+
+
+# @g.comment -- "A profile that cannot be loaded degrades to a null-fingerprint record with the error rather than aborting the whole report — provenance is an audit aid, not a gate."
+def test_build_auth_provenance_tolerates_missing_profile(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    prov = cxg_pentest.build_auth_provenance(["ghost"], [])
+    assert prov[0]["name"] == "ghost"
+    assert prov[0]["fingerprint"] is None
+    assert "error" in prov[0]
+
+
+# @g.comment -- "auth_profiles stays a list of NAMES (siete reads it as strings); provenance rides in the separate auth_provenance field. Pins that the no-templates report carries auth_provenance so both report shapes share the key set."
+def test_no_templates_report_carries_auth_provenance(tmp_path):
+    class _Args:
+        target = "https://x"
+        auth = ["alice"]
+        goal = None
+        target_type = "web"
+        output = ""
+
+    prov = [{"name": "alice", "fingerprint": "sha256:abc", "fresh": True}]
+    report = cxg_pentest.build_no_templates_report(
+        _Args(), tmp_path, tmp_path, tmp_path / "tpl", sarif=[], hyps=[], config_hyps=[],
+        review_only=[], auth_provenance=prov)
+    assert report["auth_profiles"] == ["alice"]  # still names, unchanged for siete
+    assert report["auth_provenance"] == prov

--- a/pentest/tests/test_auth_verify.py
+++ b/pentest/tests/test_auth_verify.py
@@ -1,0 +1,107 @@
+"""Tests for STORY B2 — `auth verify` liveness gate (the landing-page half).
+
+verify reuses the SAME landing test scan-time pre-flight uses: navigate to the target
+with the saved cookies and see whether we get bounced to a login page. Exit 0 alive /
+non-zero dead, so a pipeline can gate on it before spending a whole run. These tests drive
+a real headless Chromium against a tiny local server: one profile whose target serves a
+dashboard (alive → 0) and one whose target bounces to /login (dead → non-zero).
+"""
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+import auth
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # silence
+        pass
+
+    def do_GET(self):
+        if self.path.startswith("/app"):
+            body = b"<html><body><h1>Dashboard</h1><p>welcome</p></body></html>"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path.startswith("/secure"):
+            # A dead session: the app bounces us to the login page.
+            self.send_response(302)
+            self.send_header("Location", "/login")
+            self.end_headers()
+        elif self.path.startswith("/login"):
+            body = (b"<html><body><form>Please sign in to continue"
+                    b"<input type=\"password\" name=\"password\"></form></body></html>")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+@pytest.fixture
+def server():
+    httpd = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+
+
+def _write_profile(tmp_path, name, target):
+    (tmp_path / f"{name}.json").write_text(json.dumps({"cookies": [], "origins": []}))
+    (tmp_path / f"{name}.meta.json").write_text(json.dumps(
+        {"name": name, "target": target, "label": None, "extra_headers": {},
+         "kind": "storage_state"}))
+
+
+# @g.comment -- "A session that lands on a dashboard is ALIVE → exit 0, so a pipeline gate passes and spends the run."
+def test_verify_live_session_exits_zero(tmp_path, monkeypatch, server):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    _write_profile(tmp_path, "live", server + "/app")
+    assert auth.verify_profile("live") == 0
+
+
+# @g.comment -- "A session that bounces to /login is DEAD → non-zero, using the exact 'expired — re-capture and re-import' message. This is the login-bouncing fixture the DoD names, and the exit code is what a pipeline gates on."
+def test_verify_login_bouncing_session_exits_nonzero(tmp_path, monkeypatch, server, capsys):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    _write_profile(tmp_path, "dead", server + "/secure")
+    rc = auth.verify_profile("dead")
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "session for dead expired — re-capture and re-import" in err
+
+
+# @g.comment -- "A profile that does not exist is a distinct non-zero (2), not a crash — a gate must get a clean signal, not a traceback."
+def test_verify_missing_profile_exits_nonzero(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    assert auth.verify_profile("nope") == 2
+
+
+# @g.comment -- "A desktop identity has no browser landing test; verify says so and returns 0 (matching profile_inspect's 'no verdict from pre-flight' placeholder) rather than fabricating a death."
+def test_verify_desktop_identity_reports_not_applicable(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    (tmp_path / "desk.meta.json").write_text(json.dumps(
+        {"name": "desk", "target": "", "kind": "user_data_dir",
+         "user_data_dir": str(tmp_path / "ud")}))
+    rc = auth.verify_profile("desk")
+    assert rc == 0
+    assert "desktop identity" in capsys.readouterr().err
+
+
+# @g.comment -- "End-to-end through auth.main: `auth verify --profile live` returns 0 against a live target."
+def test_auth_main_verify_end_to_end(tmp_path, monkeypatch, server):
+    monkeypatch.setattr(auth, "AUTH_DIR", tmp_path)
+    _write_profile(tmp_path, "live", server + "/app")
+    assert auth.main(["verify", "--profile", "live"]) == 0


### PR DESCRIPTION
Merge the cert-x-gen staging line into main so a RELEASED cxg carries the CI auth surface the bugb-ci runner image needs.

Contents: non-interactive cxg pentest auth import (--storage-state <path|->, CXG_AUTH_STATE_*); session-health gate + provenance in CI mode (--ci / CXG_CI hard-fail on dead session); --auth-dir on the pentest run (redirects the profile store).

This is the release blocker for cxg-in-CI.