### PR TITLE
docs: align README and --help with shipped v1.2.0 behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 <h4 align="center">A Polyglot Execution Engine for Vulnerability Detection</h4>
 
 <p align="center">
-Write security checks as real code — Python, Rust, Go, C, Shell, or YAML — and run them safely, reproducibly, and at scale.
+Write security checks as real code — Python, Rust, Go, C, Shell, or YAML — and run them reproducibly, at scale.
 </p>
 
 <p align="center">
 <a href="https://github.com/Bugb-Technologies/cert-x-gen/releases"><img src="https://img.shields.io/github/v/release/Bugb-Technologies/cert-x-gen?style=flat-square"></a>
 <a href="https://github.com/Bugb-Technologies/cert-x-gen/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square"></a>
 <a href="https://github.com/Bugb-Technologies/cert-x-gen/actions"><img src="https://img.shields.io/github/actions/workflow/status/Bugb-Technologies/cert-x-gen/ci.yml?style=flat-square"></a>
-<a href="https://github.com/Bugb-Technologies/cert-x-gen-templates"><img src="https://img.shields.io/badge/templates-147-orange?style=flat-square"></a>
 </p>
 
 <p align="center">
 <a href="#what-is-cert-x-gen">What is it</a> •
+<a href="#two-surfaces">Surfaces</a> •
 <a href="#installation">Install</a> •
 <a href="#quick-start">Quick Start</a> •
 <a href="#templates">Templates</a> •
@@ -28,7 +28,7 @@ Write security checks as real code — Python, Rust, Go, C, Shell, or YAML — a
 
 Modern security scanning has outgrown static templates. Today's vulnerability detection often requires real programming logic, protocol-level control, data processing, and reuse of existing scripts — yet most scanners force everything into YAML-only abstractions.
 
-CERT-X-GEN is a different kind of scanner. It is a **polyglot security execution engine** that treats vulnerability detection as code, not configuration. You write detection logic in the language that fits the problem — CERT-X-GEN handles orchestration, sandboxing, and output.
+CERT-X-GEN is a different kind of scanner. It is a **polyglot security execution engine** that treats vulnerability detection as code, not configuration. You write detection logic in the language that fits the problem — CERT-X-GEN handles orchestration, execution, and output.
 
 **What this means in practice:**
 
@@ -50,6 +50,42 @@ cxg scan --scope targets.txt --templates redis*.py,docker*.go,system*.sh
 - A **bridge** between research scripts and production scanners
 - A scanner **designed for CI, automation, and agentic systems**
 
+> **A note on execution privileges.** Templates run as ordinary child processes with the
+> privileges of the user invoking cxg, with full network and filesystem access. There is no
+> execution sandbox or resource limiting — run cxg inside a container or VM, and as a
+> non-privileged user, if you need isolation. See the [Sandbox Guide](docs/SANDBOX_GUIDE.md),
+> whose `cxg sandbox` command manages per-language *dependency* environments (not isolation).
+
+
+---
+
+
+## Two Surfaces
+
+CERT-X-GEN ships two distinct workflows:
+
+| Surface | Command | What it does |
+|---------|---------|--------------|
+| **Template scanning** | `cxg scan` | Runs polyglot detection templates against network/host targets (single host, file, CIDR, URL). This is the classic scanner. |
+| **AI-driven whitebox pentest** | `cxg pentest` | Ranks guardlink source-code hypotheses against an operator goal, has a local AI CLI write JavaScript probe templates that read the target's source, and executes them in parallel **authenticated** Chromium contexts against a running web app or Electron desktop app. |
+
+The full command set:
+
+| Command | Purpose |
+|---------|---------|
+| `cxg scan` | Run a polyglot template security scan |
+| `cxg pentest` | AI-driven whitebox pentest pipeline (web or Electron) |
+| `cxg template` | Manage templates (list, search, info, validate, update) |
+| `cxg search` | Search templates (full-text, regex, filters) |
+| `cxg ai` | AI-powered template generation |
+| `cxg mcp` | Run as an MCP (Model Context Protocol) server for AI agents |
+| `cxg sandbox` | Manage per-language dependency environments |
+| `cxg config` | Generate / validate / show configuration |
+| `cxg update` | Update cxg to the latest released build |
+| `cxg server` | REST API server — **not implemented** (returns an error) |
+| `cxg version` | Display version information |
+
+Run `cxg <command> --help` for the full reference on any of them.
 
 ---
 
@@ -162,14 +198,14 @@ Download pre-built binaries from [GitHub Releases](https://github.com/Bugb-Techn
 
 ```bash
 cxg --version
-cxg template update  # Downloads official templates
+cxg template update  # Clones the official template library into ~/.cert-x-gen/templates/
 ```
 
 ---
 
 ## Quick Start
 
-### Basic Scanning
+### Scanning (`cxg scan`)
 
 ```bash
 # Scan a single target
@@ -185,6 +221,37 @@ cxg scan --scope 192.168.1.0/24 --top-ports 100
 cxg scan --scope targets.txt --templates redis*.py
 ```
 
+### Whitebox Pentest (`cxg pentest`)
+
+The pentest pipeline drives an authenticated browser (or Electron app), so it needs a captured
+session and a guardlink source-code analysis (`whitebox/findings.sarif`) in the codebase.
+
+```bash
+# 1. Capture an authenticated session interactively (opens a real browser to log in)
+cxg pentest auth --target https://app.example.com --profile admin
+
+# 2. Run the pipeline: rank hypotheses, generate probes with your local AI CLI, execute them
+cxg pentest run --codebase ./repo --target https://app.example.com \
+  --auth admin --ai --ai-provider claude \
+  --goal "test for IDOR in the records and transactions APIs"
+```
+
+For CI, capture the session once, export it as a Playwright `storage_state`, then replay it
+without a browser:
+
+```bash
+cxg pentest auth import --profile pentest --target https://staging.app \
+  --storage-state ./pentest.storage.json
+cxg pentest auth verify --profile pentest           # exit 0 = alive, non-zero = expired
+cxg pentest run --codebase ./repo --target https://staging.app --auth pentest --ci
+```
+
+`--ci` (or `CXG_CI=1`) makes a dead/expired session a hard failure (**exit code 5**) at
+pre-flight, so a pipeline never silently probes unauthenticated. A profile bundle can also be
+materialised from the base64 env var `CXG_AUTH_STATE_<NAME>` and pointed at with `--auth-dir`.
+See the [pentest docs](#documentation) for the full pipeline, Electron target support, OAST
+modes, and the `report.json` schema.
+
 ### Template Operations
 
 ```bash
@@ -194,45 +261,49 @@ cxg template list
 # Search templates
 cxg template search redis
 
-# Validate a template
-cxg template validate my-template.py
-
-# Get template info
-cxg template info smtp-open-relay.py
+# Get template info (by template ID)
+cxg template info redis-unauthenticated
 ```
 
 ### Output Formats
 
+`cxg scan` writes reports with `--output-format` (comma-separated for several at once) and
+`-o`/`--output` for the destination basename. The output extension is derived from the format —
+**any extension you put on `--output` is replaced**, so `--output report.txt --output-format json`
+writes `report.json`.
+
 ```bash
 # JSON output
-cxg scan --scope target.com --format json -o results.json
+cxg scan --scope target.com --output-format json -o results
 
 # HTML report
-cxg scan --scope target.com --format html -o report.html
+cxg scan --scope target.com --output-format html -o report
 
 # SARIF for CI/CD
-cxg scan --scope target.com --format sarif -o results.sarif
+cxg scan --scope target.com --output-format sarif -o results
+
+# Several formats at once
+cxg scan --scope target.com --output-format json,html,sarif -o report
 ```
+
+Supported formats: **json, csv, sarif, html, markdown**.
 
 ---
 
 
 ## Templates
 
-Templates are maintained in a separate repository for community contributions:
+Runtime templates are **not shipped in this repository**. They are distributed separately in the
+template library repo:
 
 **[github.com/Bugb-Technologies/cert-x-gen-templates](https://github.com/Bugb-Technologies/cert-x-gen-templates)**
 
-| Language | Count | Best For |
-|----------|-------|----------|
-| Python | 15 | Stateful protocols, HTTP APIs, data processing |
-| Go | 5 | Binary protocols, high concurrency |
-| C | 5 | Low-level protocols, maximum performance |
-| Rust | 4 | Memory-safe performance, async I/O |
-| Shell | 5 | Native tool integration, system checks |
-| YAML | 24 | Simple HTTP checks, Nuclei compatibility |
+Fetch them with `cxg template update`, which clones the library into `~/.cert-x-gen/templates/`.
+From there the scanner discovers them automatically. (Templates are not auto-downloaded by a bare
+`cxg scan` — run `cxg template update`, or pass `--ut` / `--auto-update-templates` on a scan.)
 
-Templates auto-download on first scan. Update with `cxg template update`.
+Templates cover multiple languages — Python, Go, C, Rust, Shell, YAML and more — with the exact
+inventory maintained in the template repository.
 
 ### Writing Templates
 
@@ -276,7 +347,6 @@ if 'redis_version' in response:
 
 - **Code over configuration** — use real languages for real logic
 - **Deterministic execution** — same input, same output
-- **Sandboxed by default** — templates run with strict resource limits
 - **Composable scans** — mix languages, reuse logic across templates
 - **Automation-first** — built for CI, pipelines, and agentic systems
 
@@ -286,20 +356,31 @@ if 'redis_version' in response:
 
 **Execution Engine**
 - 12 supported languages (Python, Go, Rust, C, C++, Java, JavaScript, Ruby, Perl, PHP, Shell, YAML)
-- Sandboxed execution with configurable resource limits
 - Compilation caching for compiled languages
 - Parallel template execution with rate limiting
 
 **CLI**
 - Unified `--scope` for targets (single, file, CIDR, URL)
 - Smart `--templates` selection (glob patterns, tags, severity)
-- Multiple output formats (JSON, HTML, CSV, Markdown, SARIF)
-- Built-in template management and validation
+- Multiple output formats (JSON, CSV, SARIF, HTML, Markdown)
+- Built-in template management
 
 **Integration**
-- Git-based template repositories with auto-update
+- Git-based template repositories, updatable with `cxg template update`
 - CI/CD friendly (exit codes, SARIF output)
-- Configurable via CLI, config file, or environment variables
+- Configurable via CLI flags and a config file (`--config`)
+- MCP server (`cxg mcp`) for AI-agent integration
+
+### AI providers (pentest)
+
+`cxg pentest` generates probes with a local AI CLI or an HTTP API. `--ai-provider` accepts:
+`auto | bridge | claude | codex | gemini | anthropic | openai`. The **`bridge`** provider posts
+each prompt to `$BUGB_BRIDGE_URL` (with `Authorization: Bearer $BUGB_BRIDGE_TOKEN` when set) and
+reads the completion back — an editor/CI integration point rather than a local CLI. When
+`--ai-provider auto` is used, the bridge is preferred whenever `$BUGB_BRIDGE_URL` is set.
+
+Findings in `report.json` carry a `threat_id` linking each finding back to the originating
+guardlink hypothesis (`null` for AI/mutation-synthesised probes).
 
 ---
 
@@ -311,8 +392,18 @@ if 'redis_version' in response:
 | [Usage Guide](docs/USAGE_GUIDE.md) | Comprehensive CLI usage and examples |
 | [Architecture](docs/ARCHITECTURE.md) | System design and internals |
 | [Engine Guide](docs/ENGINES.md) | Language-specific execution details |
-| [Sandbox Guide](docs/SANDBOX_GUIDE.md) | Security model and resource limits |
+| [Sandbox Guide](docs/SANDBOX_GUIDE.md) | `cxg sandbox` dependency-environment management |
 | [Contributing](CONTRIBUTING.md) | How to contribute code and templates |
+
+**Whitebox pentest (`cxg pentest`):**
+
+| Document | Description |
+|----------|-------------|
+| [Pentest Overview](pentest/README.md) | The pentest pipeline at a glance |
+| [Pentest Architecture](pentest/docs/ARCHITECTURE.md) | Pipeline, substrate, and runtime intelligence layer |
+| [Operator Guide](pentest/docs/OPERATOR_GUIDE.md) | Running scans: auth, targets, OAST, Electron |
+| [Probe Templates](pentest/docs/TEMPLATES.md) | The JavaScript probe format and available primitives |
+| [Troubleshooting](pentest/docs/TROUBLESHOOTING.md) | Diagnosing pentest runs |
 
 ---
 

--- a/cert-x-gen.example.yaml
+++ b/cert-x-gen.example.yaml
@@ -1,4 +1,8 @@
 # CERT-X-GEN Example Configuration
+#
+# NOTE: This file does NOT currently load — the config parser rejects it, and many of the
+# keys below are parsed but have no effect. It is being revised. Do not rely on it yet.
+#
 # Copy this file to cert-x-gen.yaml and customize for your environment
 
 global:

--- a/docs/SANDBOX_GUIDE.md
+++ b/docs/SANDBOX_GUIDE.md
@@ -2,10 +2,17 @@
 
 ## Overview
 
-CERT-X-GEN features a **unified sandboxed environment** that isolates all language runtimes and their dependencies from the host system. This provides:
+> **What this is — and is not.** `cxg sandbox` is a **dependency environment manager**, not
+> a security sandbox. It gives each language runtime its own package directory (a venv, an
+> `npm` prefix, a `GEM_HOME`, or a Docker dev container you `enter`) so template dependencies
+> stay off the system package managers. It does **not** confine, isolate, or resource-limit
+> template execution. Templates run as ordinary child processes with the invoking user's full
+> privileges and unrestricted network and filesystem access. If you need real isolation, run
+> cxg itself inside a container or VM (see [Security Considerations](#security-considerations)).
+
+`cxg sandbox` manages per-language **dependency environments** for the templates you run. This provides:
 
 - **Dependency Isolation**: Each language runtime has its own package directory
-- **Security**: Templates execute in a controlled environment
 - **Reproducibility**: Consistent package versions across installations
 - **Cleanliness**: No pollution of system-wide package managers
 - **Flexibility**: Easy to add, remove, or update packages
@@ -580,18 +587,21 @@ cxg sandbox init --languages python,javascript
 
 ## Security Considerations
 
-### Isolation
+### No execution isolation
 
-The sandbox provides **process-level isolation** but not complete system-level isolation. For maximum security:
+`cxg sandbox` does **not** isolate or resource-limit template execution. Templates run as
+ordinary child processes with the invoking user's privileges and full network and filesystem
+access — the "sandbox" only decides which per-language dependency directory is on the path.
+All isolation must therefore come from outside cxg:
 
-1. **Run in containers**: Use Docker/Podman for additional isolation
+1. **Run cxg in containers**: Use Docker/Podman to isolate the whole tool
 2. **Limit permissions**: Run cxg as a non-privileged user
 3. **Network isolation**: Use firewall rules or network namespaces
 4. **Resource limits**: Use cgroups to limit CPU/memory usage
 
 ### Template Security
 
-Templates execute with full sandbox access. Only use trusted templates:
+Templates execute with the full privileges of the user running cxg. Only use trusted templates:
 
 1. **Review templates**: Check template code before execution
 2. **Use official templates**: Prefer templates from trusted sources

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
   🔍 Powerful Template Search: Full-text search, regex, content search, multiple filters
   ⚡ High Performance: Parallel execution, compilation caching for compiled languages
   📊 Multiple Output Formats: JSON, CSV, SARIF, HTML, Markdown
-  🔌 Extensible: Plugin system, custom templates in any supported language
+  🔌 Extensible: Custom templates in any supported language
 
 EXAMPLES:
   # Basic scanning
@@ -60,7 +60,7 @@ EXAMPLES:
   cxg scan --scope example.com --output results --output-format json
 
   # Performance tuning
-  cxg scan --scope example.com --threads 20 --parallel-targets 100
+  cxg scan --scope example.com --parallel-targets 100 --parallel-templates 20
   cxg scan --scope example.com --timeout 60s --retry 5
 
   # Stealth and safety
@@ -134,7 +134,7 @@ pub enum Commands {
     /// Search templates
     Search(SearchArgs),
 
-    /// Run as API server
+    /// Run as API server [NOT IMPLEMENTED — returns an error]
     Server(ServerArgs),
 
     /// Generate configuration file
@@ -469,7 +469,8 @@ pub enum PentestAction {
     ///   0 → no confirmed findings (clean scan)
     ///   1 → no templates available (guardlink output missing or empty)
     ///   2 → confirmed findings present
-    ///   3 → scan was hard-killed (5xx streak, scope violation, etc.)
+    ///   3 → scan was hard-killed (5xx streak, scope violation) OR, under
+    ///       `--no-restart`, a desktop target died mid-scan and was not relaunched
     ///   5 → CI mode (`--ci` / CXG_CI=1): an auth session was dead/expired at
     ///       pre-flight, so the run stopped before spending any AI calls rather
     ///       than silently probing UNAUTHENTICATED
@@ -566,11 +567,16 @@ pub enum PentestAction {
         #[arg(long, default_value = "2")]
         mutation_retries: usize,
 
-        /// AI provider. `auto` picks the first available CLI tool (claude > codex > gemini),
-        /// falling back to ANTHROPIC_API_KEY / OPENAI_API_KEY HTTP APIs. Otherwise specify
-        /// explicitly. CLI providers don't need API keys — they use your existing CLI auth.
+        /// AI provider. `auto` prefers the editor bridge when $BUGB_BRIDGE_URL is set,
+        /// then the first available CLI tool (claude > codex > gemini), falling back to
+        /// ANTHROPIC_API_KEY / OPENAI_API_KEY HTTP APIs. Otherwise specify explicitly.
+        /// CLI providers don't need API keys — they use your existing CLI auth.
         ///
-        /// Options: auto | claude | codex | gemini | anthropic | openai
+        /// Options: auto | bridge | claude | codex | gemini | anthropic | openai
+        ///
+        /// `bridge` posts each prompt to $BUGB_BRIDGE_URL (with Authorization: Bearer
+        /// $BUGB_BRIDGE_TOKEN when set) and reads the completion back — an editor/CI
+        /// integration point rather than a local CLI.
         #[arg(long, default_value = "claude")]
         ai_provider: String,
 
@@ -977,19 +983,6 @@ PORT SELECTION:
     Example:
       cxg scan --scope example.com --override-ports 80,443
 
-PROTOCOL SPECIFICATION:
-  Define which protocols to use for scanning (http, https, tcp, udp, etc.).
-  
-  --protocol <PROTOCOL>
-    Use a single protocol for all scans.
-    Example:
-      cxg scan --scope example.com --protocol https
-  
-  --protocols <PROTOCOLS>
-    Test multiple protocols (comma-separated). Engine tries each protocol.
-    Example:
-      cxg scan --scope example.com --protocols http,https
-
 TEMPLATE FILTERING:
   Control which vulnerability templates are executed. Filter by ID, language, severity, or tags.
   
@@ -1037,45 +1030,32 @@ OUTPUT AND REPORTING:
   Customize how scan results are saved and displayed.
   
   --output <BASENAME>
-    Set the output file basename. Extensions are added based on format.
+    Set the output file basename. Any trailing extension is REPLACED by the chosen
+    format's extension — e.g. `--output report.txt --output-format json` writes report.json.
     Default: scan-results
     Example:
-      cxg scan --scope example.com --output my-scan
-      # Creates: my-scan.json, my-scan.csv, etc.
-  
+      cxg scan --scope example.com --output my-scan --output-format json
+      # Writes: my-scan.json
+
   --output-format <FORMATS>
     Specify output formats (comma-separated). Multiple formats can be generated simultaneously.
-    Available: json, csv, sarif, html, xml
+    Available: json, csv, sarif, html, markdown
     - json: Machine-readable, ideal for automation and APIs
     - csv: Spreadsheet-friendly, good for reporting and analysis
     - sarif: Static Analysis Results Interchange Format (for CI/CD integration)
     - html: Human-readable report with visualizations
-    - xml: Structured format for enterprise tools
+    - markdown: Human-readable Markdown report
     Example:
       cxg scan --scope example.com --output-format json,html,sarif
-  
-  --stream
-    Enable real-time streaming output. Results are displayed as they're found.
-    Useful for long-running scans where you want immediate feedback.
-    Example:
-      cxg scan --scope example.com --stream
-  
+
   --quiet
-    Suppress non-essential output. Only show critical information and errors.
-    Ideal for scripting and automation where you want minimal noise.
+    Suppress the ASCII startup banner. Scan output itself is unchanged.
     Example:
-      cxg scan --scope example.com --quiet --output-format json
+      cxg scan --scope example.com --quiet
 
 PERFORMANCE AND CONCURRENCY:
   Tune scan performance based on your resources and target infrastructure.
-  
-  --threads <N>
-    Number of worker threads for parallel execution. Higher = faster but more resource-intensive.
-    Default: Number of CPU cores
-    Recommendation: Start with default, increase if targets can handle load
-    Example:
-      cxg scan --scope example.com --threads 20
-  
+
   --parallel-targets <N>
     How many targets to scan simultaneously. Higher = faster but may trigger rate limits.
     Default: 50
@@ -1174,7 +1154,7 @@ NETWORK CONFIGURATION:
   
   --follow-redirects
     Follow HTTP redirects automatically. Useful for discovering redirect chains.
-    Default: Enabled
+    Default: Disabled (redirects are not followed unless this flag is passed)
     Example:
       cxg scan --scope example.com --follow-redirects --max-redirects 10
   
@@ -1184,51 +1164,19 @@ NETWORK CONFIGURATION:
     Example:
       cxg scan --scope example.com --max-redirects 3
 
-ADVANCED FEATURES:
-  Advanced capabilities for complex scanning scenarios.
-  
-  --resume <SCAN-ID>
-    Resume a previously interrupted scan from where it left off.
-    Scan state is automatically saved, allowing recovery from crashes or interruptions.
-    Example:
-      cxg scan --scope example.com --resume a1b2c3d4-e5f6-7890-abcd-ef1234567890
-  
-  --distributed
-    Enable distributed scanning mode. Coordinates with other scanner instances.
-    Allows horizontal scaling across multiple machines for massive scans.
-    Example:
-      cxg scan --scope @10000-targets.txt --distributed --coordinator http://coordinator:8080
-  
-  --coordinator <URL>
-    URL of the distributed scan coordinator. Required when using --distributed.
-    The coordinator manages work distribution and result aggregation.
-    Example:
-      cxg scan --scope example.com --distributed --coordinator http://192.168.1.100:8080
-  
-  --worker-id <ID>
-    Unique identifier for this worker in distributed mode. Auto-generated if not specified.
-    Example:
-      cxg scan --scope @targets.txt --distributed --coordinator http://coordinator:8080 --worker-id scanner-01
-
 CONFIGURATION FILES:
-  Use configuration files for complex setups and reusable scan profiles.
-  
+  Use configuration files for complex setups.
+
   --config <FILE>
     Load settings from a configuration file (YAML, TOML, or JSON).
     CLI arguments override config file settings.
     Example:
       cxg scan --config production-scan.yaml --scope example.com
-  
-  --profile <NAME>
-    Use a named configuration profile from your config file.
-    Profiles allow quick switching between different scanning scenarios.
-    Example:
-      cxg scan --profile production --scope example.com
 
 COMMON SCANNING SCENARIOS:
 
 1. Quick Vulnerability Assessment (Fast, High-Severity Only):
-   cxg scan --scope example.com --severity critical,high --threads 20
+   cxg scan --scope example.com --severity critical,high
 
 2. Comprehensive Security Audit (All Templates, All Severities):
    cxg scan --scope example.com --output-format json,html,sarif
@@ -1306,11 +1254,17 @@ pub struct ScanArgs {
 
     // Protocol specification
     /// Protocol to use for scanning
-    #[arg(long, help = "Specify protocol: http, https, tcp, udp, etc.")]
+    #[arg(
+        long,
+        help = "Specify protocol: http, https, tcp, udp, etc. [NOT IMPLEMENTED — accepted and ignored]"
+    )]
     pub protocol: Option<String>,
 
     /// Multiple protocols to test (comma-separated)
-    #[arg(long, help = "Test multiple protocols. Example: http,https")]
+    #[arg(
+        long,
+        help = "Test multiple protocols. Example: http,https [NOT IMPLEMENTED — accepted and ignored]"
+    )]
     pub protocols: Option<String>,
 
     // Template selection
@@ -1366,7 +1320,7 @@ pub struct ScanArgs {
     /// thread count. The actual concurrency is controlled by --parallel-targets and
     /// --parallel-templates. This option is kept for compatibility and may be used
     /// for future thread pool configuration.
-    #[arg(long, default_value_t = num_cpus::get(), help = "Worker threads for parallel execution. Higher = faster but more CPU usage. Note: In async context, concurrency is controlled by --parallel-targets and --parallel-templates")]
+    #[arg(long, default_value_t = num_cpus::get(), help = "Worker threads for parallel execution. Concurrency is actually controlled by --parallel-targets and --parallel-templates. [NOT IMPLEMENTED — accepted and ignored]")]
     pub threads: usize,
 
     /// Number of targets to scan simultaneously
@@ -1491,26 +1445,26 @@ pub struct ScanArgs {
     )]
     pub output: String,
 
-    /// Output formats (comma-separated: json,html,sarif,csv,xml)
+    /// Output formats (comma-separated: json,csv,sarif,html,markdown)
     #[arg(
         long,
         default_value = "json",
-        help = "Output formats. json=automation, csv=spreadsheet, sarif=CI/CD, html=visual, xml=enterprise"
+        help = "Output formats. json=automation, csv=spreadsheet, sarif=CI/CD, html=visual, markdown=docs"
     )]
     pub output_format: String,
 
     /// Enable real-time streaming output (results shown as found)
     #[arg(
         long,
-        help = "Stream results in real-time. Useful for long scans where you want immediate feedback"
+        help = "Stream results in real-time. [NOT IMPLEMENTED — accepted and ignored]"
     )]
     pub stream: bool,
 
-    /// Quiet mode (suppress non-essential output)
+    /// Quiet mode (suppress the startup banner)
     #[arg(
         short,
         long,
-        help = "Minimal output: only critical info and errors. Ideal for scripting and automation"
+        help = "Suppress the ASCII startup banner. Scan output itself is unchanged"
     )]
     pub quiet: bool,
 
@@ -1518,35 +1472,35 @@ pub struct ScanArgs {
     /// Resume previously interrupted scan by scan ID
     #[arg(
         long,
-        help = "Resume scan from where it stopped. Scan state is auto-saved for recovery from crashes"
+        help = "Resume scan from where it stopped. [NOT IMPLEMENTED — accepted and ignored]"
     )]
     pub resume: Option<String>,
 
     /// Enable distributed scanning mode (horizontal scaling)
     #[arg(
         long,
-        help = "Distributed mode: coordinate with other scanners for massive scans across multiple machines"
+        help = "Distributed mode: coordinate with other scanners for massive scans. [NOT IMPLEMENTED — accepted and ignored]"
     )]
     pub distributed: bool,
 
     /// Coordinator URL for distributed scanning (required with --distributed)
     #[arg(
         long,
-        help = "Coordinator manages work distribution. Example: http://coordinator:8080"
+        help = "Coordinator URL for distributed mode. [NOT IMPLEMENTED — accepted and ignored]"
     )]
     pub coordinator: Option<String>,
 
     /// Unique worker ID for distributed scanning (auto-generated if not set)
     #[arg(
         long,
-        help = "Worker identifier in distributed mode. Example: scanner-01, worker-east-1"
+        help = "Worker identifier in distributed mode. [NOT IMPLEMENTED — accepted and ignored]"
     )]
     pub worker_id: Option<String>,
 
     /// Configuration profile name from config file
     #[arg(
         long,
-        help = "Use named profile from config. Allows quick switching between scan scenarios"
+        help = "Use named profile from config. [NOT IMPLEMENTED — accepted and ignored]"
     )]
     pub profile: Option<String>,
 
@@ -1751,7 +1705,10 @@ pub enum TemplateAction {
     /// Show the template directories used by cxg
     Pwd,
 
-    /// Display the skeleton/scaffold template for a language
+    /// Display the skeleton/scaffold template for a language.
+    ///
+    /// This is a starting scaffold, not a ready-to-run template. The emitted YAML skeleton
+    /// in particular does not pass the engine loader as-is and must be edited before use.
     Skeleton {
         /// Programming language for the skeleton
         #[arg(value_enum, value_name = "LANG")]
@@ -1919,22 +1876,13 @@ pub struct SearchArgs {
 
 #[derive(Parser, Debug)]
 #[command(
-    about = "Run CERT-X-GEN as an API server",
-    long_about = "Start CERT-X-GEN as a REST API server for remote scanning capabilities, \
-                  web-based management, and integration with other security tools.",
-    after_help = "EXAMPLES:
-  # Start server with defaults
-  cxg server
-
-  # Custom port and bind address
-  cxg server --port 8080
-  cxg server --bind 0.0.0.0 --port 3000
-
-  # Enable TLS/HTTPS
-  cxg server --tls --tls-cert server.crt --tls-key server.key
-
-  # With authentication
-  cxg server --auth-token my-secret-token"
+    about = "Run as API server [NOT IMPLEMENTED — returns an error]",
+    long_about = "Intended to start CERT-X-GEN as a REST API server for remote scanning.\n\n\
+                  NOT IMPLEMENTED: this command currently exits with \
+                  `Error: Not implemented: API server not yet implemented`. The flags below \
+                  (including --tls*) are accepted but the server does not start.",
+    after_help = "NOTE: `cxg server` is not implemented and exits with an error. The options \
+                  below are placeholders and have no effect."
 )]
 pub struct ServerArgs {
     /// Server port


### PR DESCRIPTION
Makes every user-facing claim in **README.md** and the **`cxg --help`** tree true of the built binary, in both directions (delete what is false, document what is real). Work list: `docs/_analysis/delta-v1.2.0.md` §9 (Revision 3) — 61 not-OK rows.

## Hard constraint honoured
Docs/help strings only — **no implementation.** No logic, defaults, clap arg shapes, `value_enum`, or `possible_values` changed. Verified:
- `cargo build` + `cargo test --lib` → **210 passed, 0 failed**
- `cxg server` still errors (`Not implemented`); its `--tls*` flags still present
- All INERT flags still parse (accepted-and-ignored), not turned into hard errors
- Only 4 files touched: `README.md`, `src/cli.rs`, `docs/SANDBOX_GUIDE.md`, `cert-x-gen.example.yaml`

## By ledger category
- **WRONG → corrected:** `--follow-redirects` help now says *Default: Disabled* (a bare scan runs `Policy::none()`); `--quiet` only suppresses the banner; `--output-format` drops unregistered `xml`; `-o` documented as *extension-replacing*; README `--format`→`--output-format`; `template info <id>`; pentest `--ai-provider` gains `bridge`; exit code `3` notes `--no-restart`; template-count table/badge removed; "auto-download on first scan" and "environment variables" claims corrected.
- **INERT → labelled `[NOT IMPLEMENTED — accepted and ignored]`, worked examples deleted:** scan `--protocol/--protocols/--stream/--resume/--distributed/--coordinator/--worker-id/--threads/--profile`.
- **STUB → kept + labelled:** `cxg server` and `--tls*`.
- **MISSING → documented:** `markdown` format; `bridge` provider + `BUGB_BRIDGE_URL`/`BUGB_BRIDGE_TOKEN`; `threat_id`; the six top-level commands + the whole `cxg pentest` surface; **Track B CI-auth** (`auth import`/`verify`, `run --ci`/`--auth-dir`, exit 5, `CXG_CI`, `CXG_AUTH_STATE_<NAME>`) — now reachable via clap (PR #54), verified against the fresh build.

## Sandbox (narrow exception)
Removed the false "sandboxed by default / strict resource limits" claims from README and `SANDBOX_GUIDE.md`; state that templates run as ordinary child processes with the invoking user's privileges and full network/filesystem access; reframe `cxg sandbox` as **dependency-environment management**.

## Out of scope (unchanged / noted)
- `cert-x-gen.example.yaml`: single top comment added (does not load / being revised); no other change.
- `ResourceManager`, `sandbox.*` config keys, the `cxg sandbox` command tree.
- CHANGELOG staleness (`mcp serve`, MCP client list) → CHANGELOG backfill workstream; the `cxg mcp install --client` **help already matches the installer** (claude-desktop, claude-code, cursor, windsurf, vscode, zed) — verified, no change.
- Python `cxg_pentest.py` argparse `--ai-provider` help drift → not part of the `cxg` binary's `--help`; left untouched per the docs-only constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)