### PR TITLE
docs(changelog): reconstruct CHANGELOG and bump to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,166 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-12
+
+### Added
+
+**Desktop application pentesting**
+- `cxg pentest run --target-type electron` — launch, isolate, and probe Electron desktop
+  applications. cxg starts N isolated app instances (via `--app-cmd` or `--app-binary`),
+  drives their renderers over CDP, and additionally probes IPC channels, renderer security
+  configuration, and local data at rest. Add `--host-scan-path` to also scan an existing
+  installation directory. Tauri is explicitly **unsupported** — it exposes no CDP endpoint on
+  macOS or Linux.
+
+**Out-of-band (OAST) callback confirmation**
+- `--oast-interactsh [<server>]` — cxg registers an interactsh session it **owns** and polls it,
+  so a callback becomes a genuine `confirmed=true` finding with the interaction recorded as
+  evidence. This is different from `--oast <host>`, which only **injects** a callback URL that
+  cxg **cannot read back** (e.g. Burp Collaborator or a canary you host): under `--oast`, blind
+  probes (SSRF, blind SQLi/XXE/cmd-injection) fall back to status-code and timing heuristics and
+  findings stay **unconfirmed** — reading the callback is the operator's job, in their own
+  tooling. The two flags **conflict at the CLI level deliberately**: two canaries would leave
+  "was this confirmed?" with no single answer per finding.
+
+**Crash recovery for desktop targets**
+- `--no-restart` — do not relaunch a desktop target that dies mid-scan (the run ends with a
+  truncation caveat and exit code 3).
+- `--stall-timeout <secs>` — idle-time bound that catches a frozen app (electron only).
+- `--template-timeout <secs>` — absolute per-template dispatch ceiling (a backstop).
+
+**Non-interactive CI authentication**
+- `cxg pentest auth import` — write an auth profile from a session captured once and exported as
+  a Playwright `storage_state`, with no browser. The state can come from a file, from stdin
+  (`--storage-state -`), or from the base64 environment variable `CXG_AUTH_STATE_<NAME>`.
+- `cxg pentest auth verify` — liveness-check a saved session (exit 0 alive / non-zero dead)
+  before a run spends any AI budget.
+- `cxg pentest run --ci` (also enabled by `CXG_CI=1`) — a dead or expired auth session becomes a
+  hard failure with **exit code 5** at pre-flight, so a pipeline never silently probes
+  unauthenticated.
+- `--auth-dir <dir>` — read/write auth profiles from a directory other than `~/.cert-x-gen/auth`,
+  so CI can restore a bundle of imported profiles and point the run at it.
+
+**AI generation**
+- `bridge` AI provider — posts each prompt to `$BUGB_BRIDGE_URL` (with
+  `Authorization: Bearer $BUGB_BRIDGE_TOKEN` when set) and reads the completion back; an
+  editor/CI integration point rather than a local CLI. It is preferred first by
+  `--ai-provider auto` whenever `$BUGB_BRIDGE_URL` is set.
+
+**Reporting**
+- `threat_id` on findings in `report.json`, linking each finding back to the originating
+  guardlink hypothesis (`null` for AI- or mutation-synthesised probes).
+- `review_only_threats` in `report.json` (electron): routeless guardlink threats that have no IPC
+  channel to test, surfaced for manual review rather than silently dropped.
+- Engine-stamped actor provenance — every request now records which captured identity issued it,
+  which feeds cross-identity (IDOR / privilege-escalation) triage in the report and audit log.
+
+**Templates**
+- `@requires_capability` template header — a probe declares a substrate capability it needs; the
+  engine skips any template whose capability the running substrate does not provide, instead of
+  recording an undefined-namespace error as a refutation.
+
+**Environment**
+- `CXG_NO_NAG` — opt out of the occasional one-line post-scan GitHub-star request (which prints
+  only on an interactive terminal and at most once a week).
+
+### Changed
+- `--help` restructured into functional groups, with a two-tier split: `-h` shows one terse line
+  per flag, `--help` shows the full explanation. `cxg scan -h` went from **375 lines to 95**.
+- The ASCII banner is now suppressed whenever stdout is **not** a terminal. `cxg --version` is a
+  single, parseable line, and piped output is clean — previously the banner corrupted
+  `cxg search --format json | jq`. Explicit overrides remain: `CXG_NO_BANNER`, `--quiet`/`-q`.
+- Configuration sections are now optional. A partial config file loads, with omitted sections and
+  omitted keys taking their compiled-in defaults.
+
+### Fixed
+- `cert-x-gen.example.yaml` now loads through the config parser. It previously failed to load on a
+  required field that had no default; a regression test now loads it on every build.
+- Fewer false "confirmed" pentest findings: the empty-evidence guard no longer mistakes a finding
+  carrying only bookkeeping keys for one that the AI confirmed with real evidence.
+- Documentation was aligned with actual behaviour across `README.md` and the `--help` tree — false
+  and stale claims were removed or corrected (see Notes below).
+
+### Removed
+- **36 dead configuration keys** and the unused metrics module. Every one of these keys was parsed
+  but had **no effect**. Existing config files that still set them **continue to load** — the keys
+  are simply ignored.
+  - (a) Removed, no plan to reinstate: `global.{verbosity,color,log_level,log_file,debug}`,
+    `templates.{use_system_templates,use_user_templates,use_local_templates,auto_update,cache_dir}`,
+    `network.{http2,dns_servers,follow_redirects}`,
+    `execution.{threads,passive_mode,safe_mode,cache_enabled}`, `output.stream`,
+    `metrics.{enabled,export_port,export_format}`, `plugins.{enabled,directories,plugins}`,
+    `ai.fallback_providers`, `ai.cost_tracking.*`, `ai.cache.*`.
+    (`network.follow_redirects` was removed as a config key only; the `--follow-redirects` flag is
+    unaffected.)
+  - (b) Removed, but plausible candidates to reinstate wired up later — these describe things a
+    config file could reasonably control, and were removed because they lied, not because the
+    capability is unwanted: `output.min_severity`, `output.formats`, `output.output_dir`,
+    `output.output_file`, `templates.enabled_languages`.
+
+### Notes — accepted-and-ignored surface
+
+Stated plainly so it produces no more false leads:
+
+- **Template execution is NOT sandboxed.** Despite earlier "sandboxed by default" claims in this
+  changelog and the README, no execution path isolates or resource-limits templates: they run as
+  ordinary child processes with the invoking user's privileges and full network and filesystem
+  access. Run cxg inside a container or VM if you need isolation. (`cxg sandbox` manages
+  per-language *dependency* environments — it does not confine template execution.)
+- Nine `cxg scan` flags are accepted and silently ignored: `--protocol`, `--protocols`,
+  `--threads`, `--stream`, `--resume`, `--distributed`, `--coordinator`, `--worker-id`,
+  `--profile`. They are now grouped under a "Not Implemented" heading in `--help`.
+- `cxg server` is not implemented — it exits with an error; its `--tls*`, `--port`, `--bind`, and
+  `--auth-token` flags are accepted but do nothing.
+- Runtime templates are distributed separately, in the
+  [cert-x-gen-templates](https://github.com/Bugb-Technologies/cert-x-gen-templates) repository, and
+  installed to `~/.cert-x-gen/templates/`. No template count is stated here.
+
+## [1.2.0] - 2026-08-01
+
+### Added
+
+**AI-driven whitebox pentest pipeline (`cxg pentest`)**
+- New subsystem that reads guardlink's `whitebox/findings.sarif`, LLM-ranks threats against an
+  operator goal, and has a local AI CLI (claude / codex / gemini, or the Anthropic / OpenAI HTTP
+  APIs) write JavaScript probe templates that read the target's source to craft code-aware
+  payloads. Those templates run in N parallel **authenticated** Chromium contexts, emitting
+  confirmed / refuted / ambiguous findings to `report.json` plus a JSONL audit log of every HTTP
+  request.
+- Interactive auth capture for SSO/MFA flows (`cxg pentest auth`), chained-auth probes for
+  cross-user IDOR (`--auth-numbers 2+`), scope enforcement (URL/method allowlist, per-endpoint
+  budget, 5xx hard-kill), validator-guarded code generation, and retry-with-mutation on ambiguous
+  triage.
+- Operator-supplied identity metadata — `--tier`, `--persona`, `--cohort`, and free-form `--tag`
+  — fed to the AI ranker so it selects the right identity per probe.
+- The Python orchestrator is embedded in the binary (via `include_dir!`) and installed on demand,
+  for a self-contained distribution.
+- `cxg update` — self-update the `cxg` binary to the latest released build.
+
+### Fixed
+- SPA dashboards are no longer false-flagged as dead sessions during pentest pre-flight and
+  session-health checks.
+- Template config-directory resolution is now cross-platform (fixes Windows).
+- `AIManager` provider tests are isolated from any on-disk AI config.
+
+### Security
+- Cleared dependency advisories: openssl 0.10.73 → 0.10.81 (8 advisories),
+  bytes 1.10.1 → 1.12.1 (integer overflow), git2 0.18 → 0.20.4 (GHSA-j39j-6gw9-jw6h),
+  prometheus 0.13 → 0.14 (protobuf advisory). TLS/HTTP stacks were consolidated onto reqwest.
+
 ## [1.1.1] - 2026-03-25
 
 ### Added
 
 **MCP Server (Model Context Protocol)**
-- 12-tool MCP server for AI agent integration via `cxg mcp serve`
+- 12-tool MCP server for AI agent integration via `cxg mcp` (there is no `serve` subcommand — the
+  server is the bare `cxg mcp` invocation)
   - `cxg_search`, `cxg_template_list`, `cxg_template_info`, `cxg_scan`
   - `cxg_template_validate`, `cxg_template_create`, `cxg_template_write`
   - `cxg_template_get_notes`, `cxg_ai_generate`, `cxg_template_test`
   - `cxg_template_stats`, `cxg_template_update`
-- `cxg mcp install` — auto-configure 6 AI coding agents (Claude Desktop, Cursor, Windsurf, Cline, Roo Code, Claude Code)
+- `cxg mcp install` — auto-configure 6 AI coding agents (Claude Desktop, Claude Code, Cursor,
+  Windsurf, VS Code, Zed), matching `src/mcp/installer.rs`
 
 **AI Template Generation**
 - `cxg ai generate` — natural-language to template generation (dual-mode: scaffold or full)
@@ -25,9 +174,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--api-key` flag for session-only cloud provider authentication
 
 **Parameterised Template Metadata**
-- 5 new metadata fields for Bravos pipeline routing: `context_vars`, `batch_group`, `confidence`, `execution_mode`, `pipeline_stage`
+- 5 new metadata fields on the template struct: `context_vars`, `vuln_class`, `hypothesis_tags`,
+  `batch_group`, `auto_probe` (an earlier revision of this entry listed `confidence`,
+  `execution_mode`, and `pipeline_stage`, which do not exist)
 - `@field:` annotation parsing across all 12 supported languages
-- `context` and `batch_group` parameters added to `cxg_scan` MCP tool
+- `context` and `batch_group` parameters added to the `cxg_scan` MCP tool
 
 **Template CLI Extensions**
 - `cxg template search` — search templates by query, language, severity, or tags
@@ -43,8 +194,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Template count updated from 58 to 147 across 9 categories and 12 languages
-- MCP server instructions updated to reflect current template count
+- Template library and MCP server template metadata refreshed. (An earlier revision of this entry
+  cited specific template counts — 58 and 147 — that did not correspond to any shipped template
+  population; templates are maintained in the separate cert-x-gen-templates repository, so no count
+  is stated here.)
 
 ## [1.0.0] - 2025-01-13
 
@@ -88,8 +241,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Template signature verification (planned)
 - Safe defaults for all operations
 
+> Note: the "sandboxed execution" claims in this 1.0.0 entry never reflected the shipped binary —
+> template execution has never been isolated or resource-limited. See the 1.3.0 Notes.
+
 ---
 
-[Unreleased]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/Bugb-Technologies/cert-x-gen/compare/v1.0.0...v1.1.1
 [1.0.0]: https://github.com/Bugb-Technologies/cert-x-gen/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "cert-x-gen"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cert-x-gen"
 # @g.comment -- "release 1.2.0: ships the self-update command (#12) and AI pentest pipeline (#10)"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["CERT-X-GEN Core Team"]
 description = "Advanced Multi-Language Security Scanning Engine"


### PR DESCRIPTION
Reconstructs the CHANGELOG (which ended at 1.1.1 with an empty `[Unreleased]`), corrects the wrong 1.1.1 claims **in place**, adds `[1.2.0]` and `[1.3.0]`, fixes the link refs, and bumps `Cargo.toml` to **1.3.0**. No git tag created.

## Corrected in [1.1.1] (known false leads)
- MCP server is the bare `cxg mcp`, **not** `cxg mcp serve` (no `Serve` variant).
- MCP client list matched to `src/mcp/installer.rs`: **Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Zed** (was "Cline, Roo Code").
- Template metadata fields are **context_vars, vuln_class, hypothesis_tags, batch_group, auto_probe** (`execution_mode`/`pipeline_stage` do not exist).
- Removed the bogus **58→147** count (no shipped population matches it; §6.7.1).

## [1.2.0] (v1.1.1..v1.2.0, dated from the tag)
The AI-driven whitebox pentest pipeline (`cxg pentest`), operator identity metadata, embedded orchestrator, `cxg update`; SPA/Windows/test fixes; and a batch of dependency **Security** advisories.

## [1.3.0] (v1.2.0..HEAD) — written for users
Electron `--target-type`, `--oast-interactsh` (owns+polls → `confirmed=true`) vs inject-only `--oast` (they conflict deliberately), crash recovery (`--no-restart`/`--stall-timeout`/`--template-timeout`), Track B CI auth (`auth import`/`verify`, `run --ci`, `--auth-dir`, exit 5, `CXG_CI`, `CXG_AUTH_STATE_<NAME>`), the `bridge` provider (`BUGB_BRIDGE_URL`/`TOKEN`), `threat_id`, `@requires_capability`, `review_only_threats`, `CXG_NO_NAG`; the `--help`/banner/optional-config changes; the `example.yaml` load fix; and the 36-key removal with PR #56's two-bucket split.

## Honesty
- States plainly that **template execution is NOT sandboxed** (ordinary child processes, invoking user's privileges, full network/filesystem) — no historical sandboxing claim repeated; added a correction note under 1.0.0 too.
- Lists the **nine accepted-and-ignored** scan flags and `cxg server`.
- **No template count** cited in the new sections; templates ship via the separate cert-x-gen-templates repo.

## Verify
- `cargo build --release` succeeds; `cxg --version` → `cxg 1.3.0` (single line).
- Grep confirms no `mcp serve` / `execution_mode` (except the correction) / `Cline` / `Roo Code` / `147 templates` / "skeleton now loads" survive.
- Link refs: `[Unreleased]` → `v1.3.0...HEAD`, `[1.3.0]` → `v1.2.0...v1.3.0`, etc.

## Report
- **Could not verify → omitted:** the suggested Fixed entry "the shipped YAML template skeleton now loads through the engine." Tested against a fresh build — the skeleton still has a string `author` + a `dsl` matcher and is rejected by the engine loader ("No templates loaded"); no commit fixed it. Including it would contradict Revision 3 §6.2, so it was dropped.
- **Git history attribution:** every merged PR/theme in `v1.2.0..HEAD` mapped to a 1.3.0 entry via the delta doc + merge list (electron: `desktop-target-substrate`/#41/#49; OAST: #50; bridge: #46/#47; threat_id: #48; actor provenance: #52; Track B: #53/#54; plus #55–#60). Nothing was left unattributable at the theme level. (Individual commits were mapped by PR, not line-by-line across all 132.)
- **One historical count remains:** the untouched `[1.0.0]` entry still says "58 templates" as a record of the original release claim; flagging it since the file-wide no-count rule is about the new sections.
- **PR #60 (`CXG_NO_NAG`) was MERGED** (2026-08-12T15:17:39Z) when I wrote that entry, so it is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)