### PR TITLE
feat(config): make top-level config sections optional at load time

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,13 +7,17 @@ use std::path::{Path, PathBuf};
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
-    /// Template configuration
+    /// Template configuration. Omitted → `TemplateConfig::default()`.
+    #[serde(default)]
     pub templates: TemplateConfig,
-    /// Network configuration
+    /// Network configuration. Omitted → `NetworkConfig::default()`.
+    #[serde(default)]
     pub network: NetworkConfig,
-    /// Execution configuration
+    /// Execution configuration. Omitted → `ExecutionConfig::default()`.
+    #[serde(default)]
     pub execution: ExecutionConfig,
-    /// Sandbox configuration
+    /// Sandbox configuration. Omitted → `SandboxConfig::default()`.
+    #[serde(default)]
     pub sandbox: SandboxConfig,
 }
 
@@ -70,6 +74,7 @@ impl Config {
 
 /// Template configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TemplateConfig {
     /// Template directories (for backward compatibility)
     pub directories: Vec<PathBuf>,
@@ -88,6 +93,7 @@ impl Default for TemplateConfig {
 
 /// Network configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct NetworkConfig {
     /// Request timeout (seconds)
     pub timeout_secs: u64,
@@ -134,6 +140,7 @@ impl Default for NetworkConfig {
 
 /// Execution configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ExecutionConfig {
     /// Parallel target scanning
     pub parallel_targets: usize,
@@ -164,6 +171,7 @@ impl Default for ExecutionConfig {
 
 /// Sandbox configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct SandboxConfig {
     /// Enable sandbox
     pub enabled: bool,
@@ -231,5 +239,46 @@ mod tests {
 
         config.execution.parallel_targets = 0;
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_partial_config_uses_defaults_for_omitted_sections() {
+        // Only `network` is present, and only one of its keys. Every other
+        // section — and every unspecified network key — must fall back to its
+        // compiled-in default rather than erroring.
+        let yaml = "network:\n  timeout_secs: 20\n";
+        let config: Config = serde_yaml::from_str(yaml).expect("partial config should load");
+
+        // Specified value wins.
+        assert_eq!(config.network.timeout_secs, 20);
+        // Unspecified network key falls back to NetworkConfig::default().
+        assert_eq!(
+            config.network.connection_pool_size,
+            NetworkConfig::default().connection_pool_size
+        );
+        // Omitted sections equal their Default impls.
+        assert_eq!(
+            config.templates.timeout_secs,
+            TemplateConfig::default().timeout_secs
+        );
+        assert_eq!(
+            config.execution.parallel_targets,
+            ExecutionConfig::default().parallel_targets
+        );
+        assert_eq!(config.sandbox.enabled, SandboxConfig::default().enabled);
+
+        // A partial config still validates.
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_empty_config_is_all_defaults() {
+        // An empty document is a valid config equal to Config::default().
+        let config: Config = serde_yaml::from_str("{}").expect("empty config should load");
+        assert_eq!(
+            config.execution.parallel_targets,
+            Config::default().execution.parallel_targets
+        );
+        assert!(config.validate().is_ok());
     }
 }


### PR DESCRIPTION
Stacked on #56 (which introduced the 4-section `Config`). Base is `chore/remove-dead-config-keys` so the diff stays to one file — retarget to `main` once #56 merges.

## Problem
All four sections (`templates`, `network`, `execution`, `sandbox`) were required at load time even though each has complete compiled-in defaults, so a partial config errored — and one required section (`sandbox`) has no consumers at all.

## Change (`src/config.rs` only)
- `#[serde(default)]` on each of `Config`'s four **section fields** → a fully-omitted section falls back to its `Default` impl.
- `#[serde(default)]` as a **container attribute** on each section struct (`TemplateConfig`, `NetworkConfig`, `ExecutionConfig`, `SandboxConfig`) → an omitted key *within a present* section falls back too.

Both are needed: field-level alone makes `{}` work but still errors on `network: { timeout_secs: 20 }` (missing `user_agent`, …); the container attribute closes that.

**AIConfig** already has `#[serde(default...)]` on both its fields — no equivalent problem, unchanged.

No key removed or wired; `sandbox.*` behaviour untouched (separate workstream). This only changes whether an omitted section/key is an error.

## Verified
- `network: { timeout_secs: 20 }` → **loads**; `timeout_secs` = 20, all other network keys + other sections take defaults (unit test)
- `{}` → **loads** as all-defaults
- `cert-x-gen.example.yaml` → still loads (`tests/example_config_loads.rs`)
- fully-specified config → loads identically
- `cargo check --lib` — **warning-clean**; `cargo fmt --check` clean; full test suite green (204 lib + integration)
- New unit tests: `test_partial_config_uses_defaults_for_omitted_sections`, `test_empty_config_is_all_defaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)