### PR TITLE
fix: remove the sandbox config section, which never confined anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+**The `sandbox` configuration section, which never took effect.**
+
+- Removed the `sandbox` section from the configuration schema: `sandbox.enabled`,
+  `sandbox.memory_limit_mb`, `sandbox.cpu_limit_percent`, `sandbox.network_access` and
+  `sandbox.filesystem_access`, along with the `NetworkAccess` and `FilesystemAccess` enums.
+
+  **These settings never did anything.** No code path has ever read them to confine, throttle,
+  or restrict template execution. Their only consumer was `ResourceManager`, which was never
+  constructed outside its own unit test. A configuration setting `sandbox.enabled: true` with
+  `filesystem_access: readonly` and `network_access: none` produced a run identical to one with
+  no sandbox configuration at all: the template read the process uid and username, listed the
+  user's home directory, confirmed `.ssh` was readable, spawned a child process, and made an
+  outbound DNS query. **Any configuration relying on these keys was not protected by them**, and
+  `cxg config validate` reported such a file as simply valid.
+
+  Templates execute as ordinary child processes with the invoking user's privileges and full
+  network and filesystem access. Review templates before running them. For isolation, run cxg
+  itself inside a container or VM, as a non-privileged user.
+
+- Removed `ResourceManager` from `src/scheduler.rs`, and the now-unreachable `Error`
+  variants `ResourceLimitExceeded` and `SandboxViolation` (with the `Error::resource_limit`
+  constructor) — no cxg error path can report a limit or a violation, because no limit or
+  confinement is enforced anywhere.
+
+### Changed
+
+- A configuration file that still contains a `sandbox` section **still loads**. cxg now prints
+  a warning on load, and `cxg config validate` reports the file as loadable-with-obsolete-sections
+  rather than valid, stating that the settings never took effect and that template execution is
+  not confined. Silently ignoring the keys would leave operators believing they are hardened.
+- `cxg sandbox` — the command that manages per-language dependency environments — is unaffected
+  and unchanged in behaviour. Its help text and docs no longer describe it as providing
+  "isolation" or "security": it separates packages, not privileges.
+- A started Docker environment with `auto_start` no longer implies the running command is
+  contained by it. cxg now says explicitly that the command executes on the host; use
+  `cxg sandbox enter` to work inside the container.
+- `docs/SANDBOX_GUIDE.md` renamed to `docs/DEPENDENCY_ENVIRONMENTS.md`, matching what it
+  documents.
+
 ## [1.3.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ cxg scan --scope targets.txt --templates redis*.py,docker*.go,system*.sh
 - A **bridge** between research scripts and production scanners
 - A scanner **designed for CI, automation, and agentic systems**
 
-> **A note on execution privileges.** Templates run as ordinary child processes with the
-> privileges of the user invoking cxg, with full network and filesystem access. There is no
-> execution sandbox or resource limiting — run cxg inside a container or VM, and as a
-> non-privileged user, if you need isolation. See the [Sandbox Guide](docs/SANDBOX_GUIDE.md),
-> whose `cxg sandbox` command manages per-language *dependency* environments (not isolation).
+> **A note on execution privileges.** Templates execute as ordinary child processes with the
+> invoking user's privileges and full network and filesystem access. Review templates before
+> running them. There is no execution sandbox or resource limiting anywhere in cxg — no flag,
+> no configuration key, no default. Run cxg inside a container or VM, and as a non-privileged
+> user, if you need isolation. See the
+> [Dependency Environment Guide](docs/DEPENDENCY_ENVIRONMENTS.md), whose `cxg sandbox` command
+> manages per-language *dependency* environments (not isolation).
 
 
 ---
@@ -392,7 +394,7 @@ guardlink hypothesis (`null` for AI/mutation-synthesised probes).
 | [Usage Guide](docs/USAGE_GUIDE.md) | Comprehensive CLI usage and examples |
 | [Architecture](docs/ARCHITECTURE.md) | System design and internals |
 | [Engine Guide](docs/ENGINES.md) | Language-specific execution details |
-| [Sandbox Guide](docs/SANDBOX_GUIDE.md) | `cxg sandbox` dependency-environment management |
+| [Dependency Environments](docs/DEPENDENCY_ENVIRONMENTS.md) | `cxg sandbox` dependency-environment management |
 | [Contributing](CONTRIBUTING.md) | How to contribute code and templates |
 
 **Whitebox pentest (`cxg pentest`):**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,7 +55,10 @@ We will not pursue legal action against researchers who:
 When using CERT-X-GEN:
 
 1. **Template Sources**: Only use templates from trusted sources
-2. **Sandboxing**: Enable sandbox mode when running untrusted templates
+2. **Isolation**: cxg has no sandbox mode to enable. Templates execute as ordinary child
+   processes with the invoking user's privileges and full network and filesystem access.
+   Review templates before running them. To confine them, run cxg itself inside a container
+   or VM, as a non-privileged user.
 3. **API Keys**: Store API keys in environment variables, not in config files
 4. **Network**: Use proxies when scanning sensitive targets
 5. **Updates**: Keep CERT-X-GEN and templates updated

--- a/cert-x-gen.example.yaml
+++ b/cert-x-gen.example.yaml
@@ -4,8 +4,9 @@
 # Generate a fresh copy any time with: cxg config generate --output cert-x-gen.yaml
 #
 # Every key below has a runtime effect. (Dead configuration keys were removed in
-# v1.3.0 — old config files that still set them continue to load; the extra keys
-# are simply ignored.)
+# v1.3.0 and later — old config files that still set them continue to load; the
+# extra keys are ignored, and removed sections that implied a security guarantee
+# are warned about on load.)
 
 # Template discovery and execution
 templates:
@@ -51,13 +52,12 @@ execution:
   # Stealth mode: adds request jitter/delay.
   stealth_mode: false
 
-# Sandbox dependency-environment settings.
-# NOTE: these keys do NOT confine template execution (templates run as ordinary
-# child processes with your privileges). They are retained pending a separate
-# sandbox workstream; see docs/SANDBOX_GUIDE.md.
-sandbox:
-  enabled: true
-  memory_limit_mb: 512
-  cpu_limit_percent: 80
-  network_access: controlled
-  filesystem_access: readonly
+# There is no sandbox/confinement section. Templates execute as ordinary child
+# processes with the invoking user's privileges and full network and filesystem
+# access. Review templates before running them. For isolation, run cxg itself
+# inside a container or VM, as a non-privileged user.
+#
+# The removed `sandbox:` section never took effect. A file that still
+# sets it loads, but cxg warns about it. (Unrelated to the `cxg sandbox`
+# command, which manages per-language dependency environments — see
+# docs/DEPENDENCY_ENVIRONMENTS.md.)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,15 +134,15 @@ pub struct Executor {
 
 **Responsibilities:**
 - Execute templates with proper environment setup
-- Manage concurrent template execution
-- Handle timeouts and resource limits
+- Manage concurrent template execution (via `semaphore`)
+- Handle per-template timeouts
 - Collect and aggregate findings
 
 ### 4. Scheduler
 
 **Location**: `src/scheduler.rs`
 
-Manages resource allocation and execution scheduling:
+Orders templates for execution by severity priority:
 
 ```rust
 pub struct Scheduler {
@@ -152,9 +152,7 @@ pub struct Scheduler {
 ```
 
 **Responsibilities:**
-- Prioritize template execution
-- Manage resource constraints
-- Handle rate limiting
+- Prioritize template execution by severity
 - Optimize execution order
 
 ---
@@ -457,21 +455,28 @@ pub enum Error {
 
 ## 🔒 Security Considerations
 
+### Template execution is not confined
+
+Templates execute as ordinary child processes with the invoking user's privileges and full
+network and filesystem access. Review templates before running them.
+
+cxg implements no sandboxing, isolation, or resource limiting — there is no flag,
+configuration key, or default that provides any. Confinement, if you need it, must come from
+outside the process: run cxg in a container or VM, as a non-privileged user, with cgroup and
+network-namespace limits applied by the host.
+
 ### Security Measures
 
 1. **Input Validation** - Sanitize all inputs
-2. **Sandboxing** - Isolate template execution
-3. **Resource Limits** - Prevent resource exhaustion
-4. **Secure Defaults** - Safe configuration defaults
-5. **Error Handling** - Don't leak sensitive information
+2. **Secure Defaults** - Safe configuration defaults
+3. **Error Handling** - Don't leak sensitive information
 
 ### Template Security
 
 1. **Code Review** - Review all template code
 2. **Dependency Management** - Manage external dependencies
-3. **Execution Isolation** - Isolate template execution
-4. **Output Validation** - Validate template output
-5. **Access Control** - Control template access
+3. **Output Validation** - Validate template output
+4. **Access Control** - Control template access
 
 ---
 

--- a/docs/DEPENDENCY_ENVIRONMENTS.md
+++ b/docs/DEPENDENCY_ENVIRONMENTS.md
@@ -1,4 +1,4 @@
-# Sandbox Environment Guide
+# Dependency Environment Guide (`cxg sandbox`)
 
 ## Overview
 
@@ -6,20 +6,28 @@
 > a security sandbox. It gives each language runtime its own package directory (a venv, an
 > `npm` prefix, a `GEM_HOME`, or a Docker dev container you `enter`) so template dependencies
 > stay off the system package managers. It does **not** confine, isolate, or resource-limit
-> template execution. Templates run as ordinary child processes with the invoking user's full
-> privileges and unrestricted network and filesystem access. If you need real isolation, run
-> cxg itself inside a container or VM (see [Security Considerations](#security-considerations)).
+> template execution.
+>
+> **Templates execute as ordinary child processes with the invoking user's privileges and
+> full network and filesystem access. Review templates before running them.**
+>
+> If you need real isolation, run cxg itself inside a container or VM (see
+> [Security Considerations](#security-considerations)).
+>
+> The command's name is historical. cxg has no execution-confinement feature of any kind:
+> the `sandbox:` config-file section that appeared to configure one never took effect and
+> has been removed.
 
 `cxg sandbox` manages per-language **dependency environments** for the templates you run. This provides:
 
-- **Dependency Isolation**: Each language runtime has its own package directory
+- **Dependency Separation**: Each language runtime has its own package directory
 - **Reproducibility**: Consistent package versions across installations
 - **Cleanliness**: No pollution of system-wide package managers
 - **Flexibility**: Easy to add, remove, or update packages
 
 ## Supported Languages
 
-The sandbox supports **8 programming languages**:
+`cxg sandbox` supports **8 programming languages**:
 
 | Language | Package Manager | Virtual Environment | Ready to Use |
 |----------|----------------|---------------------|--------------|
@@ -367,7 +375,9 @@ You can customize the sandbox by editing the configuration file:
 
 ## Usage in Templates
 
-Templates automatically execute in the sandbox environment. No code changes required!
+Templates automatically resolve their dependencies from these environments. No code changes
+required — only the package search path changes, not how or with what privileges the template
+runs.
 
 ### Python Template Example
 
@@ -378,7 +388,7 @@ name: Example Python Template
 severity: medium
 """
 
-# All imports use sandboxed packages
+# Imports resolve from the per-language dependency environment
 import requests
 from bs4 import BeautifulSoup
 
@@ -402,7 +412,7 @@ def execute(target, context):
  * severity: medium
  */
 
-// All requires use sandboxed packages
+// Requires resolve from the per-language dependency environment
 const axios = require('axios');
 const cheerio = require('cheerio');
 
@@ -589,9 +599,12 @@ cxg sandbox init --languages python,javascript
 
 ### No execution isolation
 
-`cxg sandbox` does **not** isolate or resource-limit template execution. Templates run as
-ordinary child processes with the invoking user's privileges and full network and filesystem
-access — the "sandbox" only decides which per-language dependency directory is on the path.
+cxg does **not** isolate or resource-limit template execution — not through `cxg sandbox`,
+not through configuration, not through any flag. **Templates execute as ordinary child
+processes with the invoking user's privileges and full network and filesystem access. Review
+templates before running them.** The "sandbox" only decides which per-language dependency
+directory is on the path.
+
 All isolation must therefore come from outside cxg:
 
 1. **Run cxg in containers**: Use Docker/Podman to isolate the whole tool
@@ -662,7 +675,7 @@ cxg sandbox path
 
 ### Q: Can I use my system packages?
 
-**A**: No, the sandbox intentionally isolates from system packages for consistency and security. However, you can install any package in the sandbox.
+**A**: No — the environments deliberately keep template dependencies separate from system packages for reproducibility. This is a packaging boundary, not a security boundary. You can install any package you need.
 
 ### Q: How much disk space does the sandbox use?
 
@@ -687,7 +700,7 @@ cp -r $(cxg sandbox path) ~/sandbox-backup
 
 ### Q: Can I share sandboxes between users?
 
-**A**: Not recommended. Each user should have their own sandbox for security and isolation.
+**A**: Not recommended. Package directories carry per-user paths and permissions; each user should have their own.
 
 ## Related Documentation
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -502,9 +502,14 @@ Generate a starting config, then edit it:
 cxg config generate --output config.yaml
 ```
 
-The schema is nested with four required top-level sections — `templates`, `network`,
-`execution`, and `sandbox`. Every key has a runtime effect; see the annotated
+The schema is nested with three top-level sections — `templates`, `network`, and
+`execution`. Every key has a runtime effect; see the annotated
 [`cert-x-gen.example.yaml`](../cert-x-gen.example.yaml) for the full reference.
+
+There is no confinement section. Templates execute as ordinary child processes with the
+invoking user's privileges and full network and filesystem access — review templates before
+running them. Configs that still carry the obsolete `sandbox:` section (removed; it never had
+any effect) still load, and cxg warns about them on load and on `cxg config validate`.
 
 Targets, ports, output format/file, and redirect-following are set on the command line
 (`--scope`, `--ports`, `--output-format`, `--output`, `--follow-redirects`), not in this file.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,7 +150,7 @@ pub enum Commands {
     /// Generate configuration file
     Config(ConfigCommand),
 
-    /// Manage sandbox environment
+    /// Manage per-language dependency environments (does not confine execution)
     Sandbox(SandboxCommand),
 
     /// MCP (Model Context Protocol) server for AI agent integration
@@ -2284,10 +2284,15 @@ pub enum ConfigAction {
 /// Sandbox management commands
 #[derive(Parser, Debug)]
 #[command(
-    about = "Manage sandboxed language environments",
-    long_about = "Initialize, manage, and configure isolated runtime environments for all supported \
-                  programming languages. The sandbox provides dependency isolation and security for \
-                  template execution across Python, JavaScript, Ruby, Perl, PHP, Rust, Go, and Java.",
+    about = "Manage per-language dependency environments",
+    long_about = "Initialize, manage, and configure per-language dependency environments for all \
+                  supported programming languages: Python, JavaScript, Ruby, Perl, PHP, Rust, Go, \
+                  and Java. This gives each runtime its own package directory, keeping template \
+                  dependencies off the system package managers.\n\n\
+                  This does NOT confine template execution. Templates execute as ordinary child \
+                  processes with the invoking user's privileges and full network and filesystem \
+                  access. Review templates before running them. For isolation, run cxg itself \
+                  inside a container or VM, as a non-privileged user.",
     after_help = "EXAMPLES:
   # Initialize sandbox with all languages
   cxg sandbox init
@@ -2316,35 +2321,38 @@ pub struct SandboxCommand {
     pub action: SandboxAction,
 }
 
-/// Sandbox environment management
+/// Dependency environment management
 ///
-/// CERT-X-GEN supports two types of sandboxes:
+/// Neither kind of environment below confines template execution. Templates execute as
+/// ordinary child processes with the invoking user's privileges and full network and
+/// filesystem access. Review templates before running them.
 ///
-/// 1. Docker Sandbox (RECOMMENDED - True Isolation):
-///    - Complete OS-level isolation using Docker containers
-///    - Fresh Python, Ruby, Node, Go, Java, etc. inside container
+/// CERT-X-GEN supports two kinds of dependency environment:
+///
+/// 1. Docker environment:
+///    - A container holding fresh Python, Ruby, Node, Go, Java, etc.
 ///    - Named environments (dev, test, prod)
-///    - Auto-enter on CLI start
-///    - Access to local network and files
+///    - An interactive shell inside the container via 'enter' — work done in that
+///      shell is contained by Docker in the ordinary way
+///    - Scans launched from your host still run on your host, not in the container
 ///    - Commands: create, enter, delete, set-default, info
 ///
-/// 2. Package Sandbox (Legacy - Package-Level Isolation):
-///    - Python venv, npm node_modules, gem isolation
+/// 2. Package environment:
+///    - Python venv, npm node_modules, gem directories
 ///    - Uses host system's language runtimes
-///    - Simple directory-based isolation
 ///    - Commands: init, status, install, clean
 ///
 /// Use 'cxg sandbox info' to check Docker availability.
-/// Use 'cxg sandbox create <name>' to create a Docker sandbox.
+/// Use 'cxg sandbox create <name>' to create a Docker environment.
 #[derive(Debug, Clone, Subcommand)]
 pub enum SandboxAction {
-    /// Initialize package-level sandbox (legacy mode)
+    /// Initialize package-level dependency environment
     ///
-    /// Creates isolated package directories for Python (venv), JavaScript (node_modules),
+    /// Creates separate package directories for Python (venv), JavaScript (node_modules),
     /// Ruby (gems), etc. This mode uses your host system's language runtimes.
     ///
-    /// Note: This is a lightweight alternative to Docker sandboxes. For true isolation,
-    /// use 'cxg sandbox create <name>' to create a Docker-based sandbox.
+    /// Note: this separates packages, not privileges. Templates still execute as ordinary
+    /// child processes with your privileges and full network and filesystem access.
     ///
     /// The init command is smart:
     /// - First run: Sets up all language environments and installs packages

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,89 @@ use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+/// Top-level config sections this build no longer reads.
+///
+/// `sandbox` held `enabled`, `memory_limit_mb`, `cpu_limit_percent`,
+/// `network_access` and `filesystem_access`. Nothing ever enforced any of
+/// them — the values were deserialized and, outside one unit test, never read.
+/// Unrelated to the `cxg sandbox` command, which manages per-language
+/// dependency environments and is unaffected.
+const OBSOLETE_SECTIONS: &[&str] = &["sandbox"];
+
+/// Report an obsolete section on stderr.
+///
+/// Loud on purpose: someone whose config says `sandbox.enabled: true` believes
+/// they are hardened. Dropping the keys silently would leave them believing it.
+fn warn_obsolete_section(section: &str, path: &Path) {
+    tracing::warn!(
+        "config file {} contains an obsolete `{}` section that has no effect",
+        path.display(),
+        section
+    );
+
+    if section == "sandbox" {
+        eprintln!(
+            "\n\
+              warning: {} contains a `sandbox:` section.\n\
+             \n\
+             These settings never took effect. `enabled`, `memory_limit_mb`,\n\
+             `cpu_limit_percent`, `network_access` and `filesystem_access` were\n\
+             parsed and then ignored — no code path has ever read them to confine\n\
+             anything. A config setting them was not protected by them.\n\
+             \n\
+             Templates execute as ordinary child processes with the invoking user's\n\
+             privileges and full network and filesystem access. Review templates\n\
+             before running them.\n\
+             \n\
+             Remove the `sandbox:` section from {}. For real isolation, run cxg\n\
+             itself inside a container or VM, as a non-privileged user.\n\
+             \n\
+             (The `cxg sandbox` command is unrelated and still works — it manages\n\
+             per-language dependency environments, not execution confinement.)\n",
+            path.display(),
+            path.display()
+        );
+    } else {
+        eprintln!(
+            "\nwarning: {} contains an obsolete `{}:` section that has no effect. \
+             Remove it.\n",
+            path.display(),
+            section
+        );
+    }
+}
+
+/// Top-level keys of a config document, or empty if it cannot be parsed as a map.
+fn top_level_keys(content: &str, path: &Path) -> Vec<String> {
+    match path.extension().and_then(|s| s.to_str()) {
+        Some("yaml") | Some("yml") => serde_yaml::from_str::<serde_yaml::Value>(content)
+            .ok()
+            .and_then(|v| {
+                v.as_mapping().map(|m| {
+                    m.keys()
+                        .filter_map(|k| k.as_str().map(String::from))
+                        .collect()
+                })
+            })
+            .unwrap_or_default(),
+        Some("toml") => toml::from_str::<toml::Value>(content)
+            .ok()
+            .and_then(|v| {
+                v.as_table()
+                    .map(|t| t.keys().map(|k| k.to_string()).collect())
+            })
+            .unwrap_or_default(),
+        Some("json") => serde_json::from_str::<serde_json::Value>(content)
+            .ok()
+            .and_then(|v| {
+                v.as_object()
+                    .map(|m| m.keys().map(|k| k.to_string()).collect())
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -16,27 +99,73 @@ pub struct Config {
     /// Execution configuration. Omitted → `ExecutionConfig::default()`.
     #[serde(default)]
     pub execution: ExecutionConfig,
-    /// Sandbox configuration. Omitted → `SandboxConfig::default()`.
-    #[serde(default)]
-    pub sandbox: SandboxConfig,
 }
 
 impl Config {
-    /// Load configuration from file
+    /// Load configuration from file.
+    ///
+    /// Obsolete sections are not an error: the file still loads, but each one
+    /// is reported on stderr (see [`Config::obsolete_sections`]) so nobody is
+    /// left believing a setting is doing something it never did.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
         let content = std::fs::read_to_string(path)
             .map_err(|e| Error::config(format!("Failed to read config file: {}", e)))?;
 
+        let config = Self::parse(&content, path)?;
+
+        for section in Self::obsolete_sections(&content, path) {
+            warn_obsolete_section(section, path);
+        }
+
+        Ok(config)
+    }
+
+    /// Parse configuration from a string, dispatching on the path's extension.
+    fn parse(content: &str, path: &Path) -> Result<Self> {
         match path.extension().and_then(|s| s.to_str()) {
-            Some("yaml") | Some("yml") => serde_yaml::from_str(&content)
+            Some("yaml") | Some("yml") => serde_yaml::from_str(content)
                 .map_err(|e| Error::config(format!("Invalid YAML config: {}", e))),
-            Some("toml") => toml::from_str(&content)
+            Some("toml") => toml::from_str(content)
                 .map_err(|e| Error::config(format!("Invalid TOML config: {}", e))),
-            Some("json") => serde_json::from_str(&content)
+            Some("json") => serde_json::from_str(content)
                 .map_err(|e| Error::config(format!("Invalid JSON config: {}", e))),
             _ => Err(Error::config("Unsupported config file format")),
         }
+    }
+
+    /// Top-level sections present in `content` that this build no longer reads.
+    ///
+    /// Unknown keys are ignored by the parser, so a config that still sets one
+    /// loads cleanly — which is exactly why callers must surface these.
+    pub fn obsolete_sections(content: &str, path: &Path) -> Vec<&'static str> {
+        let keys = top_level_keys(content, path);
+        OBSOLETE_SECTIONS
+            .iter()
+            .copied()
+            .filter(|section| keys.iter().any(|key| key == section))
+            .collect()
+    }
+
+    /// Load a configuration file and report which obsolete sections it contains.
+    ///
+    /// Same load semantics as [`Config::from_file`], but the caller gets the
+    /// list back instead of only seeing it on stderr.
+    pub fn from_file_reporting_obsolete<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<(Self, Vec<&'static str>)> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| Error::config(format!("Failed to read config file: {}", e)))?;
+
+        let config = Self::parse(&content, path)?;
+        let obsolete = Self::obsolete_sections(&content, path);
+
+        for section in &obsolete {
+            warn_obsolete_section(section, path);
+        }
+
+        Ok((config, obsolete))
     }
 
     /// Save configuration to file
@@ -169,58 +298,6 @@ impl Default for ExecutionConfig {
     }
 }
 
-/// Sandbox configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct SandboxConfig {
-    /// Enable sandbox
-    pub enabled: bool,
-    /// Memory limit (MB)
-    pub memory_limit_mb: usize,
-    /// CPU limit (percentage)
-    pub cpu_limit_percent: usize,
-    /// Network access control
-    pub network_access: NetworkAccess,
-    /// Filesystem access
-    pub filesystem_access: FilesystemAccess,
-}
-
-impl Default for SandboxConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            memory_limit_mb: 512,
-            cpu_limit_percent: 80,
-            network_access: NetworkAccess::Controlled,
-            filesystem_access: FilesystemAccess::ReadOnly,
-        }
-    }
-}
-
-/// Network access levels
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum NetworkAccess {
-    /// No network access
-    None,
-    /// Controlled access (only to targets)
-    Controlled,
-    /// Full network access
-    Full,
-}
-
-/// Filesystem access levels
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum FilesystemAccess {
-    /// No filesystem access
-    None,
-    /// Read-only access
-    ReadOnly,
-    /// Full access
-    Full,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,10 +342,57 @@ mod tests {
             config.execution.parallel_targets,
             ExecutionConfig::default().parallel_targets
         );
-        assert_eq!(config.sandbox.enabled, SandboxConfig::default().enabled);
 
         // A partial config still validates.
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_legacy_sandbox_section_still_loads_and_is_reported() {
+        // A config written against the old `sandbox` section must keep loading —
+        // breaking the load would be a worse outcome than the dead keys were.
+        let yaml = "network:\n  timeout_secs: 20\n\
+                    sandbox:\n  enabled: true\n  memory_limit_mb: 512\n  \
+                    cpu_limit_percent: 80\n  network_access: none\n  \
+                    filesystem_access: readonly\n";
+        let path = Path::new("cert-x-gen.yaml");
+
+        let config = Config::parse(yaml, path).expect("legacy config must still load");
+        assert_eq!(config.network.timeout_secs, 20);
+        assert!(config.validate().is_ok());
+
+        // ...but it must never load quietly.
+        assert_eq!(Config::obsolete_sections(yaml, path), vec!["sandbox"]);
+    }
+
+    #[test]
+    fn test_clean_config_reports_no_obsolete_sections() {
+        let yaml = "network:\n  timeout_secs: 20\n";
+        assert!(Config::obsolete_sections(yaml, Path::new("cert-x-gen.yaml")).is_empty());
+    }
+
+    #[test]
+    fn test_obsolete_sections_detected_in_toml_and_json() {
+        assert_eq!(
+            Config::obsolete_sections("[sandbox]\nenabled = true\n", Path::new("c.toml")),
+            vec!["sandbox"]
+        );
+        assert_eq!(
+            Config::obsolete_sections(r#"{"sandbox": {"enabled": true}}"#, Path::new("c.json")),
+            vec!["sandbox"]
+        );
+    }
+
+    #[test]
+    fn test_generated_config_has_no_sandbox_section() {
+        // `cxg config generate` serializes Config::default(); it must not put the
+        // section back into every new config file.
+        let yaml = serde_yaml::to_string(&Config::default()).expect("serialize");
+        assert!(
+            !yaml.contains("sandbox"),
+            "generated config still emits a sandbox section:\n{}",
+            yaml
+        );
     }
 
     #[test]

--- a/src/engine/README.md
+++ b/src/engine/README.md
@@ -228,19 +228,25 @@ The `common.rs` file contains shared utilities used by multiple engines:
 
 ## Security Considerations
 
-### Sandboxing
+### No engine confines template execution
 
-- **YAML:** Safe (declarative, no code execution)
-- **Scripting engines:** Requires sandboxing for untrusted templates
-- **Compiled engines:** Requires code review before compilation
+Templates execute as ordinary child processes with the invoking user's privileges and full
+network and filesystem access. Review templates before running them.
 
-### Resource Limits
+- **YAML:** Declarative, no arbitrary code execution
+- **Scripting engines:** Run the interpreter directly — untrusted templates get your privileges
+- **Compiled engines:** Compile and run native code — review before compilation
 
-All engines should implement:
-- Timeout limits
-- Memory limits
+Isolation for untrusted templates must come from outside cxg: a container, a VM, or an
+unprivileged user with host-applied cgroup and network limits.
+
+### Limits engines do apply
+
+- Per-template timeouts
+- Concurrent execution limits (executor semaphore)
 - Network rate limiting
-- Concurrent execution limits
+
+No engine applies memory or CPU limits.
 
 ## Testing
 
@@ -248,7 +254,6 @@ Each engine should have:
 - Unit tests for core functionality
 - Integration tests with sample templates
 - Performance benchmarks
-- Security tests for sandboxing
 
 ## Future Enhancements
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,17 +109,6 @@ pub enum Error {
     #[error("Scheduler error: {0}")]
     Scheduler(String),
 
-    /// Resource limit exceeded
-    #[error("Resource limit exceeded: {resource} (limit: {limit}, current: {current})")]
-    ResourceLimitExceeded {
-        /// Resource type
-        resource: String,
-        /// Limit value
-        limit: String,
-        /// Current value
-        current: String,
-    },
-
     /// Timeout error
     #[error("Operation timed out after {duration}")]
     Timeout {
@@ -134,10 +123,6 @@ pub enum Error {
     /// Command execution error
     #[error("Command execution error: {0}")]
     Command(String),
-
-    /// Sandbox violation
-    #[error("Sandbox violation: {0}")]
-    SandboxViolation(String),
 
     /// Rate limit exceeded
     #[error("Rate limit exceeded: {0}")]
@@ -294,20 +279,6 @@ impl Error {
         }
     }
 
-    /// Create a resource limit exceeded error
-    pub fn resource_limit<R, L, C>(resource: R, limit: L, current: C) -> Self
-    where
-        R: Into<String>,
-        L: Into<String>,
-        C: Into<String>,
-    {
-        Error::ResourceLimitExceeded {
-            resource: resource.into(),
-            limit: limit.into(),
-            current: current.into(),
-        }
-    }
-
     /// Create a command execution error
     pub fn command<S: Into<String>>(message: S) -> Self {
         Error::Command(message.into())
@@ -315,13 +286,7 @@ impl Error {
 
     /// Check if error is fatal (should stop execution)
     pub fn is_fatal(&self) -> bool {
-        matches!(
-            self,
-            Error::Internal(_)
-                | Error::SandboxViolation(_)
-                | Error::ResourceLimitExceeded { .. }
-                | Error::Coordinator(_)
-        )
+        matches!(self, Error::Internal(_) | Error::Coordinator(_))
     }
 
     /// Check if error is retryable

--- a/src/main.rs
+++ b/src/main.rs
@@ -2954,9 +2954,21 @@ fn run_config_command(cmd: cli::ConfigCommand) -> Result<()> {
             Ok(())
         }
         ConfigAction::Validate { config } => {
-            let cfg = Config::from_file(&config)?;
+            // `from_file_reporting_obsolete` prints the detail for each obsolete
+            // section; a file carrying one must not come back as simply valid.
+            let (cfg, obsolete) = Config::from_file_reporting_obsolete(&config)?;
             cfg.validate()?;
-            println!("Configuration is valid");
+
+            if obsolete.is_empty() {
+                println!("Configuration is valid");
+            } else {
+                println!(
+                    "Configuration is loadable, but contains {} obsolete section(s) with no \
+                     effect: {}. See the warning above; remove them.",
+                    obsolete.len(),
+                    obsolete.join(", ")
+                );
+            }
             Ok(())
         }
         ConfigAction::Show => {
@@ -3034,7 +3046,7 @@ async fn run_sandbox_command(cmd: cli::SandboxCommand) -> Result<()> {
                 {
                     term.write_line(&format!("\n{} Docker detected!", style("ℹ").blue()))?;
                     term.write_line(
-                        &"  For true OS-level isolation, consider using Docker sandboxes instead:"
+                        &"  For fresh runtimes instead of your host's, consider a Docker environment:"
                             .to_string(),
                     )?;
                     term.write_line(&format!(
@@ -3046,8 +3058,10 @@ async fn run_sandbox_command(cmd: cli::SandboxCommand) -> Result<()> {
                         style("cxg sandbox set-default my-env").yellow()
                     ))?;
                     term.write_line("")?;
-                    term.write_line(&"  This command (init) creates a package-level sandbox using your host's language runtimes.".to_string())?;
-                    term.write_line(&"  Docker sandboxes provide complete isolation with fresh runtimes inside containers.".to_string())?;
+                    term.write_line(&"  This command (init) creates package directories using your host's language runtimes.".to_string())?;
+                    term.write_line(&"  A Docker environment gives you fresh runtimes inside a container you can 'enter'.".to_string())?;
+                    term.write_line(&"  Neither confines template execution: templates run as ordinary child processes".to_string())?;
+                    term.write_line(&"  with your privileges and full network and filesystem access. Review templates first.".to_string())?;
                     term.write_line("")?;
                     term.write_line(&format!(
                         "  Run {} for more info.",
@@ -4030,17 +4044,26 @@ async fn check_and_enter_sandbox(cli: &Cli) -> Result<()> {
                 }
             }
 
-            // Verify container is ready
+            // Verify container is ready.
             sandbox
                 .exec_cli(&std::env::args().collect::<Vec<_>>())
                 .await?;
 
-            // Mark that we're using Docker sandbox context
-            // The actual command will execute with container awareness
-            tracing::info!("Command will execute with Docker sandbox context");
-
-            // Don't exit - let the command run with container context
-            // The sandbox module will use docker exec for operations
+            // The container is started, but this command is NOT relocated into it —
+            // `exec_cli` only checks readiness, and nothing downstream routes execution
+            // through `docker exec`. Say so, rather than let the started container imply
+            // the scan about to run is contained by it.
+            tracing::info!(
+                "Started Docker environment '{}'; this command still runs on the host",
+                name
+            );
+            eprintln!(
+                "note: Docker environment '{}' is running, but this command executes on the \
+                 host, not inside it. Templates run as ordinary child processes with your \
+                 privileges and full network and filesystem access. To run inside the \
+                 container, use `cxg sandbox enter {}`.",
+                name, name
+            );
         }
     }
 

--- a/src/sandbox/README.md
+++ b/src/sandbox/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The sandbox module provides isolated runtime environments for all supported programming languages in CERT-X-GEN. This ensures dependency isolation, security, and reproducibility across different systems.
+The sandbox module provides per-language **dependency environments** for all supported programming languages in CERT-X-GEN — a separate package directory per runtime, for reproducibility and to keep template dependencies off the system package managers.
+
+It is not a security boundary. Templates execute as ordinary child processes with the invoking user's privileges and full network and filesystem access. Review templates before running them. See [Security](#security) below.
 
 ## Architecture
 
@@ -385,24 +387,30 @@ if status.python_ready {
 
 - **Overhead**: ~10ms per execution
 - **No caching**: Scripts execute each time
-- **Isolation**: Each execution is isolated
 
 ## Security
 
-### Isolation Level
+### This module confines nothing
 
-- ✅ **Process isolation**: Separate processes
-- ✅ **Environment isolation**: Separate env vars
-- ✅ **Package isolation**: Separate dependencies
-- ⚠️ **Network access**: Not restricted
-- ⚠️ **File system**: Host file system access
+**Templates execute as ordinary child processes with the invoking user's privileges and full network and filesystem access. Review templates before running them.**
+
+What this module separates is *packages*, not privileges:
+
+- ✅ **Package separation**: Separate dependency directories per language
+- ✅ **Environment variables**: Per-language `VIRTUAL_ENV`, `GEM_HOME`, `GOPATH`, …
+- ❌ **Privileges**: Child processes inherit the invoking user's, unrestricted
+- ❌ **Network access**: Not restricted
+- ❌ **File system**: Full host file system access
+- ❌ **CPU / memory**: Not limited
 
 ### Recommendations
 
-1. **Use containers** for maximum isolation
+All confinement must come from outside cxg:
+
+1. **Use containers or VMs** for actual isolation
 2. **Run as unprivileged user**
-3. **Apply resource limits** (cgroups)
-4. **Restrict network access** (firewall)
+3. **Apply resource limits** (cgroups — cxg applies none of its own)
+4. **Restrict network access** (firewall / network namespaces)
 5. **Monitor execution** (logging)
 
 ## Troubleshooting
@@ -468,6 +476,4 @@ if has_python {
 
 ## Documentation
 
-- [User Guide](../../SANDBOX_GUIDE.md)
-- [Implementation Details](../../SANDBOX_IMPLEMENTATION.md)
-- [CLI Reference](../../CLI_REFERENCE.md)
+- [Dependency Environment Guide](../../docs/DEPENDENCY_ENVIRONMENTS.md)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,8 +1,8 @@
-//! Scheduler for template execution prioritization and resource management
+//! Scheduler for template execution prioritization
 
 use crate::config::Config;
 use crate::core::ScanJob;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::template::Template;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -122,77 +122,6 @@ impl Ord for PrioritizedTemplate {
     }
 }
 
-/// Resource manager for tracking and limiting resource usage
-#[derive(Debug)]
-pub struct ResourceManager {
-    /// Maximum memory limit (bytes)
-    max_memory_bytes: usize,
-    /// Current memory usage (bytes)
-    current_memory_bytes: usize,
-    /// Maximum CPU percentage
-    #[allow(dead_code)]
-    max_cpu_percent: usize,
-    /// Maximum concurrent operations
-    max_concurrent: usize,
-    /// Current concurrent operations
-    current_concurrent: usize,
-}
-
-impl ResourceManager {
-    /// Create a new resource manager
-    pub fn new(config: &Config) -> Self {
-        Self {
-            max_memory_bytes: config.sandbox.memory_limit_mb * 1024 * 1024,
-            current_memory_bytes: 0,
-            max_cpu_percent: config.sandbox.cpu_limit_percent,
-            max_concurrent: config.execution.parallel_templates,
-            current_concurrent: 0,
-        }
-    }
-
-    /// Check if resources are available
-    pub fn can_allocate(&self, memory_bytes: usize) -> bool {
-        self.current_memory_bytes + memory_bytes <= self.max_memory_bytes
-            && self.current_concurrent < self.max_concurrent
-    }
-
-    /// Allocate resources
-    pub fn allocate(&mut self, memory_bytes: usize) -> Result<()> {
-        if !self.can_allocate(memory_bytes) {
-            return Err(Error::resource_limit(
-                "memory or concurrency",
-                format!("{} MB", self.max_memory_bytes / 1024 / 1024),
-                format!("{} MB", self.current_memory_bytes / 1024 / 1024),
-            ));
-        }
-
-        self.current_memory_bytes += memory_bytes;
-        self.current_concurrent += 1;
-        Ok(())
-    }
-
-    /// Release resources
-    pub fn release(&mut self, memory_bytes: usize) {
-        self.current_memory_bytes = self.current_memory_bytes.saturating_sub(memory_bytes);
-        self.current_concurrent = self.current_concurrent.saturating_sub(1);
-    }
-
-    /// Get current memory usage
-    pub fn current_memory_mb(&self) -> usize {
-        self.current_memory_bytes / 1024 / 1024
-    }
-
-    /// Get maximum memory limit
-    pub fn max_memory_mb(&self) -> usize {
-        self.max_memory_bytes / 1024 / 1024
-    }
-
-    /// Get current concurrent operations
-    pub fn current_concurrent(&self) -> usize {
-        self.current_concurrent
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,18 +188,5 @@ mod tests {
 
         assert!(critical > high);
         assert!(high > medium);
-    }
-
-    #[test]
-    fn test_resource_manager() {
-        let config = Config::default();
-        let mut manager = ResourceManager::new(&config);
-
-        assert!(manager.can_allocate(100 * 1024 * 1024)); // 100 MB
-        assert!(manager.allocate(100 * 1024 * 1024).is_ok());
-        assert_eq!(manager.current_memory_mb(), 100);
-
-        manager.release(100 * 1024 * 1024);
-        assert_eq!(manager.current_memory_mb(), 0);
     }
 }


### PR DESCRIPTION
## What this removes and why

A template running under a config containing `sandbox.enabled: true` and `filesystem_access: readonly` read the process uid and username, listed 86 entries in `$HOME`, confirmed `.ssh` was readable, spawned a child process, and made an outbound DNS query — **identical to the run with no sandbox config at all**. `cxg config validate` reported that config as "Configuration is valid".

The five `sandbox.*` keys were deserialized and never read. Their only consumer was `ResourceManager`, which was never constructed outside its own unit test.

## Scope boundary: the command vs. the config section

**`cxg sandbox` — the command — is real and is not touched by this PR.** Verified before changing anything:

| | `cxg sandbox` command | `sandbox:` config section |
|---|---|---|
| Backed by | `src/sandbox/*`, `cert_x_gen::sandbox::SandboxConfig` (`root_dir`, `enable_python`, … `auto_init`) | `crate::config::SandboxConfig` (`enabled`, `memory_limit_mb`, …) |
| Persisted at | `<sandbox_root>/config.yaml` | the scan config file |
| Consumers | 20 subcommands, all functional | `ResourceManager::new` only — test-only |
| Status | **works** | **dead** |

The two `SandboxConfig` structs are unrelated types that share a name. Nothing in `src/sandbox/` references `crate::config`. `cxg sandbox init --languages python` builds a real venv and installs real packages into it; that still works after this change.

## Changes

**Removed** — `SandboxConfig` + its five keys, the `NetworkAccess` / `FilesystemAccess` enums, `ResourceManager` + its unit test, and the now-unreachable `Error::ResourceLimitExceeded`, `Error::SandboxViolation`, `Error::resource_limit`.

**Warns instead of silently dropping.** Removal alone would be worse than the status quo — someone who set these keys believes they are hardened. A config containing a `sandbox` section still **loads**, and now prints a warning stating the settings never took effect and that template execution is not confined. `cxg config validate` reports it as loadable-with-obsolete-sections rather than valid.

**Honest statement** added wherever template execution is described: templates execute as ordinary child processes with the invoking user's privileges and full network and filesystem access; review templates before running them.

**Docs** — `docs/SANDBOX_GUIDE.md` → `docs/DEPENDENCY_ENVIRONMENTS.md` (it documents the working command; see note below), plus README, SECURITY.md, ARCHITECTURE.md, USAGE_GUIDE.md, `cert-x-gen.example.yaml`, `src/sandbox/README.md`, `src/engine/README.md`.

## Found while sweeping — not anticipated by the brief

**The Docker auto-enter path is a second dead confinement surface.** With a default Docker environment and `auto_start`, `check_and_enter_sandbox` starts the container, calls `exec_cli(...)` — which only checks the container is running and returns `Ok(())` — then comments "the sandbox module will use docker exec for operations". Nothing does; `get_active_docker_sandbox()` has zero callers. Meanwhile the help text advertised "Complete OS-level isolation" and "Auto-enter on CLI start". The scan ran on the host, unconfined. cxg now says so explicitly. The container itself is real for `cxg sandbox enter`, and `docker run --memory/--cpus` limits genuinely apply to it — that code is correct and stays.

## Verification against a fresh build

- `cxg config generate` emits no sandbox section ✅
- a config containing `sandbox.*` still loads, and warns ✅ (scan path exits 0)
- `cxg config validate` on that config warns rather than reporting valid ✅
- `cxg sandbox --help` works; all 20 subcommands, all options, and the examples block are unchanged ✅
- dependency environments work end to end — real venv, `requests 2.34.2` installed into it ✅
- repo-wide grep returns only working-command references and the honest statement ✅
- `cargo check --lib` warning-clean; `cargo fmt --check` clean; 251 tests pass, 0 fail ✅

Four new tests cover: legacy config still loads and is reported, clean config stays quiet, detection across TOML/JSON, and that generated configs never re-emit the section.