### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,28 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # No continue-on-error. crates.io is the irreversible channel — a version
+      # number, once consumed, can be yanked but never reused — so a failed
+      # publish is exactly the thing that must not pass silently. The previous
+      # `continue-on-error: true` is the same pattern that hid three consecutive
+      # Homebrew tap failures behind a green release.
+      #
+      # It was there to tolerate re-running a release whose version already
+      # exists. That case is now handled explicitly: an "already uploaded" error
+      # is reported and skipped, and every other failure fails the job.
       - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        continue-on-error: true  # Don't fail if version already exists
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if out=$(cargo publish 2>&1); then
+            echo "$out"
+            exit 0
+          fi
+          echo "$out"
+          if echo "$out" | grep -qiE "already (been )?uploaded|crate version .* is already"; then
+            echo "::notice::This version is already on crates.io; nothing to publish."
+            exit 0
+          fi
+          echo "::error::cargo publish failed."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,48 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-
-**The `sandbox` configuration section, which never took effect.**
-
-- Removed the `sandbox` section from the configuration schema: `sandbox.enabled`,
-  `sandbox.memory_limit_mb`, `sandbox.cpu_limit_percent`, `sandbox.network_access` and
-  `sandbox.filesystem_access`, along with the `NetworkAccess` and `FilesystemAccess` enums.
-
-  **These settings never did anything.** No code path has ever read them to confine, throttle,
-  or restrict template execution. Their only consumer was `ResourceManager`, which was never
-  constructed outside its own unit test. A configuration setting `sandbox.enabled: true` with
-  `filesystem_access: readonly` and `network_access: none` produced a run identical to one with
-  no sandbox configuration at all: the template read the process uid and username, listed the
-  user's home directory, confirmed `.ssh` was readable, spawned a child process, and made an
-  outbound DNS query. **Any configuration relying on these keys was not protected by them**, and
-  `cxg config validate` reported such a file as simply valid.
-
-  Templates execute as ordinary child processes with the invoking user's privileges and full
-  network and filesystem access. Review templates before running them. For isolation, run cxg
-  itself inside a container or VM, as a non-privileged user.
-
-- Removed `ResourceManager` from `src/scheduler.rs`, and the now-unreachable `Error`
-  variants `ResourceLimitExceeded` and `SandboxViolation` (with the `Error::resource_limit`
-  constructor) — no cxg error path can report a limit or a violation, because no limit or
-  confinement is enforced anywhere.
-
-### Changed
-
-- A configuration file that still contains a `sandbox` section **still loads**. cxg now prints
-  a warning on load, and `cxg config validate` reports the file as loadable-with-obsolete-sections
-  rather than valid, stating that the settings never took effect and that template execution is
-  not confined. Silently ignoring the keys would leave operators believing they are hardened.
-- `cxg sandbox` — the command that manages per-language dependency environments — is unaffected
-  and unchanged in behaviour. Its help text and docs no longer describe it as providing
-  "isolation" or "security": it separates packages, not privileges.
-- A started Docker environment with `auto_start` no longer implies the running command is
-  contained by it. cxg now says explicitly that the command executes on the host; use
-  `cxg sandbox enter` to work inside the container.
-- `docs/SANDBOX_GUIDE.md` renamed to `docs/DEPENDENCY_ENVIRONMENTS.md`, matching what it
-  documents.
-
-## [1.3.0] - 2026-08-12
+## [1.3.0] - 2026-08-13
 
 ### Added
 
@@ -119,6 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cxg search --format json | jq`. Explicit overrides remain: `CXG_NO_BANNER`, `--quiet`/`-q`.
 - Configuration sections are now optional. A partial config file loads, with omitted sections and
   omitted keys taking their compiled-in defaults.
+- A configuration file that still contains a `sandbox` section **still loads**. cxg now prints
+  a warning on load, and `cxg config validate` reports the file as loadable-with-obsolete-sections
+  rather than valid, stating that the settings never took effect and that template execution is
+  not confined. Silently ignoring the keys would leave operators believing they are hardened.
+- `cxg sandbox` — the command that manages per-language dependency environments — is unaffected
+  and unchanged in behaviour. Its help text and docs no longer describe it as providing
+  "isolation" or "security": it separates packages, not privileges.
+- A started Docker environment with `auto_start` no longer implies the running command is
+  contained by it. cxg now says explicitly that the command executes on the host; use
+  `cxg sandbox enter` to work inside the container.
+- `docs/SANDBOX_GUIDE.md` renamed to `docs/DEPENDENCY_ENVIRONMENTS.md`, matching what it
+  documents.
 
 ### Fixed
 - `cert-x-gen.example.yaml` now loads through the config parser. It previously failed to load on a
@@ -129,6 +100,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and stale claims were removed or corrected (see Notes below).
 
 ### Removed
+
+**The `sandbox` configuration section, which never took effect.**
+
+- Removed the `sandbox` section from the configuration schema: `sandbox.enabled`,
+  `sandbox.memory_limit_mb`, `sandbox.cpu_limit_percent`, `sandbox.network_access` and
+  `sandbox.filesystem_access`, along with the `NetworkAccess` and `FilesystemAccess` enums.
+
+  **These settings never did anything.** No code path has ever read them to confine, throttle,
+  or restrict template execution. Their only consumer was `ResourceManager`, which was never
+  constructed outside its own unit test. A configuration setting `sandbox.enabled: true` with
+  `filesystem_access: readonly` and `network_access: none` produced a run identical to one with
+  no sandbox configuration at all: the template read the process uid and username, listed the
+  user's home directory, confirmed `.ssh` was readable, spawned a child process, and made an
+  outbound DNS query. **Any configuration relying on these keys was not protected by them**, and
+  `cxg config validate` reported such a file as simply valid.
+
+  Templates execute as ordinary child processes with the invoking user's privileges and full
+  network and filesystem access. Review templates before running them. For isolation, run cxg
+  itself inside a container or VM, as a non-privileged user.
+
+- Removed `ResourceManager` from `src/scheduler.rs`, and the now-unreachable `Error`
+  variants `ResourceLimitExceeded` and `SandboxViolation` (with the `Error::resource_limit`
+  constructor) — no cxg error path can report a limit or a violation, because no limit or
+  confinement is enforced anywhere.
+
+**Dead configuration keys.**
+
 - **36 dead configuration keys** and the unused metrics module. Every one of these keys was parsed
   but had **no effect**. Existing config files that still set them **continue to load** — the keys
   are simply ignored.
@@ -153,7 +151,9 @@ Stated plainly so it produces no more false leads:
   changelog and the README, no execution path isolates or resource-limits templates: they run as
   ordinary child processes with the invoking user's privileges and full network and filesystem
   access. Run cxg inside a container or VM if you need isolation. (`cxg sandbox` manages
-  per-language *dependency* environments — it does not confine template execution.)
+  per-language *dependency* environments — it does not confine template execution.) The
+  `sandbox` config section that appeared to configure confinement is removed in this release,
+  and a config still carrying it now warns rather than loading silently — see **Removed**.
 - Nine `cxg scan` flags are accepted and silently ignored: `--protocol`, `--protocols`,
   `--threads`, `--stream`, `--resume`, `--distributed`, `--coordinator`, `--worker-id`,
   `--profile`. They are now grouped under a "Not Implemented" heading in `--help`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,20 @@ authors = ["CERT-X-GEN Core Team"]
 description = "Advanced Multi-Language Security Scanning Engine"
 license = "Apache-2.0"
 repository = "https://github.com/Bugb-Technologies/cert-x-gen"
+# The crate's front page on crates.io. Cargo would auto-detect README.md, but
+# declaring it keeps the front page from silently changing if the file is ever
+# renamed.
+readme = "README.md"
 keywords = ["security", "scanning", "vulnerability", "pentesting"]
 categories = ["command-line-utilities", "network-programming"]
+# Internal working notes — release deltas and design specs. Tracked in git, but
+# there is no reason to ship ~370K of them to every crates.io consumer.
+#
+# Do NOT extend this to pentest/ or templates/: both are build-time mandatory.
+# src/main.rs embeds pentest/ via include_dir!, and src/ai/prompt.rs embeds
+# templates/skeleton/* via include_str!, so excluding either makes the published
+# crate fail to compile.
+exclude = ["docs/_analysis", "docs/superpowers"]
 
 [[bin]]
 name = "cxg"


### PR DESCRIPTION
Release prep for **v1.3.0**. No tag — that stays manual.

## 1. CHANGELOG — `[Unreleased]` folded into `[1.3.0]`

PR #62's sandbox removal landed in `[Unreleased]` *after* the changelog PR had already written `[1.3.0]`. Since v1.3.0 has never been tagged, nothing has shipped under that number, so the content belongs in the release it will actually go out with.

Folded into the existing subsections rather than appended as a block:
- **Removed** — the sandbox config section and `ResourceManager` now sit alongside the 36 dead config keys, under their own sub-heading
- **Changed** — the legacy-config warning, the corrected `cxg sandbox --help` claims, the Docker auto-enter clarification, and the doc rename

I also reconciled the **Notes** bullet, which still said template execution isn't sandboxed without acknowledging the section was now gone — it would have read as contradicting **Removed**.

Date is **2026-08-13**, per instruction.

### Audit against `git log v1.2.0..HEAD`

I diffed the actual user-facing surface across all 136 commits rather than trusting commit subjects:

- **11 new flags** (`--target-type`, `--app-cmd`, `--app-binary`, `--host-scan-path`, `--oast-interactsh`, `--no-restart`, `--stall-timeout`, `--template-timeout`, `--ci`, `--auth-dir`, `--storage-state`) — all documented
- **5 new env vars** (`BUGB_BRIDGE_URL`, `BUGB_BRIDGE_TOKEN`, `CXG_AUTH_STATE_<NAME>`, `CXG_CI`, `CXG_NO_NAG`) — all documented
- Subcommand set identical; nothing removed anywhere
- The ~90 `fix(pentest)`/`fix(electron)` commits refine features introduced *in this same release*, so they are correctly not listed separately. The two that touch output schemas (SARIF `cxg_` prefixing, `review_only`/`candidate_channels`) are intra-release, so no v1.2.0 consumer breaks.

Nothing user-facing is missing.

## 2. `exclude` — stop shipping internal notes

```toml
exclude = ["docs/_analysis", "docs/superpowers"]
```

~370K of release deltas and design specs were going to every crates.io consumer.

**`pentest/` and `templates/skeleton/` are deliberately NOT excluded, and must never be** — `src/main.rs` embeds `pentest/` via `include_dir!`, and `src/ai/prompt.rs` embeds `templates/skeleton/*` via `include_str!`. Excluding either publishes a crate that cannot compile. There's a comment on the `exclude` key saying so, because the next person to trim the package is exactly who needs to know.

Verified three ways:
| | before | after |
|---|---|---|
| `docs/_analysis` | 1 | **0** |
| `docs/superpowers` | 9 | **0** |
| `pentest/` | 87 | **87** |
| `templates/skeleton/` | 24 | **24** |

All 12 `include_str!` targets confirmed present by exact path, and `cargo publish --dry-run`'s verify step **compiles the packaged crate** — the real proof the embeds resolve.

## 3. `readme = "README.md"`

Declared explicitly. Cargo was auto-detecting it correctly, but declaring it means the crate's front page can't change silently if the file is renamed.

## 4. crates.io publish can now fail

Removed `continue-on-error: true`. crates.io is the **irreversible** channel — a consumed version number can be yanked but never reused — which made it the worst possible place for a step that cannot fail, and it is the same pattern that hid three consecutive Homebrew tap failures behind a green release.

The flag existed to tolerate re-running a release whose version already exists. That case is now handled explicitly: an "already uploaded" error is matched, reported as a notice, and skipped. **Every other failure now fails the job.**

## 5. `half` 2.7.0 → 2.7.1

Clears the yanked-crate warning from `cargo publish`. Dev-dependency only (`criterion → ciborium → ciborium-ll`), so nothing consumer-visible.

## Verification

- **`cargo publish --dry-run`** — clean. The `half` yanked warning is gone; the only remaining line is `aborting upload due to dry run`, which is `--dry-run` itself, not a package warning.
- **Package** — 247 files / 3.9 MiB (1.0 MiB compressed) → **237 files / 3.5 MiB (914.1 KiB compressed)**
- **`cxg --version`** → `cxg 1.3.0`, single line
- **Suite** — 251 passed, 0 failed; `cargo fmt --check` clean

## Not included

The Homebrew tap fix is separate and still open: #63 here, plus Bugb-Technologies/homebrew-cxg#2 and a tap ruleset change. **The tap is still on 1.0.0** — tagging v1.3.0 before that lands means `brew install` continues serving 1.0.0, and the release job will now correctly fail on it rather than reporting green.