### PR TITLE
fix(cli): don't print the ASCII banner onto machine-readable stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use cert_x_gen::{
 };
 use clap::Parser;
 use include_dir::{include_dir, Dir};
+use std::io::IsTerminal;
 use std::sync::Arc;
 use std::{
     collections::HashSet,
@@ -28,14 +29,17 @@ use cli::{Cli, Commands};
 
 #[tokio::main]
 async fn main() {
-    // Display banner first (before parsing CLI)
-    // Check if --quiet flag is present in args
+    // Display the banner first (before parsing CLI), but never onto machine-readable
+    // stdout. The default rule is a TTY check: suppress the banner whenever stdout is
+    // not a terminal (pipes, redirects, CI, JSON-RPC over stdio for `mcp`, etc.).
+    // Explicit escapes still force suppression even on a terminal.
     let args: Vec<String> = std::env::args().collect();
-    let is_quiet = args.iter().any(|arg| arg == "--quiet" || arg == "-q")
-        || args.iter().any(|arg| arg == "mcp")
-        || std::env::var("CXG_NO_BANNER").is_ok();
+    let suppress_banner = std::env::var("CXG_NO_BANNER").is_ok()
+        || args.iter().any(|arg| arg == "--quiet" || arg == "-q")
+        || args.iter().any(|arg| arg == "--version" || arg == "-V")
+        || !std::io::stdout().is_terminal();
 
-    if !is_quiet {
+    if !suppress_banner {
         cert_x_gen::banner::display_banner();
     }
 


### PR DESCRIPTION
The banner was written to stdout before CLI parsing, suppressed only by an argv scan for `--quiet`/`-q`, a hardcoded `mcp` check, and `CXG_NO_BANNER`. So `cxg --version` emitted 12 lines, and any piped output (`search --format json`, etc.) was prefixed with the banner, breaking `| jq`.

## Fix
Replace the argv/subcommand heuristics with a **TTY check** (`std::io::IsTerminal`, no new dependency): suppress the banner whenever stdout is **not** a terminal. Explicit escapes remain as overrides:
- `CXG_NO_BANNER` — suppresses (even on a TTY)
- `--quiet` / `-q` — suppresses (even on a TTY)
- `--version` / `-V` — now suppressed too, so interactive `cxg --version` is one parseable line
- The hardcoded **`mcp` special-case is removed** — the TTY rule covers it (JSON-RPC over stdio is never a terminal), verified below.

Banner content and `--quiet`'s behaviour are unchanged (still banner-suppression-only, keeping its PR #55 help text). No new dependency; `cargo check --all-targets` warning-clean; fmt clean; all tests pass (204 lib + 28 + integration).

## Verify — before → after (fresh build)
| Case | Before | After |
|------|--------|-------|
| `cxg --version` | 12 lines (banner + `cxg 1.2.0`) | **1 line** (`cxg 1.2.0`) |
| `cxg --version \| cat` | 12 lines | **1 line** |
| `cxg --version` on a TTY | 12 lines | **1 line** (`--version` override) |
| `cxg search --query x --format json \| jq .` | jq **fails** (banner pollutes) | **parses** ✓ |
| `cxg template list` piped | banner present | **no banner** |
| `cxg mcp` (JSON-RPC over stdio) | no banner (via `mcp` special-case) | **no banner** (via TTY rule) ✓ |
| `cxg scan --scope 127.0.0.1` in a terminal | banner present | **banner present** ✓ |
| `cxg scan --scope 127.0.0.1 \| cat` | banner present | **no banner** |
| `CXG_NO_BANNER=1 cxg scan …` (TTY) | no banner | **no banner** |
| `cxg scan -q …` (TTY) | no banner | **no banner** |

TTY cases were exercised under a pseudo-terminal; the terminal-present result was confirmed by capturing PTY stdout to a file.

## Note — out of scope
The task listed `cxg template list --json` and `cxg template validate --json`, but **`--json` is not a flag on those subcommands** in the current binary (only `cxg search --format json` produces JSON). I did not add it (that would be a feature change, not the banner fix). The banner fix is universal to any non-TTY stdout, so those commands' piped output is now banner-free regardless — demonstrated with `cxg template list` piped above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)