### PR TITLE
ci(release): fail the release when the Homebrew tap update fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,13 +171,64 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Trigger Homebrew tap update
-        run: |
-          gh workflow run update-formula.yml \
-            -f version=${{ steps.version.outputs.VERSION }} \
-            -R Bugb-Technologies/homebrew-cxg
+      # `gh workflow run` returns 0 as soon as the dispatch is ACCEPTED, not when
+      # the tap workflow succeeds. That is why the tap silently stayed on 1.0.0
+      # through v1.1.1 and v1.2.0 while this job reported green every time: the
+      # tap-side push was rejected by its branch ruleset and nothing here looked.
+      #
+      # So: dispatch, find the run we just started, and block on its result.
+      # The run is identified by "newest run id that is not the one that existed
+      # before we dispatched" -- run ids increase monotonically, which avoids
+      # depending on clock agreement between this runner and GitHub.
+      - name: Trigger Homebrew tap update and wait for its result
         env:
           GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          TAP: Bugb-Technologies/homebrew-cxg
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+
+          before=$(gh run list -R "$TAP" --workflow=update-formula.yml \
+            --json databaseId --jq '.[0].databaseId // 0')
+
+          gh workflow run update-formula.yml -f version="$VERSION" -R "$TAP"
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            sleep 5
+            latest=$(gh run list -R "$TAP" --workflow=update-formula.yml \
+              --json databaseId --jq '.[0].databaseId // 0')
+            if [ "$latest" != "$before" ]; then
+              run_id="$latest"
+              break
+            fi
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "::error::Dispatched the tap update for v${VERSION} but no new run appeared within 150s."
+            exit 1
+          fi
+
+          echo "Tap run: https://github.com/${TAP}/actions/runs/${run_id}"
+          # --exit-status makes a failed tap run fail this job.
+          gh run watch "$run_id" -R "$TAP" --exit-status
+
+      # Independent of the workflow's own result: confirm the tap actually serves
+      # this version. Catches a run that goes green without moving the formula.
+      - name: Verify the tap formula is on this version
+        env:
+          GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          formula=$(gh api repos/Bugb-Technologies/homebrew-cxg/contents/Formula/cxg.rb \
+            --jq '.content' | base64 -d)
+          if ! echo "$formula" | grep -q "version \"${VERSION}\""; then
+            echo "::error::Tap formula is not at v${VERSION} after a successful update run."
+            echo "$formula" | grep -E '^\s*version ' || true
+            exit 1
+          fi
+          echo "Tap formula is at v${VERSION}."
 
   # Publish to crates.io
   crates:


### PR DESCRIPTION
The dispatching half of the Homebrew tap fix. Companion: Bugb-Technologies/homebrew-cxg#2 plus a ruleset change on the tap.

## Why three releases broke unnoticed

`gh workflow run` returns 0 as soon as the dispatch is **accepted** — not when the dispatched workflow succeeds. So "Update Homebrew Tap" went green on v1.1.1 and v1.2.0 while the tap-side `git push` was being rejected by the tap's branch ruleset (`GH013`), leaving `brew install cxg` serving **1.0.0** with three green releases stacked on top.

A job that cannot fail is not a check.

## This PR

**Dispatch, then block on the result.** The job finds the run it just started and waits with `gh run watch --exit-status`, so a tap failure fails the release.

Run identification is by *id*, not timestamp: capture the newest `update-formula.yml` run id before dispatching, then poll until a different one appears. Run ids increase monotonically, so this does not depend on the runner's clock agreeing with GitHub's — a timestamp filter would be quietly wrong under skew. Bounded at 30 × 5s, and a dispatch that never produces a run is itself an error rather than a silent pass.

**Then verify the artifact, not just the exit code.** A second step reads `Formula/cxg.rb` back from the tap and asserts `version "<this release>"`. That closes the remaining gap — a tap run that goes green without moving the formula. Given the track record, the workflow's own verdict is not sufficient evidence that the tap actually updated.

## Not in scope, still worth deciding

The `crates` job in this same file carries `continue-on-error: true` — the identical "cannot fail" pattern, on the one channel that is irreversible. I have not changed it here because flipping it changes release behaviour on a channel you may want to keep non-blocking. Flagging it rather than deciding it for you.