### PR TITLE
docs: update stale Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,7 +278,7 @@ By contributing, you agree that your contributions will be licensed under the Ap
 ## Questions?
 
 - Open a discussion on GitHub
-- Join our Discord: https://discord.gg/cert-x-gen
+- Join our Discord: https://discord.gg/3RFkNtHRE
 - Email: team@cert-x-gen.io
 
 ## Recognition


### PR DESCRIPTION
The Discord invite in `CONTRIBUTING.md` (`https://discord.gg/cert-x-gen`) is dead. Replaced with the current invite `https://discord.gg/3RFkNtHRE`. Only occurrence in the repo; nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLcFzJs4yBgqTyKbFsF4mx