### PR TITLE
feat(build): cxg build --instrument, the Rust overflow class, and manifest provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,17 @@ This file is the project's committed home for project-intrinsic agent knowledge:
   with `cc`; every test that uses one is `#[cfg(unix)]`, because the suite runs on Windows
   and there is no `cc` there.
 
+## The instrumented build assist (`cxg build --instrument`)
+
+- **Nightly Rust is a real dependency** (`-Zsanitizer` is unstable, no stable equivalent).
+  `tests/build_instrument.rs` explains itself and passes when nightly is missing rather than
+  failing the build; do not turn that into a hard failure. `src/build/cargo.rs`'s module doc
+  is the authority on the four load-bearing build flags.
+- The proof toy's manifest is checked in as
+  `tests/fixtures/build-instrument/cargo-manifest.toml`, **not** `Cargo.toml`, and the test
+  materialises it into a temp directory. Renaming it to `Cargo.toml` nests a package inside
+  the package under test and breaks `cargo build` and `cargo fmt --all`.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**The instrumentation component — building a target that can earn its verdict**
+- **`cxg build --instrument`** — a new verb that produces an *instrumented* build of a
+  compiled target, so the CLI Security Baseline's low-level classes reach real
+  `confirmed`/`refuted` verdicts instead of an honest skip. It detects the build system,
+  asks **rustc** what the target can do rather than guessing, builds into a private target
+  directory, **re-reads the binary it just produced**, and prints one JSON manifest.
+  Cargo/Rust is the only back end; every other recognised build system skips with
+  `build-system-not-implemented`.
+  `cxg scan` is untouched: it still inspects and refuses, and never builds anything.
+  Building runs the project's own build system as the invoking user and costs minutes and
+  gigabytes, which is why it is a verb rather than a scan flag.
+- **There is no path from "I could not instrument this" to "here is a binary."** Every
+  precondition failure is a `skipped` with a machine-readable reason —
+  `unknown-build-system`, `build-system-not-implemented(...)`,
+  `nightly-toolchain-unavailable(...)`, `sanitizer-unsupported-on-target`,
+  `sanitizer-not-verifiable(...)`, `binary-target-ambiguous(pass --bin NAME)`,
+  `rust-src-missing(...)`, `instrumented-build-failed(exit=N)` with the last 20 log lines,
+  and **`build-produced-no-instrumentation(wanted=… detected=…)`** for a build that reported
+  success and produced an artefact carrying none of what it was asked for.
+- **`rust-overflow-checks` instrumentation label and the `overflow` oracle.** Rust has no
+  UBSan — `-Zsanitizer=undefined` does not exist on any target — so the integer class
+  (CWE-190) is carried by `-C overflow-checks=on`, which cxg passes on every instrumented
+  build. The detector reads it from the symbol table
+  (`core::panicking::panic_const::panic_const_*_overflow`), and `overflow` is a
+  *build-dependent* oracle, so a template's overflow branch cannot claim a verdict on a
+  build where the check was compiled out.
+- **`cxg scan --instrumented-manifest <path>`** — provenance beats inspection. Where cxg
+  built the binary itself it already read the artefact back, and that record is used in
+  preference to re-sniffing the file, for the binary the manifest names and no other. A
+  manifest recording a *skipped* build is an error rather than a silent no-op. Omit the flag
+  and a scan behaves exactly as it did before.
+- Toolchain cost, stated plainly: **nightly Rust is required** for `-Zsanitizer`
+  (`rustup toolchain install nightly`). There is no stable equivalent. Where it is missing,
+  `cxg build` skips with an actionable reason and the proof tests explain themselves and
+  pass rather than failing a build over it.
+
 **The probe contract — driving a local binary and recording an honest verdict**
 - `--scope cli:///path/to/binary` — a scan target can be a locally-built executable rather
   than a network host. `CERT_X_GEN_TARGET_HOST` carries the binary path and the new

--- a/docs/ENGINE_ARCHITECTURE.md
+++ b/docs/ENGINE_ARCHITECTURE.md
@@ -303,11 +303,70 @@ nothing. An **interpreted CLI therefore always detects `none`** — see
 `@oracles` below for how a template whose oracles do not need a sanitizer still
 runs against one.
 
-cxg **inspects and refuses; it does not build the target.** Doing that
-honestly needs a per-project build recipe, and half-doing it produces exactly
-the confident false refutations this feature exists to prevent. Build the
-target with your language's instrumented profile — for C/C++,
-`-fsanitize=address -g`.
+`cxg scan` **inspects and refuses; it never builds the target.** Building runs
+the project's own build system — `build.rs`, `configure`, arbitrary `Makefile`
+recipes — as the invoking user, which is a different trust decision from
+reading a file, and it costs minutes and gigabytes. Both belong to a verb an
+operator types, not a flag a scan turns on. Build the target with your
+language's instrumented profile — for C/C++, `-fsanitize=address -g` — or use
+the build assist below.
+
+### `cxg build --instrument`
+
+```bash
+cxg build --instrument --project . --bin cxg --sanitizer address --manifest /tmp/m.json
+```
+
+The deliberate opt-in on the other side of that line. It detects the build
+system, asks **rustc** what the target can do rather than guessing, builds into
+a private target directory, **re-reads the produced binary**, and prints one
+JSON manifest. Cargo/Rust is the only back end today; every other recognised
+build system skips with `build-system-not-implemented`.
+
+**There is no path from "I could not instrument this" to "here is a binary."**
+Every precondition failure is a `skipped` carrying a machine-readable reason:
+
+| Reason | Meaning |
+| --- | --- |
+| `unknown-build-system` | no marker file matched, and the tree is not guessed at. The manifest lists what was looked for |
+| `build-system-not-implemented(cmake)` | recognised, no back end yet |
+| `nightly-toolchain-unavailable(install: …)` | `-Zsanitizer` is nightly-only and there is no stable equivalent |
+| `sanitizer-unsupported-on-target` | rustc's own `supported-sanitizers` for this triple does not list it — MSan and LSan are absent on `aarch64-apple-darwin`. Asking for **UBSan** lands here with a note: `-Zsanitizer=undefined` does not exist on *any* Rust target |
+| `sanitizer-not-verifiable(cfi)` | rustc supports it, but no symbol marker distinguishes the build, and cxg does not report instrumentation it cannot read back out of the artefact |
+| `binary-target-ambiguous(pass --bin NAME)` | several binary targets and no way to know which is the CLI under test |
+| `instrumented-build-failed(exit=N)` | with the last 20 lines of the build log |
+| **`build-produced-no-instrumentation(wanted=… detected=…)`** | the build reported success and the artefact does not carry what was asked for |
+
+That last row is the one the design turns on. A build that accepted the flags
+and silently dropped them — a `Makefile` that assigns rather than appends
+`CFLAGS`, or a shell that exported `CARGO_ENCODED_RUSTFLAGS` — still links,
+still runs, and is indistinguishable from an instrumented build until you look
+at the artefact. So cxg looks, with the same symbol-table scan the preflight
+uses, and skips rather than handing a scan a binary it could not vouch for.
+
+**Rust specifics.** `-Zsanitizer` needs nightly; `--target <host triple>` is
+passed even when not cross-compiling, so `RUSTFLAGS` does not reach the build
+scripts and proc-macro crates cargo compiles *and runs* on the host; the target
+directory is never the project's own, because `RUSTFLAGS` is part of cargo's
+fingerprint. Rust has **no UBSan**, so the integer class is carried by
+`-C overflow-checks=on`, which cxg passes on every instrumented build and which
+the detector reports as the `rust-overflow-checks` label (see the `overflow`
+oracle below). Budget several gigabytes per instrumented project.
+
+### `--instrumented-manifest`: provenance beats inspection
+
+```bash
+cxg scan --scope cli://$BIN --require-instrumentation --instrumented-manifest /tmp/m.json
+```
+
+Where cxg built the binary it does not have to re-derive what the binary
+carries: it passed the flags and read the artefact back before it was willing
+to call the build instrumented. That record is better evidence than a second
+sniff of the same file — it survives stripping and a copy away from the build
+tree — so a manifest is believed in preference to inspection, for the binary it
+names and no other. A manifest recording a *skipped* build is an error, not a
+silent no-op. **Omit the flag and a scan behaves exactly as it did before this
+existed.**
 
 ### Template annotations
 
@@ -316,7 +375,7 @@ Parsed exactly like the existing `@`-annotations, all optional:
 | Annotation | Example | Effect |
 | --- | --- | --- |
 | `@allow_nonzero_exit` | `true` | The template exits non-zero on purpose. A probe that successfully provokes a crash naturally does; without this cxg discards its stdout and the finding is lost |
-| `@oracles` | `asan, signal, exit` | How the template decides something is wrong. Vocabulary: `asan` `ubsan` `msan` `tsan` `signal` `exit` `exception` `assert` `timeout` `diff` `property` `detector` |
+| `@oracles` | `asan, signal, exit` | How the template decides something is wrong. Vocabulary: `asan` `ubsan` `msan` `tsan` `overflow` `signal` `exit` `exception` `assert` `timeout` `diff` `property` `detector` |
 | `@target_kinds` | `cli` | Which kinds the template accepts. **Absent means every kind** — do not add it for completeness, only when the template genuinely cannot handle other kinds |
 
 #### The `exception` oracle
@@ -347,6 +406,34 @@ findings of its own, and declared no status of its own: a template that reached
 its own verdict keeps it. It needs nothing from the build, so it also runs
 under `--require-instrumentation` against a target whose instrumentation is
 `none` — which is every interpreted CLI.
+
+#### The `overflow` oracle — the Rust integer class
+
+**Rust has no UBSan.** `-Zsanitizer=undefined` is not in rustc's vocabulary on
+any target, on any nightly, so a baseline class that declares `ubsan` is
+declaring something unreachable on every Rust build there will ever be. The
+equivalent check is `-C overflow-checks=on`, which turns an integer wrap into a
+panic; compile it out and the same program returns the same wrong number and
+exits **0**.
+
+That makes it exactly as build-dependent as a sanitizer, so `overflow` is a
+build-dependent oracle mapped to the `rust-overflow-checks` instrumentation
+label. A template's overflow branch is therefore gated the same way an ASan
+branch is and cannot claim a verdict on a build where the check was never
+compiled in.
+
+The label is read from the symbol table like every other: the check compiles in
+a call to `core::panicking::panic_const::panic_const_{add,sub,mul,neg,shl,shr}_overflow`,
+and those symbols are present if and only if the flag was passed. (`div` and
+the by-zero panics are emitted either way — they are hard errors, not overflow
+checks.) A build with the check on but no fallible arithmetic left after
+const-folding carries no such symbol and reads as uninstrumented, which is the
+safe direction: the template skips rather than claims.
+
+Reaching instead for a build-*independent* oracle such as `exception` would
+make the whole template read as build-independent and let it run — and refute —
+on an uninstrumented build, quietly undoing the preflight. That is why the
+integer class needs its own build-dependent oracle rather than borrowing one.
 
 ### Declaring an execution status
 

--- a/src/build/cargo.rs
+++ b/src/build/cargo.rs
@@ -1,0 +1,673 @@
+//! The cargo (Rust) back end.
+//!
+//! Rust is the immediate target and the only back end implemented. Four things
+//! about the build command are load bearing, and each is a defect if dropped:
+//!
+//! * **`+nightly`.** `-Zsanitizer` is an unstable flag. There is no stable
+//!   path and no `RUSTC_BOOTSTRAP` shortcut worth shipping, so nightly is this
+//!   component's one hard dependency -- and a machine without it gets an
+//!   actionable skip, not a clean build.
+//! * **`--target <host triple>`, even when not cross-compiling.** Without it
+//!   `RUSTFLAGS` reaches build scripts and proc-macro crates, which cargo
+//!   compiles *and runs on the host* during the build -- so the build itself
+//!   ends up executing under the sanitizer. Passing `--target` splits host
+//!   artefacts from target artefacts. This is the single cargo quirk most
+//!   likely to be missed.
+//! * **`-C debuginfo=2`.** A sanitizer report without symbols is a hex
+//!   address.
+//! * **`--target-dir`, never the project's own.** `RUSTFLAGS` is part of
+//!   cargo's fingerprint, so sharing a target directory means a full rebuild
+//!   in *both* directions every time the operator alternates between an
+//!   instrumented scan and their ordinary `cargo build`.
+//!
+//! The profile is left at `dev`: `-O` can optimise a planted defect away
+//! entirely, and a build that cannot show the defect is the thing this whole
+//! component exists to avoid handing to a scan.
+
+use super::{InstrumentRequest, Instrumented, Manifest, Skipped};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Sanitizers cxg is willing to build with, mapped to the label
+/// [`crate::engine::common::detect_instrumentation`] reports for each.
+///
+/// The list is short **because verification is not optional**. cxg refuses to
+/// report `instrumented` for something it cannot read back out of the produced
+/// binary, so a sanitizer with no marker in `INSTRUMENTATION_MARKERS` -- `cfi`,
+/// `safestack`, `realtime` -- is declined up front by name rather than after a
+/// build whose result cxg would then have to take on faith.
+pub const VERIFIABLE_SANITIZERS: &[(&str, &str)] =
+    &[("address", "asan"), ("thread", "tsan"), ("memory", "msan")];
+
+/// What rustc calls UBSan-shaped requests, none of which exist for Rust.
+const UBSAN_ALIASES: &[&str] = &["undefined", "ubsan"];
+
+/// The answer to "instrument this Rust project with UBSan".
+///
+/// Not a platform limitation to route around: `undefined` is not in rustc's
+/// `-Zsanitizer` vocabulary on **any** target, on any nightly. Answering with
+/// a generic "unsupported on this target" would send an operator looking for a
+/// platform that has it, so the note names the real answer instead.
+pub const UBSAN_NOTE: &str = "rustc-has-no-ubsan(no -Zsanitizer=undefined exists on any Rust \
+                              target; the Rust equivalent for the integer class is \
+                              -C overflow-checks=on, which panics -- see the overflow oracle)";
+
+/// The instrumentation label a Rust build carries because of
+/// `-C overflow-checks=on`.
+///
+/// cxg always passes that flag, so a project that turned the check off in
+/// `[profile.dev]` still gets it back.
+pub const OVERFLOW_CHECKS_LABEL: &str = "rust-overflow-checks";
+
+/// Build `project` with instrumentation, or explain why not.
+pub fn instrument(project: &Path, request: &InstrumentRequest) -> Manifest {
+    let context = |skipped: Skipped| -> Manifest {
+        Manifest::Skipped(Skipped {
+            build_system: Some("cargo".to_string()),
+            project: Some(project.to_path_buf()),
+            ..skipped
+        })
+    };
+
+    // --- 1. Toolchain preconditions.
+    if which("cargo").is_none() {
+        return context(Skipped::new("cargo-not-on-path"));
+    }
+    if which("rustup").is_none() {
+        return context(Skipped::new(
+            "rustup-not-on-path(needed to select a nightly toolchain)",
+        ));
+    }
+    if !nightly_is_installed() {
+        return context(Skipped::new(
+            "nightly-toolchain-unavailable(install: rustup toolchain install nightly)",
+        ));
+    }
+    let Some(triple) = host_triple() else {
+        return context(Skipped::new("host-triple-unavailable"));
+    };
+
+    // --- 2. Sanitizer capability, asked of rustc rather than guessed.
+    //
+    // It differs by platform -- aarch64-apple-darwin has no MSan and no LSan,
+    // x86_64-unknown-linux-gnu has both -- and a component that guessed would
+    // end up claiming an MSan verdict on a build that never had one.
+    let Some(supported) = supported_sanitizers(&triple) else {
+        return context(Skipped {
+            target: Some(triple.clone()),
+            ..Skipped::new(format!("sanitizer-capability-unknown(target={triple})"))
+        });
+    };
+
+    let plan = partition_requested(&request.sanitizers, &supported);
+    if plan.wanted.is_empty() {
+        let reason = plan.empty_reason();
+        return context(Skipped {
+            target: Some(triple),
+            requested: Some(request.sanitizers.join(",")),
+            supported: Some(supported.join(",")),
+            notes: plan.notes,
+            ..Skipped::new(reason)
+        });
+    }
+
+    // --- 3. What to build.
+    let manifest_path = project.join("Cargo.toml");
+    let bin = match request.bin.clone() {
+        Some(name) => name,
+        None => match sole_bin_target(&cargo_metadata(&manifest_path).unwrap_or_default()) {
+            Some(name) => name,
+            None => {
+                return context(Skipped::new("binary-target-ambiguous(pass --bin NAME)"));
+            }
+        },
+    };
+
+    if request.build_std && !rust_src_is_installed() {
+        return context(Skipped::new(
+            "rust-src-missing(needed by -Zbuild-std; rustup component add rust-src \
+             --toolchain nightly)",
+        ));
+    }
+
+    let target_dir = request
+        .out_dir
+        .clone()
+        .unwrap_or_else(|| project.join("target-instrumented"));
+    let rustflags = rustflags(&plan.wanted);
+
+    // --- 4. The build.
+    let mut command = Command::new("cargo");
+    command
+        .arg("+nightly")
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("--bin")
+        .arg(&bin)
+        .arg("--target")
+        .arg(&triple)
+        .arg("--target-dir")
+        .arg(&target_dir)
+        .env("RUSTFLAGS", &rustflags)
+        // CARGO_ENCODED_RUSTFLAGS takes precedence over RUSTFLAGS, so a shell
+        // that exported it would silently discard every flag above and cargo
+        // would build a perfectly ordinary, uninstrumented binary.
+        .env_remove("CARGO_ENCODED_RUSTFLAGS");
+    if request.build_std {
+        command.arg("-Zbuild-std");
+    }
+
+    let output = match command.output() {
+        Ok(output) => output,
+        Err(e) => {
+            return context(Skipped {
+                rustflags: Some(rustflags),
+                ..Skipped::new(format!("instrumented-build-not-runnable({e})"))
+            })
+        }
+    };
+    if !output.status.success() {
+        let code = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".to_string());
+        return context(Skipped {
+            rustflags: Some(rustflags),
+            build_log_tail: Some(log_tail(&output.stdout, &output.stderr)),
+            ..Skipped::new(format!("instrumented-build-failed(exit={code})"))
+        });
+    }
+
+    // `EXE_SUFFIX` rather than a bare name: cargo writes `<bin>.exe` on
+    // Windows, and looking for the wrong path there would report
+    // `instrumented-binary-not-found` for a build that succeeded.
+    let binary = target_dir
+        .join(&triple)
+        .join("debug")
+        .join(format!("{bin}{}", std::env::consts::EXE_SUFFIX));
+    if !binary.is_file() {
+        return context(Skipped {
+            binary: Some(binary.clone()),
+            rustflags: Some(rustflags),
+            ..Skipped::new(format!(
+                "instrumented-binary-not-found({})",
+                binary.display()
+            ))
+        });
+    }
+
+    // --- 5. Post-build verification -- the part that makes this honest.
+    //
+    // Re-read the binary that was just produced with the same symbol-table
+    // scan the scan preflight uses, and refuse to say `instrumented` unless
+    // what was asked for is actually in there. A build that accepted the flags
+    // and dropped them still links and still runs; the only way to know is to
+    // look at the artefact.
+    let detected = crate::engine::common::detect_instrumentation(&binary);
+    if let Some(reason) = verification_gap(&plan.wanted, &detected) {
+        return context(Skipped {
+            binary: Some(binary),
+            rustflags: Some(rustflags),
+            notes: plan.notes,
+            ..Skipped::new(reason)
+        });
+    }
+
+    Manifest::Instrumented(Instrumented {
+        build_system: "cargo".to_string(),
+        toolchain: "nightly".to_string(),
+        target: triple,
+        bin,
+        binary,
+        rustflags,
+        build_std: request.build_std,
+        instrumentation: detected,
+        unsupported_requested: plan.unsupported,
+        notes: plan.notes,
+    })
+}
+
+/// How a set of requested sanitizers splits against what the target can do.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SanitizerPlan {
+    /// Requested, supported by the target, and verifiable in the artefact.
+    pub wanted: Vec<String>,
+    /// Requested and not available here, including every UBSan alias.
+    pub unsupported: Vec<String>,
+    /// Requested and supported by rustc, but with no marker cxg can read back
+    /// out of the produced binary.
+    pub unverifiable: Vec<String>,
+    /// Human-readable explanations for the above.
+    pub notes: Vec<String>,
+}
+
+impl SanitizerPlan {
+    /// The skip reason when nothing survived the split.
+    ///
+    /// The two cases are genuinely different and an operator acts on them
+    /// differently: `sanitizer-unsupported-on-target` means "not here, maybe
+    /// elsewhere", `sanitizer-not-verifiable` means "cxg will not vouch for
+    /// this anywhere", and collapsing them would send someone hunting for a
+    /// platform that would not help.
+    pub fn empty_reason(&self) -> String {
+        if self.unsupported.is_empty() && !self.unverifiable.is_empty() {
+            format!("sanitizer-not-verifiable({})", self.unverifiable.join(","))
+        } else {
+            "sanitizer-unsupported-on-target".to_string()
+        }
+    }
+}
+
+/// Split the requested sanitizers against what this target supports.
+pub fn partition_requested(requested: &[String], supported: &[String]) -> SanitizerPlan {
+    let mut plan = SanitizerPlan::default();
+    let mut saw_ubsan = false;
+
+    for name in requested {
+        let name = name.trim().to_lowercase();
+        if name.is_empty() {
+            continue;
+        }
+        if UBSAN_ALIASES.contains(&name.as_str()) {
+            saw_ubsan = true;
+            push_unique(&mut plan.unsupported, "undefined");
+            continue;
+        }
+        if !supported.contains(&name) {
+            push_unique(&mut plan.unsupported, &name);
+            continue;
+        }
+        if !VERIFIABLE_SANITIZERS.iter().any(|(s, _)| *s == name) {
+            push_unique(&mut plan.unverifiable, &name);
+            continue;
+        }
+        push_unique(&mut plan.wanted, &name);
+    }
+
+    if saw_ubsan {
+        plan.notes.push(UBSAN_NOTE.to_string());
+    }
+    if !plan.unverifiable.is_empty() {
+        plan.notes.push(format!(
+            "cxg-cannot-verify({}): no symbol marker distinguishes this build, and cxg does not \
+             report instrumentation it cannot read back out of the artefact",
+            plan.unverifiable.join(",")
+        ));
+    }
+    plan
+}
+
+fn push_unique(into: &mut Vec<String>, value: &str) {
+    if !into.iter().any(|v| v == value) {
+        into.push(value.to_string());
+    }
+}
+
+/// The instrumentation label a sanitizer produces, for the labels cxg can
+/// verify.
+pub fn label_for(sanitizer: &str) -> Option<&'static str> {
+    VERIFIABLE_SANITIZERS
+        .iter()
+        .find(|(name, _)| *name == sanitizer)
+        .map(|(_, label)| *label)
+}
+
+/// The `RUSTFLAGS` value for a set of sanitizers.
+///
+/// `-C overflow-checks=on` is not a sanitizer, but it is Rust's answer to
+/// UBSan's integer check and it is set explicitly so a project that turned it
+/// off in `[profile.dev]` still gets it.
+pub fn rustflags(wanted: &[String]) -> String {
+    format!(
+        "-Zsanitizer={} -C debuginfo=2 -C force-frame-pointers=yes -C overflow-checks=on",
+        wanted.join(",")
+    )
+}
+
+/// Did the build actually produce what it was asked for?
+///
+/// Returns the skip reason when it did not. **Every** wanted sanitizer has to
+/// be present: a build asked for two and carrying one is not the build the
+/// operator is about to draw a conclusion from.
+pub fn verification_gap(wanted: &[String], detected: &[String]) -> Option<String> {
+    let labels: Vec<&str> = wanted.iter().filter_map(|s| label_for(s)).collect();
+    let missing: Vec<&str> = labels
+        .iter()
+        .copied()
+        .filter(|label| !detected.iter().any(|d| d == label))
+        .collect();
+    if missing.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "build-produced-no-instrumentation(wanted={} detected={})",
+        labels.join(","),
+        if detected.is_empty() {
+            "none".to_string()
+        } else {
+            detected.join(",")
+        }
+    ))
+}
+
+/// The sole binary target of a `cargo metadata --no-deps` document, or [`None`]
+/// when there is not exactly one.
+///
+/// Refusing to pick is the point. A Cargo workspace with four binaries gives
+/// cxg no way to know which one is the CLI under test, and choosing the first
+/// would instrument something the operator never meant to scan.
+pub fn sole_bin_target(metadata: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(metadata).ok()?;
+    let mut bins: Vec<String> = Vec::new();
+    for package in parsed.get("packages")?.as_array()? {
+        for target in package.get("targets")?.as_array()? {
+            let is_bin = target
+                .get("kind")
+                .and_then(|k| k.as_array())
+                .is_some_and(|kinds| kinds.iter().any(|k| k.as_str() == Some("bin")));
+            if is_bin {
+                if let Some(name) = target.get("name").and_then(|n| n.as_str()) {
+                    push_unique(&mut bins, name);
+                }
+            }
+        }
+    }
+    match bins.len() {
+        1 => bins.pop(),
+        _ => None,
+    }
+}
+
+/// Parse `supported-sanitizers` out of a `--print target-spec-json` document.
+pub fn parse_supported_sanitizers(target_spec_json: &str) -> Option<Vec<String>> {
+    let parsed: serde_json::Value = serde_json::from_str(target_spec_json).ok()?;
+    let listed = parsed.get("supported-sanitizers")?.as_array()?;
+    let sanitizers: Vec<String> = listed
+        .iter()
+        .filter_map(|s| s.as_str())
+        .map(|s| s.to_lowercase())
+        .collect();
+    if sanitizers.is_empty() {
+        None
+    } else {
+        Some(sanitizers)
+    }
+}
+
+/// The last 20 lines of a build's combined output, for a failure manifest.
+fn log_tail(stdout: &[u8], stderr: &[u8]) -> String {
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    );
+    let lines: Vec<&str> = combined.lines().collect();
+    let start = lines.len().saturating_sub(20);
+    let tail = lines[start..].join("\n");
+    // Bound it: a proc-macro backtrace can be megabytes on a single line.
+    const MAX_CHARS: usize = 4000;
+    let length = tail.chars().count();
+    if length <= MAX_CHARS {
+        return tail;
+    }
+    tail.chars().skip(length - MAX_CHARS).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Toolchain probes. Each shells out once and treats any failure as "no".
+// ---------------------------------------------------------------------------
+
+fn which(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let program = format!("{program}{}", std::env::consts::EXE_SUFFIX);
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(&program))
+        .find(|candidate| candidate.is_file())
+}
+
+fn nightly_is_installed() -> bool {
+    Command::new("rustup")
+        .args(["toolchain", "list"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .any(|line| line.starts_with("nightly"))
+        })
+}
+
+fn rust_src_is_installed() -> bool {
+    Command::new("rustup")
+        .args(["component", "list", "--toolchain", "nightly", "--installed"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .any(|line| line.starts_with("rust-src"))
+        })
+}
+
+fn host_triple() -> Option<String> {
+    let output = Command::new("rustup")
+        .args(["run", "nightly", "rustc", "-vV"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .map(|triple| triple.trim().to_string())
+}
+
+fn supported_sanitizers(triple: &str) -> Option<Vec<String>> {
+    let output = Command::new("rustup")
+        .args(["run", "nightly", "rustc", "-Zunstable-options", "--target"])
+        .arg(triple)
+        .args(["--print", "target-spec-json"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_supported_sanitizers(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn cargo_metadata(manifest_path: &Path) -> Option<String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| v.to_string()).collect()
+    }
+
+    /// The capability question is asked of rustc, never guessed, because the
+    /// answer differs by platform.
+    #[test]
+    fn reads_the_supported_sanitizers_rustc_reports() {
+        let spec = r#"{"arch":"aarch64","supported-sanitizers":["address","thread","cfi"]}"#;
+        assert_eq!(
+            parse_supported_sanitizers(spec),
+            Some(names(&["address", "thread", "cfi"]))
+        );
+        assert_eq!(
+            parse_supported_sanitizers(r#"{"arch":"wasm32"}"#),
+            None,
+            "a target that lists no sanitizers must not read as 'all of them'"
+        );
+        assert_eq!(parse_supported_sanitizers("not json"), None);
+    }
+
+    #[test]
+    fn keeps_only_sanitizers_the_target_supports() {
+        let plan = partition_requested(
+            &names(&["address", "memory"]),
+            &names(&["address", "thread", "cfi"]),
+        );
+        assert_eq!(plan.wanted, names(&["address"]));
+        assert_eq!(plan.unsupported, names(&["memory"]));
+    }
+
+    /// MSan on arm64 macOS: rustc's own list has neither `memory` nor `leak`,
+    /// so asking for it has to skip rather than build something that cannot
+    /// show what it was asked to show.
+    #[test]
+    fn msan_on_a_target_without_it_skips_by_name() {
+        let plan = partition_requested(&names(&["memory"]), &names(&["address", "thread", "cfi"]));
+        assert!(plan.wanted.is_empty());
+        assert_eq!(plan.empty_reason(), "sanitizer-unsupported-on-target");
+    }
+
+    /// **Rust has no UBSan.** `-Zsanitizer=undefined` does not exist on any
+    /// target, on any nightly, so the skip must say so rather than imply that
+    /// some other platform would have it.
+    #[test]
+    fn ubsan_on_rust_skips_with_the_reason_that_there_is_no_such_thing() {
+        for alias in UBSAN_ALIASES {
+            let plan =
+                partition_requested(&[alias.to_string()], &names(&["address", "thread", "cfi"]));
+            assert!(plan.wanted.is_empty(), "{alias} must not be buildable");
+            assert_eq!(plan.unsupported, names(&["undefined"]));
+            assert_eq!(plan.empty_reason(), "sanitizer-unsupported-on-target");
+            assert!(
+                plan.notes.iter().any(|n| n.contains("rustc-has-no-ubsan")),
+                "{alias} must carry the note naming the real answer: {:?}",
+                plan.notes
+            );
+            assert!(
+                plan.notes.iter().any(|n| n.contains("overflow-checks=on")),
+                "the note must point at the Rust equivalent"
+            );
+        }
+    }
+
+    /// A sanitizer rustc supports but cxg cannot read back out of the artefact
+    /// is declined up front, with its own reason: no platform would help.
+    #[test]
+    fn a_sanitizer_cxg_cannot_verify_is_declined_before_the_build() {
+        let plan = partition_requested(&names(&["cfi"]), &names(&["address", "cfi"]));
+        assert!(plan.wanted.is_empty());
+        assert_eq!(plan.unverifiable, names(&["cfi"]));
+        assert_eq!(plan.empty_reason(), "sanitizer-not-verifiable(cfi)");
+    }
+
+    #[test]
+    fn a_verifiable_sanitizer_survives_alongside_an_unverifiable_one() {
+        let plan = partition_requested(&names(&["address", "cfi"]), &names(&["address", "cfi"]));
+        assert_eq!(plan.wanted, names(&["address"]));
+        assert_eq!(plan.unverifiable, names(&["cfi"]));
+    }
+
+    #[test]
+    fn every_verifiable_sanitizer_maps_to_a_label_the_detector_reports() {
+        for (name, label) in VERIFIABLE_SANITIZERS {
+            assert_eq!(label_for(name), Some(*label));
+        }
+        assert_eq!(label_for("cfi"), None);
+    }
+
+    #[test]
+    fn the_build_flags_carry_debug_info_and_the_overflow_check() {
+        let flags = rustflags(&names(&["address"]));
+        assert!(flags.contains("-Zsanitizer=address"), "{flags}");
+        assert!(flags.contains("-C debuginfo=2"), "{flags}");
+        assert!(flags.contains("-C force-frame-pointers=yes"), "{flags}");
+        // Rust's answer to UBSan's integer check, set explicitly so a project
+        // that disabled it in [profile.dev] gets it back.
+        assert!(flags.contains("-C overflow-checks=on"), "{flags}");
+        assert_eq!(
+            rustflags(&names(&["address", "thread"])),
+            rustflags(&names(&["address", "thread"])),
+            "the flag string must be deterministic"
+        );
+        assert!(rustflags(&names(&["address", "thread"])).contains("-Zsanitizer=address,thread"));
+    }
+
+    /// **The case the whole component exists for.** A build can accept the
+    /// flags, report success, link, run -- and carry no instrumentation at
+    /// all. There is no path from that to `instrumented`.
+    #[test]
+    fn a_build_that_silently_dropped_the_flags_is_refused() {
+        assert_eq!(
+            verification_gap(&names(&["address"]), &[]),
+            Some("build-produced-no-instrumentation(wanted=asan detected=none)".to_string())
+        );
+        assert_eq!(
+            verification_gap(&names(&["address"]), &names(&["debug-info"])),
+            Some("build-produced-no-instrumentation(wanted=asan detected=debug-info)".to_string())
+        );
+    }
+
+    /// A build asked for two sanitizers and carrying one is not the build the
+    /// operator is about to draw a conclusion from.
+    #[test]
+    fn a_partially_instrumented_build_is_refused_too() {
+        assert_eq!(
+            verification_gap(&names(&["address", "thread"]), &names(&["asan"])),
+            Some("build-produced-no-instrumentation(wanted=asan,tsan detected=asan)".to_string())
+        );
+    }
+
+    #[test]
+    fn a_verified_build_passes_verification() {
+        assert_eq!(
+            verification_gap(&names(&["address"]), &names(&["asan", "debug-info"])),
+            None
+        );
+        assert_eq!(
+            verification_gap(
+                &names(&["address", "thread"]),
+                &names(&["asan", "debug-info", "tsan"])
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn infers_the_binary_target_when_a_project_has_exactly_one() {
+        let metadata = r#"{"packages":[{"targets":[
+            {"kind":["lib"],"name":"toy"},
+            {"kind":["bin"],"name":"toy"}
+        ]}]}"#;
+        assert_eq!(sole_bin_target(metadata), Some("toy".to_string()));
+    }
+
+    /// A workspace with four binaries -- the real shape that provoked this --
+    /// gives cxg no way to know which one is the CLI. Naming the flag that
+    /// resolves it beats instrumenting something nobody asked for.
+    #[test]
+    fn refuses_to_choose_between_several_binary_targets() {
+        let metadata = r#"{"packages":[
+            {"targets":[{"kind":["bin"],"name":"app"},{"kind":["bin"],"name":"helper"}]},
+            {"targets":[{"kind":["bin"],"name":"tool"}]}
+        ]}"#;
+        assert_eq!(sole_bin_target(metadata), None);
+    }
+
+    #[test]
+    fn a_project_with_no_binary_target_is_also_ambiguous() {
+        let metadata = r#"{"packages":[{"targets":[{"kind":["lib"],"name":"toy"}]}]}"#;
+        assert_eq!(sole_bin_target(metadata), None);
+        assert_eq!(sole_bin_target("not json"), None);
+    }
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,0 +1,429 @@
+//! White-box build assist: produce an **instrumented** build of a target, or
+//! say honestly why one could not be produced.
+//!
+//! `cxg scan` inspects a binary and refuses; it never builds the target. This
+//! module is the deliberate opt-in on the other side of that line, reached
+//! only through the separate `cxg build --instrument` verb. Building a project
+//! runs that project's build system -- `build.rs`, `configure`, arbitrary
+//! `Makefile` recipes -- as the invoking user, which is a different trust
+//! decision from reading a file, and it costs minutes and gigabytes. Both are
+//! reasons it is a verb an operator types rather than a flag a scan turns on.
+//!
+//! # The honest-failure boundary
+//!
+//! **There is no path from "I could not instrument this" to "here is a
+//! binary".** Every precondition failure is a [`Skipped`] carrying a
+//! machine-readable reason, and the last check is the one that earns the
+//! phrase: after a build that reported success, cxg **re-reads the binary it
+//! just produced** with the same symbol-table scan the scan preflight uses
+//! ([`crate::engine::common::detect_instrumentation`]) and refuses to report
+//! `instrumented` unless the instrumentation it asked for is actually in
+//! there. A build system that accepted the flags and silently dropped them --
+//! a `Makefile` that assigns rather than appends `CFLAGS` is the classic --
+//! still links, still runs, and is indistinguishable from an instrumented
+//! build until you look at the artefact. That case is
+//! `build-produced-no-instrumentation`, and it skips.
+
+pub mod cargo;
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// A build system cxg knows how to recognise.
+///
+/// Recognising one is not the same as being able to instrument it: only
+/// [`BuildSystem::Cargo`] has a back end today, and every other arm skips with
+/// `build-system-not-implemented`, which is the honest answer rather than a
+/// hidden limitation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BuildSystem {
+    /// Rust, driven by `cargo`. The only back end implemented.
+    Cargo,
+    /// C/C++, configured by `cmake`.
+    Cmake,
+    /// Go, driven by the `go` tool.
+    Go,
+    /// C/C++, configured by a generated `configure` script.
+    Autotools,
+    /// C/C++, driven by a hand-written `Makefile`.
+    Make,
+    /// C/C++, configured by `meson`.
+    Meson,
+}
+
+impl BuildSystem {
+    /// The name this build system is reported under in a manifest.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BuildSystem::Cargo => "cargo",
+            BuildSystem::Cmake => "cmake",
+            BuildSystem::Go => "go",
+            BuildSystem::Autotools => "autotools",
+            BuildSystem::Make => "make",
+            BuildSystem::Meson => "meson",
+        }
+    }
+}
+
+/// Marker files that identify a build system, **in priority order**.
+///
+/// First match wins, and the order is load bearing for polyglot repositories.
+/// A Tauri application is a Cargo workspace with a `package.json`, a
+/// `postcss.config.js` and a `tailwind.config.js` beside it; the thing cxg has
+/// to instrument is the Rust binary, and putting `Cargo.toml` first is what
+/// gets that right with no special-casing.
+///
+/// A tree matching none of these is [`None`] -- never a guess. Guessing here
+/// ends in a build that produces the wrong artefact, or no artefact, and
+/// either way the operator is told something untrue about what was scanned.
+pub const BUILD_SYSTEM_MARKERS: &[(&str, BuildSystem)] = &[
+    ("Cargo.toml", BuildSystem::Cargo),
+    ("CMakeLists.txt", BuildSystem::Cmake),
+    ("go.mod", BuildSystem::Go),
+    ("configure", BuildSystem::Autotools),
+    ("Makefile", BuildSystem::Make),
+    ("makefile", BuildSystem::Make),
+    ("meson.build", BuildSystem::Meson),
+];
+
+/// Which build system this directory holds, or [`None`] for a tree cxg does
+/// not recognise.
+pub fn detect_build_system(project: &Path) -> Option<BuildSystem> {
+    BUILD_SYSTEM_MARKERS
+        .iter()
+        .find(|(marker, _)| project.join(marker).is_file())
+        .map(|(_, system)| *system)
+}
+
+/// The marker files [`detect_build_system`] looked for, for a skip manifest to
+/// report so the operator can see what would have been recognised.
+pub fn build_system_markers_looked_for() -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for (marker, _) in BUILD_SYSTEM_MARKERS {
+        if !seen.iter().any(|m| m == marker) {
+            seen.push((*marker).to_string());
+        }
+    }
+    seen
+}
+
+/// What the operator asked `cxg build --instrument` to do.
+#[derive(Debug, Clone)]
+pub struct InstrumentRequest {
+    /// The project directory whose build system will be driven.
+    pub project: PathBuf,
+    /// Which binary target to build. `None` means "infer, and refuse if the
+    /// project has more than one".
+    pub bin: Option<String>,
+    /// Sanitizers requested, in rustc's vocabulary (`address`, `thread`, ...).
+    pub sanitizers: Vec<String>,
+    /// Where to put the instrumented build tree. `None` means
+    /// `<project>/target-instrumented`.
+    ///
+    /// Never the project's own `target/`: `RUSTFLAGS` is part of cargo's
+    /// fingerprint, so sharing a target directory forces a full rebuild in
+    /// *both* directions every time the operator alternates between an
+    /// instrumented scan and their ordinary `cargo build`.
+    pub out_dir: Option<PathBuf>,
+    /// Rebuild `std` with the sanitizer (`-Zbuild-std`). Off by default;
+    /// mandatory for MSan, and merely better for ASan, which interposes the
+    /// allocator and so catches heap errors through a precompiled `std`.
+    pub build_std: bool,
+}
+
+/// The single JSON object `cxg build --instrument` prints.
+///
+/// Two shapes, distinguished by `status`, and nothing in between -- see the
+/// module documentation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum Manifest {
+    /// A binary was produced **and verified** to carry the instrumentation.
+    Instrumented(Instrumented),
+    /// No binary was produced, and `reason` says why.
+    Skipped(Skipped),
+}
+
+impl Manifest {
+    /// The instrumented half, or [`None`] when the build was skipped.
+    pub fn instrumented(&self) -> Option<&Instrumented> {
+        match self {
+            Manifest::Instrumented(i) => Some(i),
+            Manifest::Skipped(_) => None,
+        }
+    }
+}
+
+/// A build that ran, produced a binary, and had that binary verified.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Instrumented {
+    /// The build system that was driven (`cargo`).
+    pub build_system: String,
+    /// The toolchain that was selected (`nightly` -- `-Zsanitizer` is unstable
+    /// and there is no stable equivalent).
+    pub toolchain: String,
+    /// The target triple the build was pinned to.
+    pub target: String,
+    /// The binary target that was built.
+    pub bin: String,
+    /// Absolute path to the produced binary.
+    pub binary: PathBuf,
+    /// The exact `RUSTFLAGS` value the build ran with.
+    pub rustflags: String,
+    /// Whether `std` was rebuilt with the sanitizer.
+    pub build_std: bool,
+    /// The instrumentation labels **read back out of the produced binary**.
+    ///
+    /// This is what makes the manifest evidence rather than an intention: it
+    /// is what the artefact carries, not what cxg asked for. `cxg scan
+    /// --instrumented-manifest` trusts this in preference to re-sniffing the
+    /// file.
+    pub instrumentation: Vec<String>,
+    /// Sanitizers the operator asked for that this target cannot provide, kept
+    /// so a manifest records what was declined as well as what was done.
+    pub unsupported_requested: Vec<String>,
+    /// Human-readable notes, e.g. that Rust has no UBSan.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+}
+
+/// A build that did not happen, or happened and did not earn the word
+/// `instrumented`.
+///
+/// `reason` is the machine-readable half and is always present; every other
+/// field is context for the operator and is omitted when it does not apply.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Skipped {
+    /// The machine-readable reason, e.g.
+    /// `build-produced-no-instrumentation(wanted=asan detected=none)`.
+    pub reason: String,
+    /// The build system that was recognised, when one was.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_system: Option<String>,
+    /// The project directory that was examined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<PathBuf>,
+    /// The marker files that were looked for, for `unknown-build-system`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub looked_for: Vec<String>,
+    /// The target triple whose capability was consulted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// The sanitizers the operator asked for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested: Option<String>,
+    /// The sanitizers this target actually supports, as rustc reported them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported: Option<String>,
+    /// The binary that was produced but could not be verified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binary: Option<PathBuf>,
+    /// The `RUSTFLAGS` the build ran with, when it ran.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rustflags: Option<String>,
+    /// The tail of the build log, for `instrumented-build-failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_log_tail: Option<String>,
+    /// Human-readable notes, e.g. that Rust has no UBSan.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+}
+
+impl Skipped {
+    /// A skip carrying only its reason.
+    pub fn new(reason: impl Into<String>) -> Self {
+        Skipped {
+            reason: reason.into(),
+            ..Skipped::default()
+        }
+    }
+}
+
+/// Build `request`'s project with instrumentation, or explain why not.
+///
+/// Never fails: every way this can go wrong is a [`Manifest::Skipped`] with a
+/// reason, because a caller that got an error back would have to decide what
+/// to do with it, and the only correct decision is the one this module already
+/// made.
+pub fn instrument(request: &InstrumentRequest) -> Manifest {
+    let project = match request.project.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return Manifest::Skipped(Skipped {
+                project: Some(request.project.clone()),
+                ..Skipped::new(format!(
+                    "project-directory-not-found({})",
+                    request.project.display()
+                ))
+            })
+        }
+    };
+    if !project.is_dir() {
+        return Manifest::Skipped(Skipped {
+            project: Some(project.clone()),
+            ..Skipped::new(format!(
+                "project-directory-not-found({})",
+                project.display()
+            ))
+        });
+    }
+
+    let Some(system) = detect_build_system(&project) else {
+        return Manifest::Skipped(Skipped {
+            project: Some(project),
+            looked_for: build_system_markers_looked_for(),
+            ..Skipped::new("unknown-build-system")
+        });
+    };
+
+    match system {
+        BuildSystem::Cargo => cargo::instrument(&project, request),
+        // Designed but not built. Refusing by name is the honest-failure
+        // boundary doing its job: each of these needs its own flag plumbing
+        // (cmake's separate linker flags, make's assign-vs-append trap), and a
+        // back end that pretended to handle them would produce exactly the
+        // uninstrumented binary the post-build verification exists to catch.
+        other => Manifest::Skipped(Skipped {
+            build_system: Some(other.as_str().to_string()),
+            project: Some(project),
+            ..Skipped::new(format!("build-system-not-implemented({})", other.as_str()))
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dir_with(files: &[&str]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("creating a project directory");
+        for file in files {
+            std::fs::write(dir.path().join(file), b"").expect("writing a marker file");
+        }
+        dir
+    }
+
+    #[test]
+    fn recognises_each_build_system_by_its_marker_file() {
+        for (marker, expected) in BUILD_SYSTEM_MARKERS {
+            let dir = dir_with(&[marker]);
+            assert_eq!(
+                detect_build_system(dir.path()),
+                Some(*expected),
+                "{marker} should identify {expected:?}"
+            );
+        }
+    }
+
+    /// A Tauri application is a Cargo workspace with a JavaScript build beside
+    /// it, and a `Makefile` is a common convenience wrapper in a Rust repo.
+    /// The thing cxg has to instrument in both cases is the Rust binary.
+    #[test]
+    fn cargo_wins_over_every_other_marker_in_a_polyglot_tree() {
+        let dir = dir_with(&["Cargo.toml", "Makefile", "CMakeLists.txt", "go.mod"]);
+        assert_eq!(detect_build_system(dir.path()), Some(BuildSystem::Cargo));
+    }
+
+    /// The important direction: an unrecognised tree is not a guess.
+    #[test]
+    fn an_unrecognised_tree_is_not_guessed_at() {
+        let dir = dir_with(&["README.md", "setup.py", "package.json"]);
+        assert_eq!(detect_build_system(dir.path()), None);
+
+        let manifest = instrument(&InstrumentRequest {
+            project: dir.path().to_path_buf(),
+            bin: None,
+            sanitizers: vec!["address".to_string()],
+            out_dir: None,
+            build_std: false,
+        });
+        let Manifest::Skipped(skipped) = manifest else {
+            panic!("an unrecognised tree must skip");
+        };
+        assert_eq!(skipped.reason, "unknown-build-system");
+        assert!(skipped.looked_for.contains(&"Cargo.toml".to_string()));
+        assert!(skipped.looked_for.contains(&"meson.build".to_string()));
+    }
+
+    /// A directory marker must not read as a build system: `configure` and
+    /// `Makefile` are both plausible directory names.
+    #[test]
+    fn a_directory_named_like_a_marker_is_not_a_build_system() {
+        let dir = tempfile::tempdir().expect("creating a project directory");
+        std::fs::create_dir(dir.path().join("configure")).expect("creating the decoy directory");
+        assert_eq!(detect_build_system(dir.path()), None);
+    }
+
+    #[test]
+    fn a_recognised_build_system_with_no_back_end_names_itself() {
+        let dir = dir_with(&["CMakeLists.txt"]);
+        let manifest = instrument(&InstrumentRequest {
+            project: dir.path().to_path_buf(),
+            bin: None,
+            sanitizers: vec!["address".to_string()],
+            out_dir: None,
+            build_std: false,
+        });
+        let Manifest::Skipped(skipped) = manifest else {
+            panic!("cmake has no back end and must skip");
+        };
+        assert_eq!(skipped.reason, "build-system-not-implemented(cmake)");
+        assert_eq!(skipped.build_system.as_deref(), Some("cmake"));
+    }
+
+    #[test]
+    fn a_project_directory_that_does_not_exist_skips_by_name() {
+        let manifest = instrument(&InstrumentRequest {
+            project: PathBuf::from("/nonexistent/cxg-build-instrument-test"),
+            bin: None,
+            sanitizers: vec!["address".to_string()],
+            out_dir: None,
+            build_std: false,
+        });
+        let Manifest::Skipped(skipped) = manifest else {
+            panic!("a missing project directory must skip");
+        };
+        assert!(
+            skipped.reason.starts_with("project-directory-not-found("),
+            "unexpected reason: {}",
+            skipped.reason
+        );
+    }
+
+    /// The manifest is a wire format: `cxg scan --instrumented-manifest` reads
+    /// back what `cxg build --instrument` wrote, so the two shapes have to
+    /// survive a round trip and stay distinguishable by `status` alone.
+    #[test]
+    fn both_manifest_shapes_round_trip_through_json() {
+        let instrumented = Manifest::Instrumented(Instrumented {
+            build_system: "cargo".to_string(),
+            toolchain: "nightly".to_string(),
+            target: "aarch64-apple-darwin".to_string(),
+            bin: "toy".to_string(),
+            binary: PathBuf::from("/tmp/out/aarch64-apple-darwin/debug/toy"),
+            rustflags: "-Zsanitizer=address".to_string(),
+            build_std: false,
+            instrumentation: vec!["asan".to_string(), "debug-info".to_string()],
+            unsupported_requested: vec!["undefined".to_string()],
+            notes: vec!["rustc-has-no-ubsan".to_string()],
+        });
+        let json = serde_json::to_string(&instrumented).expect("serialising");
+        assert!(json.contains(r#""status":"instrumented""#), "{json}");
+        assert_eq!(
+            serde_json::from_str::<Manifest>(&json).expect("deserialising"),
+            instrumented
+        );
+
+        let skipped = Manifest::Skipped(Skipped::new("nightly-toolchain-unavailable"));
+        let json = serde_json::to_string(&skipped).expect("serialising");
+        assert_eq!(
+            json, r#"{"status":"skipped","reason":"nightly-toolchain-unavailable"}"#,
+            "a bare skip must not carry empty context fields"
+        );
+        assert_eq!(
+            serde_json::from_str::<Manifest>(&json).expect("deserialising"),
+            skipped
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,6 +135,24 @@ pub enum Commands {
     /// Run a security scan
     Scan(ScanArgs),
 
+    /// Build a target with instrumentation so a scan can earn its verdict
+    ///
+    /// `cxg scan` inspects a binary and refuses; it never builds the target.
+    /// This is the deliberate opt-in on the other side of that line, and it is
+    /// a separate verb rather than a scan flag for three reasons: building
+    /// runs the project's own build system (`build.rs`, `configure`, arbitrary
+    /// `Makefile` recipes) as you, which is a different trust decision from
+    /// reading a file; it costs minutes and gigabytes, which is a bad surprise
+    /// as a side effect and a fine one as a decision; and one instrumented
+    /// build feeds many scans.
+    ///
+    /// It prints one JSON manifest and nothing else. There is no path from
+    /// "I could not instrument this" to "here is a binary": every precondition
+    /// failure is a `skipped` with a machine-readable reason, and the last
+    /// check re-reads the binary that was just produced, so a build that
+    /// accepted the flags and silently dropped them skips rather than passes.
+    Build(BuildCommand),
+
     /// Manage templates
     Template(TemplateCommand),
 
@@ -186,6 +204,104 @@ pub enum Commands {
 
     /// Display version information
     Version,
+}
+
+/// `cxg build` — produce an instrumented build of a compiled target.
+///
+/// Cargo/Rust is the only back end today; every other recognised build system
+/// skips with `build-system-not-implemented`, which is the honest answer
+/// rather than a hidden limitation.
+// @g.comment -- "CLI options for the instrumented build-assist; drives the target's own build system"
+#[derive(Parser, Debug, Clone)]
+pub struct BuildCommand {
+    #[arg(
+        long,
+        help = "Build the target with sanitizer instrumentation",
+        long_help = "Build the target with sanitizer instrumentation. Required: `cxg build` has \
+                     no other mode, and demanding the word keeps room for one without changing \
+                     what this invocation means."
+    )]
+    pub instrument: bool,
+
+    #[arg(
+        long,
+        value_name = "DIR",
+        default_value = ".",
+        help = "Project directory whose build system to drive",
+        long_help = "Directory holding the project to build. The build system is detected from \
+                     its marker files in priority order (Cargo.toml, CMakeLists.txt, go.mod, \
+                     configure, Makefile, meson.build); Cargo.toml first, so a polyglot \
+                     repository such as a Tauri app instruments its Rust binary. A tree matching \
+                     none of them skips with unknown-build-system rather than being guessed at."
+    )]
+    pub project: PathBuf,
+
+    #[arg(
+        long,
+        value_name = "NAME",
+        help = "Which binary target to build",
+        long_help = "Which binary target to build. Inferred when the project has exactly one; a \
+                     workspace with several skips with binary-target-ambiguous rather than \
+                     instrumenting one nobody asked for."
+    )]
+    pub bin: Option<String>,
+
+    #[arg(
+        long,
+        value_name = "LIST",
+        default_value = "address",
+        help = "Comma-separated sanitizers to build with",
+        long_help = "Comma-separated sanitizers, in rustc's vocabulary: address, thread, memory. \
+                     Capability is asked of rustc per target rather than guessed, so a request \
+                     the target cannot serve (MSan on arm64 macOS) skips with \
+                     sanitizer-unsupported-on-target. Note that Rust has NO UBSan -- \
+                     -Zsanitizer=undefined does not exist on any target -- so `undefined` skips \
+                     with a note naming the Rust equivalent for the integer class, \
+                     -C overflow-checks=on, which cxg passes on every instrumented build anyway."
+    )]
+    pub sanitizer: String,
+
+    #[arg(
+        long,
+        value_name = "DIR",
+        help = "Where to put the instrumented build tree",
+        long_help = "Where to put the instrumented build tree; defaults to \
+                     <project>/target-instrumented. Never the project's own target/: RUSTFLAGS \
+                     is part of cargo's fingerprint, so sharing one forces a full rebuild in \
+                     both directions every time you alternate between an instrumented scan and \
+                     ordinary work. Budget several gigabytes per instrumented project."
+    )]
+    pub out: Option<PathBuf>,
+
+    #[arg(
+        long,
+        help = "Rebuild std with the sanitizer (-Zbuild-std)",
+        long_help = "Rebuild std with the sanitizer. Needs the rust-src component. Mandatory for \
+                     MSan, whose uninstrumented std reports uninitialised reads everywhere, and \
+                     merely better for ASan, which interposes the allocator and so catches heap \
+                     errors through a precompiled std. Off by default."
+    )]
+    pub build_std: bool,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Also write the manifest to this file",
+        long_help = "Write the manifest to this file as well as to stdout. Hand it back to a \
+                     scan with `cxg scan --instrumented-manifest <path>` so the scan trusts what \
+                     cxg recorded at build time instead of re-inspecting the artefact."
+    )]
+    pub manifest: Option<PathBuf>,
+
+    #[arg(
+        short = 'q',
+        long,
+        help = "Print only the path of the instrumented binary",
+        long_help = "Print only the path of the instrumented binary, and nothing at all on a \
+                     skip, for `cxg scan --scope cli://$(cxg build --instrument --project . -q)`. \
+                     The exit status still distinguishes the two: 0 instrumented, 3 skipped."
+    )]
+    pub quiet: bool,
 }
 
 /// `cxg update` — self-update the binary from the latest GitHub release.
@@ -1748,6 +1864,23 @@ pub struct ScanArgs {
                      build the target."
     )]
     pub require_instrumentation: bool,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        help_heading = "Probe Input",
+        display_order = 56,
+        help = "Trust this cxg build --instrument manifest over re-inspecting the binary",
+        long_help = "Manifest written by `cxg build --instrument`, naming a binary and the \
+                     instrumentation cxg verified in it at build time. Provenance beats \
+                     inspection: cxg passed the flags and read the produced artefact back before \
+                     it was willing to call the build instrumented, and that record survives \
+                     stripping and a copy away from the build tree. The record applies only to \
+                     the binary the manifest names; every other target is inspected exactly as \
+                     before. Repeatable. Omit it and the scan behaves identically to one run \
+                     before this flag existed."
+    )]
+    pub instrumented_manifest: Vec<PathBuf>,
 
     #[arg(
         long,

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -438,7 +438,7 @@ pub fn build_env_vars(target: &Target, context: &Context) -> Result<HashMap<Stri
     // Tell the template what the build can actually reveal, so a probe never
     // has to guess whether "nothing happened" means "nothing is wrong".
     if matches!(target.protocol, crate::types::Protocol::Cli) {
-        let detected = detect_instrumentation(Path::new(&target.address));
+        let detected = instrumentation_for(Path::new(&target.address), context);
         env_vars.insert(
             "CERT_X_GEN_TARGET_INSTRUMENTATION".to_string(),
             if detected.is_empty() {
@@ -857,6 +857,53 @@ const INSTRUMENTATION_MARKERS: &[(&str, &str)] = &[
     ("__llvm_profile", "profile"),
 ];
 
+/// Symbols a **Rust** build carries when `-C overflow-checks=on` compiled the
+/// integer checks in, and the label cxg reports for them.
+///
+/// This is the Rust integer class, and it needs its own table for two reasons.
+///
+/// It needs to exist at all because **Rust has no UBSan**:
+/// `-Zsanitizer=undefined` is not in rustc's vocabulary on any target, so
+/// `ubsan` is unreachable on every Rust build there will ever be. The
+/// equivalent check is `-C overflow-checks=on`, which turns the wrap into a
+/// panic -- and compile it out and the same program returns the same wrong
+/// number and exits 0, which is exactly the silent false negative the
+/// preflight exists to refuse. It is therefore build-dependent in precisely
+/// the way a sanitizer is, and [`BUILD_DEPENDENT_ORACLES`] maps the `overflow`
+/// oracle onto this label.
+///
+/// It needs to be **matched as a substring** rather than a prefix because
+/// these are Rust items, so the symbol is mangled and the name is buried:
+/// `__RNvNtNtCs..._4core9panicking11panic_const24panic_const_mul_overflow`
+/// under v0, `_ZN4core9panicking11panic_const24panic_const_mul_overflowE`
+/// under the legacy scheme. A substring is still a fact about the symbol
+/// table, which is the property that matters -- prose cannot get in there.
+///
+/// The six listed are exactly the ones the flag gates, verified by compiling
+/// the same source both ways: `panic_const_div_overflow`,
+/// `panic_const_div_by_zero` and `panic_const_rem_by_zero` are emitted either
+/// way, because those are hard errors rather than overflow checks, and
+/// including them would report every Rust build as carrying the check.
+///
+/// The failure direction is **under**-reporting, which is the safe one: a
+/// build with the check on but no fallible arithmetic left after const-folding
+/// carries no such symbol and reads as uninstrumented, so a template gated on
+/// `overflow` skips rather than claims. Toolchains older than the
+/// `panic_const` family (pre-1.79) route the panic through a shared function
+/// with a string argument and likewise read as uninstrumented.
+const RUST_OVERFLOW_CHECK_MARKERS: &[&str] = &[
+    "panic_const_add_overflow",
+    "panic_const_sub_overflow",
+    "panic_const_mul_overflow",
+    "panic_const_neg_overflow",
+    "panic_const_shl_overflow",
+    "panic_const_shr_overflow",
+];
+
+/// The label [`RUST_OVERFLOW_CHECK_MARKERS`] reports, and the instrumentation
+/// `cxg build --instrument` records for `-C overflow-checks=on`.
+pub const RUST_OVERFLOW_CHECKS_LABEL: &str = "rust-overflow-checks";
+
 /// Section names that mean the build carries DWARF debug info, and so can
 /// report a file and a line rather than a bare address.
 ///
@@ -1134,6 +1181,41 @@ pub fn oracles_are_build_independent(declared: &[String]) -> bool {
         })
 }
 
+/// What instrumentation this target carries, preferring **provenance** over
+/// inspection.
+///
+/// When cxg built the binary itself -- `cxg build --instrument`, whose manifest
+/// the operator handed back with `cxg scan --instrumented-manifest` -- it does
+/// not have to re-derive the answer from the artefact. It passed the flags, it
+/// read the produced binary back before it was willing to call the build
+/// instrumented, and that record is strictly better evidence than a second
+/// sniff of the same file: it survives stripping, it survives a binary copied
+/// away from the build tree, and it can record a build fact no scan of the
+/// artefact could recover.
+///
+/// Falls back to [`detect_instrumentation`] for every binary cxg did not
+/// build, which is the overwhelmingly common case and the one that must keep
+/// behaving exactly as it did before this existed. A manifest naming some
+/// *other* binary changes nothing here.
+pub fn instrumentation_for(path: &Path, context: &Context) -> Vec<String> {
+    if !context.instrumentation_provenance.is_empty() {
+        let key = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .to_string();
+        if let Some(recorded) = context.instrumentation_provenance.get(&key) {
+            tracing::debug!(
+                "Target {:?} instrumentation comes from a build manifest: {}",
+                path,
+                recorded.join(",")
+            );
+            return recorded.clone();
+        }
+    }
+    detect_instrumentation(path)
+}
+
 /// Inspect a local executable and report which instrumentation it carries.
 ///
 /// Returns e.g. `["asan", "debug-info"]`. An **empty** vec is the important
@@ -1286,6 +1368,15 @@ fn scan_thin_object<'data, R: object::ReadRef<'data>>(
             if !found.contains(*label) && name.starts_with(marker.trim_start_matches('_')) {
                 found.insert((*label).to_string());
             }
+        }
+        // Rust's overflow checks are mangled Rust items, so the marker is in
+        // the middle of the symbol rather than at its start.
+        if !found.contains(RUST_OVERFLOW_CHECKS_LABEL)
+            && RUST_OVERFLOW_CHECK_MARKERS
+                .iter()
+                .any(|marker| name.contains(marker))
+        {
+            found.insert(RUST_OVERFLOW_CHECKS_LABEL.to_string());
         }
     };
     for symbol in object.symbols() {
@@ -1530,6 +1621,55 @@ pub(crate) mod object_fixtures {
         format!("extern void {symbol}(void);\nvoid (*const cxg_marker_ref)(void) = {symbol};\n")
     }
 
+    /// Compile a tiny Rust source into a **real** executable and hand back its
+    /// path.
+    ///
+    /// Rust's overflow checks are the one instrumentation label that only a
+    /// Rust build can carry, so its fixture has to be a Rust build. `rustc` is
+    /// not an extra dependency by any measure: it is compiling this test.
+    pub(crate) fn compile_rust(
+        dir: &Path,
+        name: &str,
+        source: &str,
+        flags: &[&str],
+    ) -> std::path::PathBuf {
+        let src = dir.join(format!("{name}.rs"));
+        std::fs::write(&src, source).expect("writing the fixture source");
+
+        let out = dir.join(name);
+        let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+        let built = std::process::Command::new(&rustc)
+            .args(flags)
+            .arg("-o")
+            .arg(&out)
+            .arg(&src)
+            .output()
+            .unwrap_or_else(|e| panic!("running {rustc}: {e}"));
+
+        assert!(
+            built.status.success(),
+            "compiling the {name} fixture failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&built.stdout),
+            String::from_utf8_lossy(&built.stderr),
+        );
+        out
+    }
+
+    /// A Rust source whose arithmetic **can** overflow, so the compiler has to
+    /// emit the check when it is asked for.
+    ///
+    /// Every operand comes from the process's own argv, which no constant
+    /// folding can see through: a program the optimiser can evaluate carries
+    /// no check either way and would prove nothing.
+    pub(crate) fn rust_fallible_arithmetic() -> String {
+        "fn main() {\n\
+         \x20   let n: i32 = std::env::args().count() as i32;\n\
+         \x20   let m: i32 = std::env::args().skip(1).count() as i32;\n\
+         \x20   println!(\"{} {} {}\", n + m, n - m, n * m);\n\
+         }\n"
+        .to_string()
+    }
+
     /// A C source with no marker in it at all, sized by `padding` bytes of
     /// ballast so two otherwise identical fixtures differ on disk.
     pub(crate) fn no_markers(padding: usize) -> String {
@@ -1543,7 +1683,9 @@ mod tests {
     use crate::types::{Context, Protocol, Target};
 
     #[cfg(unix)]
-    use super::object_fixtures::{compile_c, no_markers, references};
+    use super::object_fixtures::{
+        compile_c, compile_rust, no_markers, references, rust_fallible_arithmetic,
+    };
 
     #[test]
     fn build_env_vars_reports_target_kind_for_network_targets() {
@@ -1998,6 +2140,169 @@ mod tests {
         assert!(
             detect_instrumentation(&object).is_empty(),
             "a marker in a string constant is prose, not a build capability"
+        );
+    }
+
+    /// **The Rust integer class.** Rust has no UBSan, so the only thing that
+    /// makes an integer overflow observable is `-C overflow-checks=on`, and
+    /// the only honest way to gate a template's overflow branch is to know
+    /// whether that flag was passed. It is a real, readable build fact: the
+    /// check compiles in a call to `core::panicking::panic_const::*_overflow`,
+    /// which is a symbol.
+    ///
+    /// Both directions, on the same source, because one alone proves nothing:
+    /// a detector that always said yes would let a template refute on a build
+    /// where the same program returns the same wrong number and exits 0.
+    #[cfg(unix)]
+    #[test]
+    fn detects_rust_overflow_checks_only_when_the_flag_compiled_them_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = rust_fallible_arithmetic();
+
+        let with = compile_rust(
+            dir.path(),
+            "checks_on",
+            &source,
+            &["-C", "overflow-checks=on"],
+        );
+        assert!(
+            detect_instrumentation(&with).contains(&RUST_OVERFLOW_CHECKS_LABEL.to_string()),
+            "a build compiled with -C overflow-checks=on carries the check: {:?}",
+            detect_instrumentation(&with)
+        );
+
+        let without = compile_rust(
+            dir.path(),
+            "checks_off",
+            &source,
+            &["-C", "overflow-checks=off"],
+        );
+        assert!(
+            !detect_instrumentation(&without).contains(&RUST_OVERFLOW_CHECKS_LABEL.to_string()),
+            "a build with the check compiled OUT must not report it -- that is the false \
+             all-clear the preflight exists to refuse: {:?}",
+            detect_instrumentation(&without)
+        );
+    }
+
+    /// `overflow` is build-dependent, so a template that can only decide that
+    /// way is refused on a build that compiled the check out -- and allowed on
+    /// one that did not.
+    #[test]
+    fn the_overflow_oracle_is_gated_on_the_rust_overflow_check_label() {
+        let declared = vec!["overflow".to_string()];
+        assert_eq!(
+            unsupported_oracles(&declared, &["asan".to_string()]),
+            Some(vec!["overflow".to_string()]),
+            "an ASan-only build cannot decide the integer class"
+        );
+        assert_eq!(
+            unsupported_oracles(
+                &declared,
+                &["asan".to_string(), RUST_OVERFLOW_CHECKS_LABEL.to_string()]
+            ),
+            None
+        );
+        assert!(
+            !oracles_are_build_independent(&declared),
+            "overflow must not read as build-independent: that would let a template refute the \
+             integer class on a build where the check was never compiled in"
+        );
+    }
+
+    /// **Provenance beats inspection.** Where cxg built the binary itself it
+    /// already read the artefact back, and that record is authoritative.
+    #[test]
+    fn a_build_manifest_is_believed_in_preference_to_re_inspecting_the_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("toy");
+        std::fs::write(
+            &binary,
+            b"#!/bin/sh
+exit 0
+",
+        )
+        .unwrap();
+        let key = binary.canonicalize().unwrap().to_string_lossy().to_string();
+
+        // Inspection alone reports nothing for this file.
+        assert!(detect_instrumentation(&binary).is_empty());
+
+        let mut context = Context::default();
+        context.instrumentation_provenance.insert(
+            key,
+            vec!["asan".to_string(), RUST_OVERFLOW_CHECKS_LABEL.to_string()],
+        );
+        assert_eq!(
+            instrumentation_for(&binary, &context),
+            vec!["asan".to_string(), RUST_OVERFLOW_CHECKS_LABEL.to_string()]
+        );
+    }
+
+    /// The additive contract: a manifest naming some *other* binary changes
+    /// nothing, and no manifest at all is exactly today's behaviour.
+    #[test]
+    fn provenance_applies_only_to_the_binary_its_manifest_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("toy");
+        std::fs::write(
+            &binary,
+            b"#!/bin/sh
+exit 0
+",
+        )
+        .unwrap();
+
+        let mut context = Context::default();
+        assert_eq!(
+            instrumentation_for(&binary, &context),
+            detect_instrumentation(&binary),
+            "with no manifest, provenance must not change a single answer"
+        );
+
+        context
+            .instrumentation_provenance
+            .insert("/some/other/binary".to_string(), vec!["asan".to_string()]);
+        assert!(
+            instrumentation_for(&binary, &context).is_empty(),
+            "a manifest for another binary must not vouch for this one"
+        );
+    }
+
+    /// End to end at the wire level: a manifest reaches the template as
+    /// `CERT_X_GEN_TARGET_INSTRUMENTATION`, which is what a gated branch reads.
+    #[test]
+    fn build_env_vars_reports_the_instrumentation_a_manifest_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("toy");
+        std::fs::write(
+            &binary,
+            b"#!/bin/sh
+exit 0
+",
+        )
+        .unwrap();
+        let key = binary.canonicalize().unwrap().to_string_lossy().to_string();
+
+        let target = Target::new(binary.to_string_lossy().to_string(), Protocol::Cli);
+        let mut context = Context::default();
+        assert_eq!(
+            build_env_vars(&target, &context)
+                .unwrap()
+                .get("CERT_X_GEN_TARGET_INSTRUMENTATION")
+                .unwrap(),
+            "none"
+        );
+
+        context
+            .instrumentation_provenance
+            .insert(key, vec!["asan".to_string(), "debug-info".to_string()]);
+        assert_eq!(
+            build_env_vars(&target, &context)
+                .unwrap()
+                .get("CERT_X_GEN_TARGET_INSTRUMENTATION")
+                .unwrap(),
+            "asan,debug-info"
         );
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -189,7 +189,10 @@ impl Executor {
         // template's oracle check below.
         let instrumentation: Vec<String> = if matches!(target.protocol, crate::types::Protocol::Cli)
         {
-            crate::engine::common::detect_instrumentation(std::path::Path::new(&target.address))
+            crate::engine::common::instrumentation_for(
+                std::path::Path::new(&target.address),
+                &job.context,
+            )
         } else {
             Vec::new()
         };
@@ -405,7 +408,7 @@ impl Executor {
             return Some("target-not-found".to_string());
         }
 
-        let detected = crate::engine::common::detect_instrumentation(path);
+        let detected = crate::engine::common::instrumentation_for(path, context);
         if detected.is_empty() {
             Some(NO_INSTRUMENTATION.to_string())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 // Core modules
 pub mod ai;
 pub mod banner;
+pub mod build;
 pub mod config;
 pub mod core;
 pub mod csrf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,8 +125,10 @@ async fn run(cli: Cli) -> Result<()> {
         Some(Commands::Template(cmd)) if matches!(cmd.action, cli::TemplateAction::Update { .. })
     );
 
-    // Handle auto-update flags before running any command (skip for template update)
-    if !is_template_update {
+    // Handle auto-update flags before running any command (skip for template
+    // update, and for `build`, which needs no templates and whose stdout is a
+    // machine-readable manifest a first-run auto-install would pollute)
+    if !is_template_update && !matches!(&cli.command, Some(Commands::Build(_))) {
         handle_auto_update(&cli).await?;
     }
 
@@ -146,6 +148,9 @@ async fn run(cli: Cli) -> Result<()> {
     match command {
         Commands::Scan(args) => {
             run_scan(args, cli.config).await?;
+        }
+        Commands::Build(cmd) => {
+            run_build_command(cmd)?;
         }
         Commands::Template(cmd) => {
             run_template_command(cmd).await?;
@@ -221,6 +226,78 @@ fn release_target() -> Result<String> {
         }
     };
     Ok(format!("{os}-{arch}"))
+}
+
+/// Handle `cxg build --instrument` — produce an instrumented build, or say
+/// honestly why one could not be produced.
+///
+/// Prints one JSON manifest on stdout and nothing else (or, with `-q`, just
+/// the binary's path). The exit status carries the same answer for a shell:
+/// **0** the binary exists and was verified, **3** the build was skipped. A
+/// skip is not an error -- nothing went wrong, cxg simply refuses to hand back
+/// an artefact it could not vouch for -- so it does not take the error path,
+/// which is reserved for cxg itself failing.
+// @g.comment -- "drives the target project's own build system, which executes that project's build scripts as the invoking user"
+// @g.sink Commands.Build -- "executes `cargo build` in the operator-named project directory"
+fn run_build_command(cmd: cli::BuildCommand) -> Result<()> {
+    use cert_x_gen::build::{self, InstrumentRequest, Manifest};
+    use std::io::Write;
+
+    if !cmd.instrument {
+        return Err(Error::config(
+            "cxg build needs --instrument: it has no other mode".to_string(),
+        ));
+    }
+
+    let sanitizers: Vec<String> = cmd
+        .sanitizer
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if sanitizers.is_empty() {
+        return Err(Error::config(
+            "--sanitizer needs at least one sanitizer, e.g. --sanitizer address".to_string(),
+        ));
+    }
+
+    let manifest = build::instrument(&InstrumentRequest {
+        project: cmd.project.clone(),
+        bin: cmd.bin.clone(),
+        sanitizers,
+        out_dir: cmd.out.clone(),
+        build_std: cmd.build_std,
+    });
+
+    let rendered =
+        serde_json::to_string_pretty(&manifest).map_err(|e| Error::Serialization(e.to_string()))?;
+    if let Some(ref path) = cmd.manifest {
+        std::fs::write(path, format!("{rendered}\n")).map_err(|e| {
+            Error::config(format!("cannot write --manifest '{}': {e}", path.display()))
+        })?;
+    }
+
+    match &manifest {
+        Manifest::Instrumented(built) => {
+            if cmd.quiet {
+                println!("{}", built.binary.display());
+            } else {
+                println!("{rendered}");
+            }
+            Ok(())
+        }
+        Manifest::Skipped(skipped) => {
+            if cmd.quiet {
+                // Nothing on stdout: `cli://$(cxg build ... -q)` must not be
+                // handed a reason string as if it were a path.
+                eprintln!("cxg build: skipped: {}", skipped.reason);
+            } else {
+                println!("{rendered}");
+            }
+            let _ = std::io::stdout().flush();
+            std::process::exit(3);
+        }
+    }
 }
 
 /// Handle `cxg update` — self-replace the running binary with the latest GitHub release.
@@ -1559,7 +1636,68 @@ fn apply_probe_input(args: &cli::ScanArgs, context: &mut cert_x_gen::types::Cont
         );
     }
 
+    for path in &args.instrumented_manifest {
+        let (binary, instrumentation) = read_instrumented_manifest(path)?;
+        tracing::info!(
+            "Instrumentation provenance for {}: {} (from {})",
+            binary,
+            instrumentation.join(","),
+            path.display()
+        );
+        context
+            .instrumentation_provenance
+            .insert(binary, instrumentation);
+    }
+
     Ok(())
+}
+
+/// Read one `cxg build --instrument` manifest into a (binary, instrumentation)
+/// pair.
+///
+/// A manifest recording a **skipped** build is an error rather than a silent
+/// no-op. It names a build that did not happen, so a scan that accepted it and
+/// carried on would be inspecting some older artefact while the operator
+/// believed they had handed over provenance -- and the reason the build was
+/// skipped is exactly what they need to see.
+fn read_instrumented_manifest(path: &std::path::Path) -> Result<(String, Vec<String>)> {
+    use cert_x_gen::build::Manifest;
+
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        Error::config(format!(
+            "--instrumented-manifest '{}' is not readable: {e}",
+            path.display()
+        ))
+    })?;
+    let manifest: Manifest = serde_json::from_str(&raw).map_err(|e| {
+        Error::config(format!(
+            "--instrumented-manifest '{}' is not a cxg build manifest: {e}",
+            path.display()
+        ))
+    })?;
+
+    match manifest {
+        Manifest::Instrumented(built) => {
+            let binary = built
+                .binary
+                .canonicalize()
+                .unwrap_or_else(|_| built.binary.clone());
+            if built.instrumentation.is_empty() {
+                return Err(Error::config(format!(
+                    "--instrumented-manifest '{}' records no instrumentation for {}",
+                    path.display(),
+                    built.binary.display()
+                )));
+            }
+            Ok((binary.to_string_lossy().to_string(), built.instrumentation))
+        }
+        Manifest::Skipped(skipped) => Err(Error::config(format!(
+            "--instrumented-manifest '{}' records a build that was SKIPPED ({}); there is no \
+             instrumented binary to trust",
+            path.display(),
+            skipped.reason
+        ))),
+    }
 }
 
 /// Resolve a `cli://` path to its canonical form, falling back to the literal.

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -303,6 +303,19 @@ pub struct Context {
     /// result that reads as a refutation but is not evidence.
     #[serde(default)]
     pub require_instrumentation: bool,
+    /// Instrumentation **provenance**: for each binary cxg itself built, the
+    /// labels it verified in the produced artefact, keyed by that binary's
+    /// path.
+    ///
+    /// Populated only by `cxg scan --instrumented-manifest`, and empty
+    /// otherwise -- which is the case that behaves exactly as cxg did before
+    /// this existed. Where a record is present it is used **in preference to
+    /// re-inspecting the file**: cxg passed the flags and read the artefact
+    /// back at build time, and that is better evidence than sniffing the same
+    /// artefact again later. Inspection stays for binaries cxg did not build,
+    /// which is where it belongs.
+    #[serde(default)]
+    pub instrumentation_provenance: BTreeMap<String, Vec<String>>,
 }
 
 impl Default for Context {
@@ -324,6 +337,7 @@ impl Default for Context {
             probe_input_dir: None,
             probe_env: Vec::new(),
             require_instrumentation: false,
+            instrumentation_provenance: BTreeMap::new(),
         }
     }
 }

--- a/tests/build_instrument.rs
+++ b/tests/build_instrument.rs
@@ -1,0 +1,360 @@
+//! `cxg build --instrument`, proved end to end on a benign synthetic toy.
+//!
+//! The unit tests in `src/build/` cover the decisions -- build-system
+//! detection, capability probing, every skip reason -- against no toolchain at
+//! all. This file covers the thing they cannot: that the component really does
+//! drive cargo, really does produce an instrumented binary, and that the
+//! binary really does turn the shipped CLI Security Baseline's B11 class into
+//! a verdict rather than a shrug.
+//!
+//! **The matrix, and why all three rows are needed.**
+//!
+//! ```text
+//! santoy_defective, built instrumented   -> CONFIRMED   the defect is reachable
+//! santoy_fixed,     built instrumented   -> REFUTED     and the class can be refuted
+//! santoy_defective, built ORDINARILY     -> SKIPPED     and a build that cannot show it
+//!                                                       does not get to refute it
+//! ```
+//!
+//! A class that only ever confirms cannot tell a defect from a tool. A class
+//! that only ever refutes has not been shown to detect anything. And the third
+//! row is the honest-failure boundary: the *same defective program*, built
+//! without a sanitizer, exits 0 on every probe and looks exactly like the
+//! fixed twin -- so the only correct answer there is `skipped`.
+//!
+//! The toy is `tests/fixtures/build-instrument/santoy.rs`: two planted flaws
+//! with their corrections beside them. Nothing here reproduces any real defect
+//! in any real program.
+//!
+//! **Toolchain.** `-Zsanitizer` is nightly-only and there is no stable
+//! equivalent, so these tests need `rustup` with a nightly toolchain. Where
+//! that is missing they print why and pass, rather than failing a build over a
+//! dependency the feature honestly has -- the same answer the component itself
+//! gives an operator.
+//!
+//! Unix-only, for the same reason as `tests/cli_baseline_pack.rs`: the
+//! templates are `bash`, which Windows cannot exec (`os error 3`).
+
+#![cfg(unix)]
+
+use cert_x_gen::build::{instrument, InstrumentRequest, Manifest};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The B11 template, vendored with the rest of the pack.
+const B11: &str = "cli-baseline-b11-memory-safety.sh";
+
+fn pack_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cli-baseline/pack")
+}
+
+fn fixture_src() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/build-instrument")
+}
+
+/// Is a nightly toolchain reachable? If not, say so once and let the test pass.
+fn nightly_or_explain(what: &str) -> bool {
+    let installed = Command::new("rustup")
+        .args(["toolchain", "list"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .any(|l| l.starts_with("nightly"))
+        });
+    if !installed {
+        eprintln!(
+            "SKIPPING {what}: -Zsanitizer is nightly-only and no nightly toolchain is \
+             installed. Install it with `rustup toolchain install nightly`. This is the \
+             feature's one real dependency and the component skips on it honestly too."
+        );
+    }
+    installed
+}
+
+/// Materialise the toy crate into a fresh directory and hand it back.
+///
+/// The manifest is checked in under a name cargo does not recognise, so the
+/// package under test never contains a nested package.
+fn materialise_toy(into: &Path) -> PathBuf {
+    let project = into.join("santoy");
+    std::fs::create_dir_all(project.join("src")).expect("creating the toy source directory");
+    std::fs::copy(
+        fixture_src().join("cargo-manifest.toml"),
+        project.join("Cargo.toml"),
+    )
+    .expect("copying the toy manifest");
+    std::fs::copy(fixture_src().join("santoy.rs"), project.join("src/main.rs"))
+        .expect("copying the toy source");
+    project
+}
+
+/// The toy project, its instrumented build tree, and its ordinary one, built
+/// once for every test in this binary.
+///
+/// Deliberately leaked into the `OnceLock` so the temp directory outlives the
+/// tests that read it.
+fn toy() -> &'static Toy {
+    static TOY: std::sync::OnceLock<Toy> = std::sync::OnceLock::new();
+    TOY.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("creating the toy build directory");
+        let project = materialise_toy(dir.path());
+        let instrumented_out = dir.path().join("out-instrumented");
+        let plain_out = dir.path().join("out-plain");
+        Toy {
+            project,
+            instrumented_out,
+            plain_out,
+            _dir: dir,
+        }
+    })
+}
+
+struct Toy {
+    project: PathBuf,
+    instrumented_out: PathBuf,
+    plain_out: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+/// Build one twin with ASan through the component under test.
+fn build_instrumented(bin: &str) -> Manifest {
+    let toy = toy();
+    instrument(&InstrumentRequest {
+        project: toy.project.clone(),
+        bin: Some(bin.to_string()),
+        sanitizers: vec!["address".to_string()],
+        out_dir: Some(toy.instrumented_out.clone()),
+        build_std: false,
+    })
+}
+
+/// Build one twin the way its own developer would -- an ordinary `cargo build`,
+/// no sanitizer, no flags from cxg at all.
+fn build_ordinarily(bin: &str) -> PathBuf {
+    let toy = toy();
+    let built = Command::new("cargo")
+        .args(["build", "--bin", bin, "--manifest-path"])
+        .arg(toy.project.join("Cargo.toml"))
+        .arg("--target-dir")
+        .arg(&toy.plain_out)
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .output()
+        .expect("running the ordinary cargo build");
+    assert!(
+        built.status.success(),
+        "the ordinary build of {bin} failed:\n{}",
+        String::from_utf8_lossy(&built.stderr)
+    );
+    toy.plain_out.join("debug").join(bin)
+}
+
+/// What one template reported.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Verdict {
+    status: String,
+    findings: usize,
+    detail: String,
+}
+
+/// Run a template against a target exactly as `src/engine/shell/mod.rs` does.
+fn run_template(template: &str, target: &Path, instrumentation: &str) -> Verdict {
+    let output = Command::new("bash")
+        .arg(pack_dir().join(template))
+        .env("CERT_X_GEN_TARGET_HOST", target)
+        .env("CERT_X_GEN_TARGET_KIND", "cli")
+        .env("CERT_X_GEN_TARGET_INSTRUMENTATION", instrumentation)
+        .output()
+        .unwrap_or_else(|e| panic!("running {template}: {e}"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "{template} did not print probe-contract JSON ({e}).\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Verdict {
+        status: json["metadata"]["status"]
+            .as_str()
+            .unwrap_or("<missing>")
+            .to_string(),
+        findings: json["findings"].as_array().map(|a| a.len()).unwrap_or(0),
+        detail: json["metadata"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+    }
+}
+
+fn expect_instrumented(manifest: &Manifest) -> &cert_x_gen::build::Instrumented {
+    match manifest {
+        Manifest::Instrumented(built) => built,
+        Manifest::Skipped(skipped) => panic!(
+            "the instrumented build was skipped: {} {:?}",
+            skipped.reason, skipped.build_log_tail
+        ),
+    }
+}
+
+/// **The proof.** Confirm on the flawed twin, refute on the fixed one, skip on
+/// the build that could not have shown either.
+#[test]
+fn the_instrumented_twins_confirm_and_refute_and_an_ordinary_build_skips() {
+    if !nightly_or_explain("the instrumented-build proof") {
+        return;
+    }
+
+    // --- flawed twin, built instrumented: CONFIRMED.
+    let flawed = build_instrumented("santoy_defective");
+    let flawed = expect_instrumented(&flawed);
+    assert!(
+        flawed.instrumentation.contains(&"asan".to_string()),
+        "the component must not report `instrumented` without reading ASan back out of the \
+         artefact: {:?}",
+        flawed.instrumentation
+    );
+    let verdict = run_template(B11, &flawed.binary, &flawed.instrumentation.join(","));
+    assert_eq!(
+        verdict.status, "confirmed",
+        "the flawed twin's planted heap overflow must be confirmed under ASan: {verdict:?}"
+    );
+    assert_eq!(verdict.findings, 1, "{verdict:?}");
+    assert!(
+        verdict.detail.contains("AddressSanitizer"),
+        "the verdict must rest on a sanitizer report, not an inference: {verdict:?}"
+    );
+
+    // --- fixed twin, same build recipe: REFUTED.
+    let fixed = build_instrumented("santoy_fixed");
+    let fixed = expect_instrumented(&fixed);
+    let verdict = run_template(B11, &fixed.binary, &fixed.instrumentation.join(","));
+    assert_eq!(
+        verdict.status, "refuted",
+        "a class that cannot be refuted is a class nobody can trust a green result from: \
+         {verdict:?}"
+    );
+    assert_eq!(verdict.findings, 0, "{verdict:?}");
+
+    // --- the SAME flawed program, built ordinarily: SKIPPED.
+    //
+    // This is the honest-failure boundary. The defect is still there and still
+    // reachable; the build simply cannot show it, so every probe exits 0 and
+    // the binary is indistinguishable from its fixed twin. `refuted` here
+    // would be a false negative dressed as evidence.
+    let plain = build_ordinarily("santoy_defective");
+    let detected = cert_x_gen::engine::common::detect_instrumentation(&plain);
+    assert!(
+        !detected.iter().any(|d| d == "asan"),
+        "an ordinary cargo build carries no ASan: {detected:?}"
+    );
+    let instrumentation = if detected.is_empty() {
+        "none".to_string()
+    } else {
+        detected.join(",")
+    };
+    let verdict = run_template(B11, &plain, &instrumentation);
+    assert_eq!(
+        verdict.status, "skipped",
+        "an uninstrumented build must not be allowed to refute the memory class: {verdict:?}"
+    );
+    assert_eq!(verdict.findings, 0, "{verdict:?}");
+}
+
+/// The toy has three binary targets and no way to guess which is the CLI under
+/// test, so the component names the flag that resolves it instead of picking
+/// one. This is the same shape a real Cargo workspace has.
+#[test]
+fn a_project_with_several_binaries_refuses_to_choose() {
+    if !nightly_or_explain("the ambiguous-binary check") {
+        return;
+    }
+    let manifest = instrument(&InstrumentRequest {
+        project: toy().project.clone(),
+        bin: None,
+        sanitizers: vec!["address".to_string()],
+        out_dir: Some(toy().instrumented_out.clone()),
+        build_std: false,
+    });
+    let Manifest::Skipped(skipped) = manifest else {
+        panic!("three binaries and no --bin must skip");
+    };
+    assert_eq!(skipped.reason, "binary-target-ambiguous(pass --bin NAME)");
+}
+
+/// **Rust has no UBSan.** Asking for it must skip with the reason that says
+/// so, on a real toolchain, rather than build something that cannot show what
+/// it was asked to show.
+#[test]
+fn asking_a_rust_project_for_ubsan_skips_with_the_real_reason() {
+    if !nightly_or_explain("the UBSan-on-Rust check") {
+        return;
+    }
+    let manifest = instrument(&InstrumentRequest {
+        project: toy().project.clone(),
+        bin: Some("santoy_defective".to_string()),
+        sanitizers: vec!["undefined".to_string()],
+        out_dir: Some(toy().instrumented_out.clone()),
+        build_std: false,
+    });
+    let Manifest::Skipped(skipped) = manifest else {
+        panic!("there is no -Zsanitizer=undefined; asking for it must skip");
+    };
+    assert_eq!(skipped.reason, "sanitizer-unsupported-on-target");
+    assert!(
+        skipped
+            .notes
+            .iter()
+            .any(|n| n.contains("rustc-has-no-ubsan")),
+        "the skip must name the real answer rather than imply another platform would have it: \
+         {:?}",
+        skipped.notes
+    );
+}
+
+/// **Provenance beats inspection**, on a real artefact: what a scan reads back
+/// out of the manifest is what the build actually verified, and it reaches a
+/// template through the same environment variable inspection would have used.
+#[test]
+fn a_manifest_carries_the_build_record_into_a_scan() {
+    if !nightly_or_explain("the manifest provenance check") {
+        return;
+    }
+    let manifest = build_instrumented("santoy_fixed");
+    let built = expect_instrumented(&manifest);
+
+    // Rust's integer check is a build fact cxg passed, and it is recorded.
+    assert!(
+        built
+            .instrumentation
+            .contains(&"rust-overflow-checks".to_string()),
+        "cxg passes -C overflow-checks=on on every instrumented Rust build, so the artefact \
+         carries the integer check and the manifest records it: {:?}",
+        built.instrumentation
+    );
+
+    // Round-trip the manifest the way `--instrumented-manifest` does.
+    let json = serde_json::to_string(&manifest).expect("serialising the manifest");
+    let read_back: Manifest = serde_json::from_str(&json).expect("reading the manifest back");
+    let read_back = expect_instrumented(&read_back);
+    assert_eq!(read_back.instrumentation, built.instrumentation);
+
+    let mut context = cert_x_gen::types::Context::default();
+    context.instrumentation_provenance.insert(
+        read_back.binary.to_string_lossy().to_string(),
+        read_back.instrumentation.clone(),
+    );
+    let target = cert_x_gen::types::Target::new(
+        read_back.binary.to_string_lossy().to_string(),
+        cert_x_gen::types::Protocol::Cli,
+    );
+    let env = cert_x_gen::engine::common::build_env_vars(&target, &context)
+        .expect("building the template environment");
+    assert_eq!(
+        env.get("CERT_X_GEN_TARGET_INSTRUMENTATION").unwrap(),
+        &built.instrumentation.join(",")
+    );
+}

--- a/tests/fixtures/build-instrument/cargo-manifest.toml
+++ b/tests/fixtures/build-instrument/cargo-manifest.toml
@@ -1,0 +1,33 @@
+# The manifest for the `santoy` toy, materialised as `Cargo.toml` by
+# `tests/build_instrument.rs`.
+#
+# It is kept under a name cargo does NOT recognise so that this crate's own
+# `cargo build`, `cargo fmt --all` and `cargo test` never see a package nested
+# inside the package under test.
+#
+# Three binary targets from ONE source, so the twins cannot drift apart, and so
+# the toy also exercises `binary-target-ambiguous`: with three bins and no
+# `--bin`, there is no way to guess which one is the CLI under test.
+
+[package]
+name = "santoy"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Deliberately empty. The point of this crate is the BUILD path -- cargo plus
+# `-Zsanitizer=address` on a nightly toolchain -- so it must not drag in a
+# dependency tree that could be blamed for a failure.
+[dependencies]
+
+[[bin]]
+name = "santoy_defective"
+path = "src/main.rs"
+
+[[bin]]
+name = "santoy_intonly"
+path = "src/main.rs"
+
+[[bin]]
+name = "santoy_fixed"
+path = "src/main.rs"

--- a/tests/fixtures/build-instrument/santoy.rs
+++ b/tests/fixtures/build-instrument/santoy.rs
@@ -1,0 +1,142 @@
+//! `santoy` -- the **benign synthetic** cargo toy for the instrumented build.
+//!
+//! It exists to prove the *build path* end to end: `cargo +nightly build
+//! --target <host triple>` with `RUSTFLAGS=-Zsanitizer=address`, the sanitizer
+//! runtime that ships as an `@rpath` dylib, and the post-build verification
+//! that reads the produced artefact back. Nothing here reproduces any real
+//! defect in any real program; both flaws are planted, with their one-line
+//! corrections beside them.
+//!
+//! Two planted defects, one per low-level family, both reachable from the
+//! over-length payloads the shipped CLI Security Baseline B11 template already
+//! sends:
+//!
+//! * `--tag <text>` -- memory (CWE-787): a one-byte heap overwrite. Without a
+//!   redzone the allocator's bucket absorbs it, so the defective build prints
+//!   the right answer and exits 0. **ASan sees it; nothing else does.**
+//! * `--reserve <text>` -- integer (CWE-190): a signed 32-bit product of an
+//!   attacker-controlled length. Rust has **no UBSan**, so the check that
+//!   makes this observable is `-C overflow-checks=on`, which turns the wrap
+//!   into a panic. Compile it out and the same program prints a plainly wrong
+//!   number and exits 0.
+//!
+//! Which twin this is comes from `argv[0]`, the same one-source-many-twins
+//! convention as `tests/fixtures/cli-baseline/memtoy.c`: twins that can drift
+//! apart are worth nothing as a refutation test. Three names are recognised:
+//!
+//! * `*defective*` -- both defects present
+//! * `*intonly*` -- only the integer defect; the memory one is repaired
+//! * anything else -- both repaired
+
+use std::alloc::{alloc, dealloc, Layout};
+
+/// Bytes the tool claims to reserve per character. Large enough that a 65-char
+/// argument overflows a signed 32-bit product.
+const PER_CHAR: i32 = 33_554_432;
+
+fn usage() {
+    println!(
+        "usage: santoy <command> [value]\n\
+         \n\
+         commands:\n\
+         \x20 --tag <text>      copy <text> into a heap tag buffer\n\
+         \x20 --reserve <text>  report the byte budget <text> would need\n\
+         \x20 version           print the build identity"
+    );
+}
+
+/// Memory family. ASan-visible; silent on an uninstrumented build.
+fn cmd_tag(text: &str, is_defective: bool) -> i32 {
+    let n = text.len();
+    // The defective allocation forgets the byte the terminating NUL needs, so
+    // the write below lands exactly one past the end of the block.
+    let cap = if is_defective { n } else { n + 1 };
+    if cap == 0 {
+        println!("tag: 0 bytes");
+        return 0;
+    }
+    let layout = Layout::from_size_align(cap, 1).expect("layout");
+    unsafe {
+        let p = alloc(layout);
+        if p.is_null() {
+            return 71;
+        }
+        std::ptr::copy_nonoverlapping(text.as_ptr(), p, n);
+        *p.add(n) = 0; // one past the end on the defective twin
+        println!("tag: {} bytes", n);
+        dealloc(p, layout);
+    }
+    0
+}
+
+/// Integer family. Observable only where `-C overflow-checks=on` compiled the
+/// check in.
+fn cmd_reserve(text: &str, is_defective: bool) -> i32 {
+    if is_defective {
+        let n = text.len() as i32;
+        let bytes = n * PER_CHAR;
+        println!("reserve: {} chars -> {} bytes", n, bytes);
+        0
+    } else {
+        let n = text.len();
+        match (n as u64).checked_mul(PER_CHAR as u64) {
+            Some(bytes) if bytes <= i32::MAX as u64 => {
+                println!("reserve: {} chars -> {} bytes", n, bytes);
+                0
+            }
+            _ => {
+                eprintln!("santoy: refusing: {} chars exceeds the budget", n);
+                4
+            }
+        }
+    }
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+    let base = std::path::Path::new(&argv[0])
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    let is_defective = base.contains("defective");
+    let int_defective = is_defective || base.contains("intonly");
+
+    if argv.len() < 2 {
+        usage();
+        std::process::exit(64);
+    }
+    match argv[1].as_str() {
+        "version" => {
+            println!(
+                "santoy 0.1 ({})",
+                if is_defective {
+                    "defective"
+                } else if int_defective {
+                    "intonly"
+                } else {
+                    "fixed"
+                }
+            );
+            std::process::exit(0);
+        }
+        "--help" | "-h" | "help" => {
+            usage();
+            std::process::exit(0);
+        }
+        _ => {}
+    }
+    if argv.len() < 3 {
+        usage();
+        std::process::exit(64);
+    }
+    let rc = match argv[1].as_str() {
+        "--tag" => cmd_tag(&argv[2], is_defective),
+        "--reserve" => cmd_reserve(&argv[2], int_defective),
+        _ => {
+            usage();
+            64
+        }
+    };
+    std::process::exit(rc);
+}


### PR DESCRIPTION
Promotes the s26 scout's proven build-assist design into the engine, as items 1–3 of the report's §4.1. The detector blocker (§3.1) is already fixed and shipped; this builds on the current symbol-table detector and does not touch it.

**`cxg scan`'s existing behaviour is byte-identical when the new verb and flag are absent.** This is wiring, not a rewrite.

## 1. `cxg build --instrument` — new `src/build/` module + new verb

Detects the build system, asks **rustc** what the target can do rather than guessing, builds into a private target directory, **re-reads the produced binary**, and prints one JSON manifest. Cargo/Rust only; every other recognised build system skips with `build-system-not-implemented`.

```console
$ cxg build --instrument --project ./santoy --bin santoy_defective --out /tmp/out
{
  "status": "instrumented",
  "build_system": "cargo",
  "toolchain": "nightly",
  "target": "aarch64-apple-darwin",
  "bin": "santoy_defective",
  "binary": "/tmp/out/aarch64-apple-darwin/debug/santoy_defective",
  "rustflags": "-Zsanitizer=address -C debuginfo=2 -C force-frame-pointers=yes -C overflow-checks=on",
  "build_std": false,
  "instrumentation": ["asan", "debug-info", "rust-overflow-checks"],
  "unsupported_requested": []
}
```

It is a **verb rather than a scan flag** because building runs the project's own build system (`build.rs`, `configure`, arbitrary `Makefile` recipes) as the invoking user — a different trust decision from reading a file — and costs minutes and gigabytes. `cxg scan` still inspects and refuses, and never builds anything.

### The honest-failure boundary

**There is no path from "I could not instrument this" to "here is a binary."** Every precondition failure is a `skipped` with a machine-readable reason:

| Reason | |
| --- | --- |
| `unknown-build-system` | plus the marker files it looked for |
| `build-system-not-implemented(cmake)` | recognised, no back end |
| `cargo-not-on-path` / `rustup-not-on-path(...)` | |
| `nightly-toolchain-unavailable(install: rustup toolchain install nightly)` | |
| `sanitizer-capability-unknown(target=…)` | |
| `sanitizer-unsupported-on-target` | plus `requested`, `supported`, and notes |
| `sanitizer-not-verifiable(cfi)` | rustc supports it; cxg cannot read it back, so it will not vouch for it |
| `rust-src-missing(...)` | `-Zbuild-std` without the component |
| `binary-target-ambiguous(pass --bin NAME)` | |
| `instrumented-build-failed(exit=N)` | plus the last 20 log lines |
| **`build-produced-no-instrumentation(wanted=… detected=…)`** | the build reported success and the artefact carries none of it |

That last row is the design's load-bearing one. A build that accepted the flags and silently dropped them still links, still runs, and is indistinguishable from an instrumented build until you look at the artefact — so the last step re-reads the binary with the same symbol-table scan the preflight uses.

```console
$ cxg build --instrument --project ./santoy --bin santoy_defective --sanitizer undefined; echo "exit=$?"
{
  "status": "skipped",
  "reason": "sanitizer-unsupported-on-target",
  "target": "aarch64-apple-darwin",
  "requested": "undefined",
  "supported": "address,thread,cfi,realtime",
  "notes": ["rustc-has-no-ubsan(no -Zsanitizer=undefined exists on any Rust target; the Rust equivalent for the integer class is -C overflow-checks=on, which panics -- see the overflow oracle)"]
}
exit=3
```

### The four load-bearing cargo flags

Each is a defect if dropped, and they are documented as such in `src/build/cargo.rs`'s module doc: `+nightly` (there is no stable `-Zsanitizer`); **`--target <host triple>` even when not cross-compiling**, or `RUSTFLAGS` reaches the build scripts and proc-macro crates cargo compiles *and runs on the host*; `-C debuginfo=2`; and a target directory that is never the project's own. `CARGO_ENCODED_RUSTFLAGS` is cleared from the child environment because it silently outranks `RUSTFLAGS`.

## 2. `rust-overflow-checks` label + the `overflow` oracle

**Rust has no UBSan** — `-Zsanitizer=undefined` is not in rustc's vocabulary on any target, on any nightly. The equivalent check for the integer class is `-C overflow-checks=on`, which cxg now passes on every instrumented build.

The label is read from the symbol table like every other: the check compiles in a call to `core::panicking::panic_const::panic_const_{add,sub,mul,neg,shl,shr}_overflow`, and those symbols are present **if and only if** the flag was passed — verified empirically by compiling the same source both ways. `panic_const_div_overflow` and the by-zero panics are emitted either way (they are hard errors, not overflow checks) and are deliberately excluded; including them would report every Rust build as carrying the check.

`overflow` was already mapped in `BUILD_DEPENDENT_ORACLES`, so a template's overflow branch is now gated exactly like an ASan branch and cannot claim a verdict on a build where the check was compiled out. Under-reporting (no fallible arithmetic left after const-folding, or a pre-1.79 toolchain) is the safe direction: the template skips rather than claims.

## 3. `cxg scan --instrumented-manifest <path>`

Provenance beats inspection. Where cxg built the binary it already read the artefact back before it was willing to call the build instrumented, and that record survives stripping and a copy away from the build tree. It is used in preference to re-sniffing the file, **for the binary the manifest names and no other**. A manifest recording a *skipped* build is an error, not a silent no-op. Repeatable. Omit it and a scan behaves exactly as it did before.

## Proof — benign synthetic only

`tests/build_instrument.rs` builds a synthetic Rust toy (`tests/fixtures/build-instrument/santoy.rs` — two planted flaws with their one-line corrections beside them, twins selected by `argv[0]` like `memtoy.c`) and drives the **shipped, unmodified** B11 template:

```
santoy_defective, built instrumented  ->  CONFIRMED   oracle=asan(AddressSanitizer: heap-buffer-overflow) probe=--tag
santoy_fixed,     built instrumented  ->  REFUTED     handled every over-length input cleanly, 13 probes
santoy_defective, built ORDINARILY    ->  SKIPPED     no-instrumentation-detected(have=none need=asan ubsan msan tsan)
```

The third row is the boundary: the *same defective program*, built without a sanitizer, exits 0 on every probe and looks exactly like its fixed twin. `refuted` there would be a false negative dressed as evidence.

Confirmed end to end through the real binary too:

```console
$ cxg scan --scope "cli://$B" --templates cli-baseline-b11-memory-safety.sh \
      --require-instrumentation --instrumented-manifest /tmp/m.json
  confirmed  cli-baseline-b11-memory-safety → …/santoy_defective
    [oracle=asan(AddressSanitizer: heap-buffer-overflow) exit=134 probe=--tag
     instrumentation=asan,debug-info,rust-overflow-checks class=B11]
```

No CVE is reproduced; nothing is exploited.

## Toolchain cost, stated honestly

Nightly Rust is required for `-Zsanitizer` and there is no stable equivalent. **21 unit tests** cover build-system detection, capability probing and every skip reason with no toolchain at all; nightly is needed only by the **4 end-to-end tests**, which print why they are skipping and pass rather than failing the build:

```
SKIPPING the instrumented-build proof: -Zsanitizer is nightly-only and no nightly toolchain
is installed. Install it with `rustup toolchain install nightly`. This is the feature's one
real dependency and the component skips on it honestly too.
```

## Out of scope (queued follow-ups, per the brief)

- **Item 4** — B11 template corrections (oracle/CWE classification, the `overflow` branch, numeric boundary payloads, the BSD-grep fix). Lives in the **templates repo**.
- **Item 5** — cmake / make / go back ends.

## Gates

- `cargo fmt --all -- --check` clean.
- `cargo clippy --all-targets`: **62 warnings, exactly the merge-base baseline** (measured by stashing this branch's changes and re-running). The two warnings this change introduced were fixed.
- Full suite green: 304 lib + 43 + 4 + 7 + 1 + 30 integration + 15 doc tests, 0 failures.
- Every test that execs a shell fixture or needs `cc`/`bash` is `#![cfg(unix)]`, so the Windows leg is unaffected.
- No new dependency. `object` was already direct.

## Docs

`docs/ENGINE_ARCHITECTURE.md` gains sections for the build assist, `--instrumented-manifest` and the `overflow` oracle; the stale "cxg inspects and refuses; it does not build the target" paragraph is corrected to say that of `cxg scan` specifically. `CHANGELOG.md` and `AGENTS.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaiPvmKpgVzXuHYneKwwos
